### PR TITLE
fix the build (#252)

### DIFF
--- a/ratpack-stylesheets/_typography.scss
+++ b/ratpack-stylesheets/_typography.scss
@@ -1,11 +1,11 @@
-@include font-face("Merriweather", inline-font-files("Merriweather-Regular.woff"));
-@include font-face("Merriweather", inline-font-files("Merriweather-Bold.woff"), false, 700);
-@include font-face("Merriweather", inline-font-files("Merriweather-Italic.woff"), false, 400, italic);
-@include font-face("Merriweather Sans", inline-font-files("MerriweatherSans-Bold.woff"), false, 700);
-@include font-face("Merriweather Sans", inline-font-files("MerriweatherSans-BoldItalic.woff"), false, 700, italic);
-@include font-face("Engagement", inline-font-files("Engagement-Regular.woff"));
-@include font-face("Monaco", inline-font-files("Monaco.woff"));
-@include font-face("Monaco", inline-font-files("Monaco-Bold.woff"), false, 700);
+@include font-face("Merriweather", inline-font-files("Merriweather-Regular.woff", woff));
+@include font-face("Merriweather", inline-font-files("Merriweather-Bold.woff", woff), false, 700);
+@include font-face("Merriweather", inline-font-files("Merriweather-Italic.woff", woff), false, 400, italic);
+@include font-face("Merriweather Sans", inline-font-files("MerriweatherSans-Bold.woff", woff), false, 700);
+@include font-face("Merriweather Sans", inline-font-files("MerriweatherSans-BoldItalic.woff", woff), false, 700, italic);
+@include font-face("Engagement", inline-font-files("Engagement-Regular.woff", woff));
+@include font-face("Monaco", inline-font-files("Monaco.woff", woff));
+@include font-face("Monaco", inline-font-files("Monaco-Bold.woff", woff), false, 700);
 
 $sans-font-family: "Merriweather Sans", Futura, "Trebuchet MS", Arial, sans-serif !default;
 $serif-font-family: "Merriweather", Georgia, Times, "Times New Roman", serif !default;


### PR DESCRIPTION
It looks like inline-font-face takes arguments in pairs, the second being the format.
These fonts all appear to be .woff files, so I've adjusted them to indicate that.

http://compass-style.org/reference/compass/helpers/inline-data/
