### PR TITLE
Added run.debug system property

### DIFF
--- a/ratpack-gradle/src/main/groovy/ratpack/gradle/RatpackPlugin.groovy
+++ b/ratpack-gradle/src/main/groovy/ratpack/gradle/RatpackPlugin.groovy
@@ -54,6 +54,7 @@ class RatpackPlugin implements Plugin<Project> {
         classpath ratpackApp.springloadedClasspath
         jvmArgs ratpackApp.springloadedJvmArgs
         systemProperty "ratpack.reloadable", true
+        debug = Boolean.valueOf(System.getProperty("run.debug", "false"))
       }
     }
 


### PR DESCRIPTION
Allow setting of the run.debug system property to allow easy debugging of a locally running ratpack application.
