### PR TITLE
Make Maximum post size configurable

### DIFF
--- a/ratpack-core/src/main/java/org/ratpackframework/launch/LaunchConfig.java
+++ b/ratpack-core/src/main/java/org/ratpackframework/launch/LaunchConfig.java
@@ -41,6 +41,11 @@ public interface LaunchConfig {
   public static final int DEFAULT_PORT = 5050;
 
   /**
+   * The default max content length
+   */
+  public int DEFAULT_MAX_CONTENT_LENGTH = 65536;
+
+  /**
    * The base dir of the application, which is also the initial {@link org.ratpackframework.file.FileSystemBinding}.
    *
    * @return The base dir of the application.
@@ -146,4 +151,11 @@ public interface LaunchConfig {
    * @return The other property for {@code key}, or the {@code defaultValue} if it is not set
    */
   public String getOther(String key, String defaultValue);
+
+  /**
+   * The max content length to use for the HttpObjectAggregator
+   *
+   * @return The max content length as an int.
+   */
+  public int getMaxContentLength();
 }

--- a/ratpack-core/src/main/java/org/ratpackframework/launch/LaunchConfigBuilder.java
+++ b/ratpack-core/src/main/java/org/ratpackframework/launch/LaunchConfigBuilder.java
@@ -75,6 +75,7 @@ public class LaunchConfigBuilder {
   private ExecutorService blockingExecutorService;
   private ByteBufAllocator byteBufAllocator = PooledByteBufAllocator.DEFAULT;
   private SSLContext sslContext;
+  private int maxContentLength = LaunchConfig.DEFAULT_MAX_CONTENT_LENGTH;
 
   private LaunchConfigBuilder(File baseDir) {
     this.baseDir = baseDir;
@@ -94,7 +95,7 @@ public class LaunchConfigBuilder {
   /**
    * Sets the port to bind to.
    * <p>
-   * Default value is {@value LaunchConfig#DEFAULT_PORT}.
+   * Default value is {@value org.ratpackframework.launch.LaunchConfig#DEFAULT_PORT}.
    *
    * @param port The port to bind to
    * @see LaunchConfig#getPort()
@@ -186,6 +187,20 @@ public class LaunchConfigBuilder {
    */
   public LaunchConfigBuilder publicAddress(URI publicAddress) {
     this.publicAddress = publicAddress;
+    return this;
+  }
+
+  /**
+   * The max content length.
+   *
+   * Default value is {@value org.ratpackframework.launch.LaunchConfig#DEFAULT_MAX_CONTENT_LENGTH}
+   *
+   * @param maxContentLength The max content length to accept.
+   * @see LaunchConfig#getMaxContentLength()
+   * @return this
+   */
+  public LaunchConfigBuilder maxContentLength(int maxContentLength) {
+    this.maxContentLength = maxContentLength;
     return this;
   }
 
@@ -296,7 +311,7 @@ public class LaunchConfigBuilder {
     if (blockingExecutorService == null) {
       blockingExecutorService = Executors.newCachedThreadPool(new BlockingThreadFactory());
     }
-    return new DefaultLaunchConfig(baseDir, port, address, reloadable, mainThreads, blockingExecutorService, byteBufAllocator, publicAddress, indexFiles.build(), other.build(), handlerFactory, sslContext);
+    return new DefaultLaunchConfig(baseDir, port, address, reloadable, mainThreads, blockingExecutorService, byteBufAllocator, publicAddress, indexFiles.build(), other.build(), handlerFactory, sslContext, maxContentLength);
   }
 
   @SuppressWarnings("NullableProblems")

--- a/ratpack-core/src/main/java/org/ratpackframework/launch/LaunchConfigFactory.java
+++ b/ratpack-core/src/main/java/org/ratpackframework/launch/LaunchConfigFactory.java
@@ -299,5 +299,12 @@ public abstract class LaunchConfigFactory {
      * @see org.ratpackframework.launch.LaunchConfig#getSSLContext()
      */
     public static final String SSL_KEYSTORE_PASSWORD = "ssl.keystore.password";
+
+    /**
+     * The max conent lenght.
+     *
+     * @see org.ratpackframework.launch.LaunchConfig#getMaxContentLength()
+     */
+    public static final String MAX_CONTENT_LENGTH = "maxContentLength";
   }
 }

--- a/ratpack-core/src/main/java/org/ratpackframework/launch/internal/DefaultLaunchConfig.java
+++ b/ratpack-core/src/main/java/org/ratpackframework/launch/internal/DefaultLaunchConfig.java
@@ -43,8 +43,9 @@ public class DefaultLaunchConfig implements LaunchConfig {
   private final ImmutableList<String> indexFiles;
   private final ImmutableMap<String, String> other;
   private final SSLContext sslContext;
+  private final int maxContentLength;
 
-  public DefaultLaunchConfig(File baseDir, int port, InetAddress address, boolean reloadable, int mainThreads, ExecutorService blockingExecutorService, ByteBufAllocator byteBufAllocator, URI publicAddress, ImmutableList<String> indexFiles, ImmutableMap<String, String> other, HandlerFactory handlerFactory, SSLContext sslContext) {
+  public DefaultLaunchConfig(File baseDir, int port, InetAddress address, boolean reloadable, int mainThreads, ExecutorService blockingExecutorService, ByteBufAllocator byteBufAllocator, URI publicAddress, ImmutableList<String> indexFiles, ImmutableMap<String, String> other, HandlerFactory handlerFactory, SSLContext sslContext, int maxContentLength) {
     this.baseDir = baseDir;
     this.port = port;
     this.address = address;
@@ -57,6 +58,7 @@ public class DefaultLaunchConfig implements LaunchConfig {
     this.other = other;
     this.handlerFactory = handlerFactory;
     this.sslContext = sslContext;
+    this.maxContentLength = maxContentLength;
   }
 
   @Override
@@ -117,5 +119,10 @@ public class DefaultLaunchConfig implements LaunchConfig {
   public String getOther(String key, String defaultValue) {
     String value = other.get(key);
     return value == null ? defaultValue : value;
+  }
+
+  @Override
+  public int getMaxContentLength() {
+    return maxContentLength;
   }
 }

--- a/ratpack-core/src/main/java/org/ratpackframework/server/internal/RatpackChannelInitializer.java
+++ b/ratpack-core/src/main/java/org/ratpackframework/server/internal/RatpackChannelInitializer.java
@@ -36,11 +36,13 @@ public class RatpackChannelInitializer extends ChannelInitializer<SocketChannel>
 
   private NettyHandlerAdapter nettyHandlerAdapter;
   private SSLContext sslContext;
+  private int maxContentLength;
 
   public RatpackChannelInitializer(LaunchConfig launchConfig, Handler handler) {
     ListeningExecutorService blockingExecutorService = MoreExecutors.listeningDecorator(launchConfig.getBlockingExecutorService());
     this.nettyHandlerAdapter = new NettyHandlerAdapter(handler, launchConfig, blockingExecutorService);
     this.sslContext = launchConfig.getSSLContext();
+    this.maxContentLength = launchConfig.getMaxContentLength();
   }
 
   public void initChannel(SocketChannel ch) {
@@ -53,7 +55,7 @@ public class RatpackChannelInitializer extends ChannelInitializer<SocketChannel>
     }
 
     pipeline.addLast("decoder", new HttpRequestDecoder());
-    pipeline.addLast("aggregator", new HttpObjectAggregator(65536));
+    pipeline.addLast("aggregator", new HttpObjectAggregator(maxContentLength));
     pipeline.addLast("encoder", new HttpResponseEncoder());
     pipeline.addLast("chunkedWriter", new ChunkedWriteHandler());
     pipeline.addLast("handler", nettyHandlerAdapter);


### PR DESCRIPTION
This fixes #168 added maxContentLength to LaunchConfig that gets used as the parameter to HttpObjectAggregator in the RatpackChannelInitializer.
