### PR TITLE
TokenPathBinder: apply URI decoding to path tokens

### DIFF
--- a/ratpack-core/src/main/java/ratpack/path/internal/TokenPathBinder.java
+++ b/ratpack-core/src/main/java/ratpack/path/internal/TokenPathBinder.java
@@ -22,6 +22,8 @@ import ratpack.path.PathBinder;
 import ratpack.path.PathBinding;
 import ratpack.util.internal.Validations;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -88,7 +90,7 @@ public class TokenPathBinder implements PathBinder {
       for (String name : tokenNames) {
         String value = matchResult.group(i++);
         if (value != null) {
-          paramsBuilder.put(name, value);
+          paramsBuilder.put(name, decodeURIComponent(value));
         }
       }
 
@@ -96,5 +98,15 @@ public class TokenPathBinder implements PathBinder {
     } else {
       return null;
     }
+  }
+
+  private String decodeURIComponent(String s) {
+    String str = null;
+    try {
+      str = URLDecoder.decode(s.replaceAll("\\+", "%2B"), "UTF-8");
+    } catch (UnsupportedEncodingException ignored) {
+      throw new IllegalStateException("UTF-8 decoder should always be available");
+    }
+    return str;
   }
 }

--- a/ratpack-core/src/test/groovy/ratpack/path/internal/TokenPathBinderSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/path/internal/TokenPathBinderSpec.groovy
@@ -44,6 +44,10 @@ class TokenPathBinderSpec extends Specification {
     bind(":a/:b?/:c?", "abc/def/ghi") == [a: "abc", b: "def", c: "ghi"]
     bind(":a/:b", "foo") == null
     bind("a/:b?", "a") == [:]
+    bind(":a", "%231") == [a: "#1"]
+    bind(":a", "foo%20bar") == [a: "foo bar"]
+    bind(":a", "foo%2Bbar") == [a: "foo+bar"]
+    bind(":a", "foo+bar") == [a: "foo+bar"]
 
     when:
     bind(":a/:b?/:c", "abc/def/ghi")

--- a/ratpack-manual/src/content/chapters/99-about-the-project.md
+++ b/ratpack-manual/src/content/chapters/99-about-the-project.md
@@ -30,6 +30,7 @@ The following people have provided significant contributions.
 * [Bobby Warner](https://github.com/bobbywarner)
 * [Jim White](https://github.com/jimwhite)
 * [Dimitris Zavaliadis](https://github.com/dimzava)
+* [David M. Carr](https://github.com/davidmc24)
 
 ### Past project members
 


### PR DESCRIPTION
Otherwise, the token paths are still in their encoded form, pushing this responsibility to the application.

In my particular case, I have a path tokens that represent IRC rooms, and thus include the pound sign.
