### PR TITLE
Custom HTTP Response for Testing

### DIFF
--- a/ratpack-core/src/test/groovy/ratpack/error/DebugErrorHandlerSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/error/DebugErrorHandlerSpec.groovy
@@ -38,7 +38,7 @@ class DebugErrorHandlerSpec extends RatpackGroovyDslSpec {
     then:
     with(get("client")) {
       statusCode == 404
-      body.asString() == "Client error 404"
+      body == "Client error 404"
     }
 
     def str = new StringWriter().with {
@@ -48,7 +48,7 @@ class DebugErrorHandlerSpec extends RatpackGroovyDslSpec {
 
     with(get("server")) {
       statusCode == 500
-      body.asString() == str
+      body == str
     }
   }
 }

--- a/ratpack-core/src/test/groovy/ratpack/file/StaticFileSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/file/StaticFileSpec.groovy
@@ -18,6 +18,7 @@ package ratpack.file
 
 import com.jayway.restassured.response.Response
 import org.apache.commons.lang3.RandomStringUtils
+import ratpack.groovy.test.HttpResponse
 import ratpack.http.internal.HttpHeaderDateFormat
 import ratpack.test.internal.RatpackGroovyDslSpec
 import spock.lang.Unroll
@@ -400,7 +401,7 @@ class StaticFileSpec extends RatpackGroovyDslSpec {
     response.statusCode == 404
   }
 
-  private static Date parseDateHeader(Response response, String name) {
+  private static Date parseDateHeader(HttpResponse response, String name) {
     HttpHeaderDateFormat.get().parse(response.getHeader(name))
   }
 

--- a/ratpack-core/src/test/groovy/ratpack/file/internal/FileRenderingSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/file/internal/FileRenderingSpec.groovy
@@ -16,7 +16,7 @@
 
 package ratpack.file.internal
 
-import com.jayway.restassured.response.Response
+import ratpack.groovy.test.HttpResponse
 import ratpack.http.internal.HttpHeaderDateFormat
 import ratpack.test.internal.RatpackGroovyDslSpec
 
@@ -48,8 +48,8 @@ class FileRenderingSpec extends RatpackGroovyDslSpec {
     then:
     with(response) {
       statusCode == OK.code()
-      body.asString().contains(FILE_CONTENTS)
-      contentType.equals("text/plain;charset=UTF-8")
+      body.contains(FILE_CONTENTS)
+      header(CONTENT_TYPE) == "text/plain;charset=UTF-8"
       header(CONTENT_LENGTH).toInteger() == FILE_CONTENTS.length()
     }
   }
@@ -83,15 +83,14 @@ class FileRenderingSpec extends RatpackGroovyDslSpec {
     get("path")
 
     then:
-    with(response) {
-      statusCode == OK.code()
+    response.statusCode == OK.code()
       // compare the last modified dates formatted as milliseconds are stripped when added as a response header
-      formatDateHeader(parseDateHeader(response, LAST_MODIFIED)) == formatDateHeader(Files.getLastModifiedTime(myFile).toMillis())
-    }
+    formatDateHeader(parseDateHeader(response, LAST_MODIFIED)) == formatDateHeader(Files.getLastModifiedTime(myFile).toMillis())
+
 
   }
 
-  private static Date parseDateHeader(Response response, String name) {
+  private static Date parseDateHeader(HttpResponse response, String name) {
     HttpHeaderDateFormat.get().parse(response.getHeader(name))
   }
 

--- a/ratpack-core/src/test/groovy/ratpack/handling/ResponseTimeSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/handling/ResponseTimeSpec.groovy
@@ -30,7 +30,7 @@ class ResponseTimeSpec extends RatpackGroovyDslSpec {
 
     then:
     with(get()) {
-      headers.get("X-Response-Time") == null
+      header("X-Response-Time") == null
     }
   }
 
@@ -47,7 +47,7 @@ class ResponseTimeSpec extends RatpackGroovyDslSpec {
 
     then:
     with(get()) {
-      headers.get("X-Response-Time").value ==~ DECIMAL_NUMBER
+      header("X-Response-Time") ==~ DECIMAL_NUMBER
     }
   }
 
@@ -66,7 +66,7 @@ class ResponseTimeSpec extends RatpackGroovyDslSpec {
 
     then:
     with(get()) {
-      headers.get("X-Response-Time").value ==~ DECIMAL_NUMBER
+      header("X-Response-Time") ==~ DECIMAL_NUMBER
     }
   }
 
@@ -81,8 +81,8 @@ class ResponseTimeSpec extends RatpackGroovyDslSpec {
 
     then:
     with(get("foo.txt")) {
-      body.asString() == "foo"
-      headers.get("X-Response-Time") == null
+      body == "foo"
+      header("X-Response-Time") == null
     }
   }
 
@@ -102,8 +102,8 @@ class ResponseTimeSpec extends RatpackGroovyDslSpec {
 
     then:
     with(get("foo.txt")) {
-      body.asString() == "foo"
-      headers.get("X-Response-Time").value ==~ DECIMAL_NUMBER
+      body == "foo"
+      header("X-Response-Time") ==~ DECIMAL_NUMBER
     }
   }
 

--- a/ratpack-core/src/test/groovy/ratpack/http/internal/DefaultResponseSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/http/internal/DefaultResponseSpec.groovy
@@ -41,8 +41,8 @@ class DefaultResponseSpec extends RatpackGroovyDslSpec {
     then:
     with(response) {
       statusCode == OK.code()
-      body.asString().equals(BODY)
-      contentType.equals("text/plain;charset=UTF-8")
+      body.equals(BODY)
+      header(CONTENT_TYPE) == "text/plain;charset=UTF-8"
       header(CONTENT_LENGTH).toInteger() == BODY.length()
     }
   }
@@ -62,8 +62,8 @@ class DefaultResponseSpec extends RatpackGroovyDslSpec {
     then:
     with(response) {
       statusCode == OK.code()
-      body.asString().equals(BODY)
-      contentType.equals("text/plain;charset=UTF-8")
+      body.equals(BODY)
+      header(CONTENT_TYPE) == "text/plain;charset=UTF-8"
       header(CONTENT_LENGTH).toInteger() == BODY.length()
     }
   }
@@ -82,8 +82,8 @@ class DefaultResponseSpec extends RatpackGroovyDslSpec {
     then:
     with(response) {
       statusCode == OK.code()
-      body.asString().equals(BODY)
-      contentType.equals("application/octet-stream")
+      body.equals(BODY)
+      header(CONTENT_TYPE) == "application/octet-stream"
       header(CONTENT_LENGTH).toInteger() == BODY.length()
     }
   }
@@ -103,8 +103,8 @@ class DefaultResponseSpec extends RatpackGroovyDslSpec {
     then:
     with(response) {
       statusCode == OK.code()
-      body.asString().equals(BODY)
-      contentType.equals("application/octet-stream")
+      body.equals(BODY)
+      header(CONTENT_TYPE) == "application/octet-stream"
       header(CONTENT_LENGTH).toInteger() == BODY.length()
     }
   }
@@ -126,8 +126,8 @@ class DefaultResponseSpec extends RatpackGroovyDslSpec {
     then:
     with(response) {
       statusCode == OK.code()
-      body.asString().equals(BODY)
-      contentType.equals("text/plain;charset=UTF-8")
+      body.equals(BODY)
+      header(CONTENT_TYPE) == "text/plain;charset=UTF-8"
       header(CONTENT_LENGTH).toInteger() == BODY.length()
     }
   }
@@ -150,8 +150,8 @@ class DefaultResponseSpec extends RatpackGroovyDslSpec {
     then:
     with(response) {
       statusCode == OK.code()
-      body.asString().equals(BODY)
-      contentType.equals("text/plain;charset=UTF-8")
+      body.equals(BODY)
+      header(CONTENT_TYPE) == "text/plain;charset=UTF-8"
       header(CONTENT_LENGTH).toInteger() == BODY.length()
     }
   }
@@ -173,8 +173,8 @@ class DefaultResponseSpec extends RatpackGroovyDslSpec {
     then:
     with(response) {
       statusCode == OK.code()
-      body.asString().equals(BODY)
-      contentType.equals("application/octet-stream")
+      body.equals(BODY)
+      header(CONTENT_TYPE) == "application/octet-stream"
       header(CONTENT_LENGTH).toInteger() == BODY.length()
     }
   }
@@ -197,8 +197,8 @@ class DefaultResponseSpec extends RatpackGroovyDslSpec {
     then:
     with(response) {
       statusCode == OK.code()
-      body.asString().equals(BODY)
-      contentType.equals("application/foo")
+      body.equals(BODY)
+      header(CONTENT_TYPE) == "application/foo"
       header(CONTENT_LENGTH).toInteger() == BODY.length()
     }
   }
@@ -217,8 +217,8 @@ class DefaultResponseSpec extends RatpackGroovyDslSpec {
     then:
     with(response) {
       statusCode == OK.code()
-      body.asString().empty
-      contentType.equals("")
+      body.empty
+      !header(CONTENT_TYPE)
       header(CONTENT_LENGTH).toInteger() == 0
     }
   }

--- a/ratpack-core/src/test/groovy/ratpack/render/CharSequenceRenderingSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/render/CharSequenceRenderingSpec.groovy
@@ -31,7 +31,7 @@ class CharSequenceRenderingSpec extends RatpackGroovyDslSpec {
     then:
     with(get()) {
       header("content-type") == "text/plain;charset=UTF-8"
-      body.asString() == "foo"
+      body == "foo"
     }
   }
 
@@ -46,7 +46,7 @@ class CharSequenceRenderingSpec extends RatpackGroovyDslSpec {
     then:
     with(get()) {
       header("content-type") == "text/plain;charset=UTF-8"
-      body.asString() == "foo"
+      body == "foo"
     }
   }
 
@@ -62,7 +62,7 @@ class CharSequenceRenderingSpec extends RatpackGroovyDslSpec {
     then:
     with(get()) {
       header("content-type") == "application/json"
-      body.asString() == "foo"
+      body == "foo"
     }
   }
 

--- a/ratpack-core/src/test/groovy/ratpack/render/RenderingSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/render/RenderingSpec.groovy
@@ -69,7 +69,7 @@ class RenderingSpec extends RatpackGroovyDslSpec {
     getText() == "thing: foo"
     with(get("not-registered")) {
       statusCode == 500
-      body.asString().contains NoSuchRendererException.name
+      body.contains NoSuchRendererException.name
     }
   }
 

--- a/ratpack-groovy-test/src/main/java/ratpack/groovy/test/HttpHeader.java
+++ b/ratpack-groovy-test/src/main/java/ratpack/groovy/test/HttpHeader.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.groovy.test;
+
+
+public class HttpHeader {
+
+}

--- a/ratpack-groovy-test/src/main/java/ratpack/groovy/test/HttpResponse.java
+++ b/ratpack-groovy-test/src/main/java/ratpack/groovy/test/HttpResponse.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.groovy.test;
+
+
+import java.util.List;
+import java.util.Map;
+
+public interface HttpResponse {
+
+
+  int getStatusCode();
+
+  String getBody();
+
+  byte[] asByteArray();
+
+  String getHeader(String header);
+
+  String header(String header);
+
+  Map<String,String> getCookies();
+
+}

--- a/ratpack-groovy-test/src/main/java/ratpack/groovy/test/TestHttpClient.java
+++ b/ratpack-groovy-test/src/main/java/ratpack/groovy/test/TestHttpClient.java
@@ -16,7 +16,6 @@
 
 package ratpack.groovy.test;
 
-import com.jayway.restassured.response.Response;
 import com.jayway.restassured.specification.RequestSpecification;
 import ratpack.test.ApplicationUnderTest;
 
@@ -26,53 +25,53 @@ public interface TestHttpClient {
 
   RequestSpecification getRequest();
 
-  Response getResponse();
+  HttpResponse getResponse();
 
   RequestSpecification resetRequest();
 
-  Response head();
+  HttpResponse head();
 
-  Response head(String path);
+  HttpResponse head(String path);
 
-  Response options();
+  HttpResponse options();
 
-  Response options(String path);
+  HttpResponse options(String path);
 
-  Response get();
+  HttpResponse get();
 
-  Response get(String path);
+  HttpResponse get(String path);
 
   String getText();
 
   String getText(String path);
 
-  Response post();
+  HttpResponse post();
 
-  Response post(String path);
+  HttpResponse post(String path);
 
   String postText();
 
   String postText(String path);
 
-  Response put();
+  HttpResponse put();
 
-  Response put(String path);
+  HttpResponse put(String path);
 
   String putText();
 
   String putText(String path);
 
-  Response patch();
+  HttpResponse patch();
 
-  Response patch(String path);
+  HttpResponse patch(String path);
 
   String patchText();
 
   String patchText(String path);
 
-  Response delete();
+  HttpResponse delete();
 
-  Response delete(String path);
+  HttpResponse delete(String path);
 
   String deleteText();
 

--- a/ratpack-groovy-test/src/main/java/ratpack/groovy/test/internal/DefaultTestHttpClient.java
+++ b/ratpack-groovy-test/src/main/java/ratpack/groovy/test/internal/DefaultTestHttpClient.java
@@ -22,6 +22,7 @@ import com.jayway.restassured.response.Cookies;
 import com.jayway.restassured.response.Response;
 import com.jayway.restassured.specification.RequestSpecification;
 import ratpack.api.Nullable;
+import ratpack.groovy.test.HttpResponse;
 import ratpack.groovy.test.TestHttpClient;
 import ratpack.test.ApplicationUnderTest;
 import ratpack.func.Action;
@@ -64,8 +65,8 @@ public class DefaultTestHttpClient implements TestHttpClient {
   }
 
   @Override
-  public Response getResponse() {
-    return response;
+  public HttpResponse getResponse() {
+    return new RestassuredHttpResponse(response);
   }
 
   @Override
@@ -75,39 +76,39 @@ public class DefaultTestHttpClient implements TestHttpClient {
   }
 
   @Override
-  public Response head() {
+  public HttpResponse head() {
     return head("");
   }
 
   @Override
-  public Response head(String path) {
+  public HttpResponse head(String path) {
     preRequest();
     response = request.head(toAbsolute(path));
-    return postRequest();
+    return new RestassuredHttpResponse(postRequest());
   }
 
   @Override
-  public Response options() {
+  public HttpResponse options() {
     return options("");
   }
 
   @Override
-  public Response options(String path) {
+  public HttpResponse options(String path) {
     preRequest();
     response = request.options(toAbsolute(path));
-    return postRequest();
+    return new RestassuredHttpResponse(postRequest());
   }
 
   @Override
-  public Response get() {
+  public HttpResponse get() {
     return get("");
   }
 
   @Override
-  public Response get(String path) {
+  public HttpResponse get(String path) {
     preRequest();
     response = request.get(toAbsolute(path));
-    return postRequest();
+    return new RestassuredHttpResponse(postRequest());
   }
 
   @Override
@@ -122,15 +123,15 @@ public class DefaultTestHttpClient implements TestHttpClient {
   }
 
   @Override
-  public Response post() {
+  public HttpResponse post() {
     return post("");
   }
 
   @Override
-  public Response post(String path) {
+  public HttpResponse post(String path) {
     preRequest();
     response = request.post(toAbsolute(path));
-    return postRequest();
+    return new RestassuredHttpResponse(postRequest());
   }
 
   @Override
@@ -145,15 +146,15 @@ public class DefaultTestHttpClient implements TestHttpClient {
   }
 
   @Override
-  public Response put() {
+  public HttpResponse put() {
     return put("");
   }
 
   @Override
-  public Response put(String path) {
+  public HttpResponse put(String path) {
     preRequest();
     response = request.put(toAbsolute(path));
-    return postRequest();
+    return new RestassuredHttpResponse(postRequest());
   }
 
   @Override
@@ -163,20 +164,20 @@ public class DefaultTestHttpClient implements TestHttpClient {
 
   @Override
   public String putText(String path) {
-    return put(path).asString();
+    return put(path).getBody();
   }
 
 
   @Override
-  public Response patch() {
+  public HttpResponse patch() {
     return patch("");
   }
 
   @Override
-  public Response patch(String path) {
+  public HttpResponse patch(String path) {
     preRequest();
     response = request.patch(toAbsolute(path));
-    return postRequest();
+    return new RestassuredHttpResponse(postRequest());
   }
 
   @Override
@@ -186,19 +187,19 @@ public class DefaultTestHttpClient implements TestHttpClient {
 
   @Override
   public String patchText(String path) {
-    return patch(path).asString();
+    return patch(path).getBody();
   }  
 
   @Override
-  public Response delete() {
+  public HttpResponse delete() {
     return delete("");
   }
 
   @Override
-  public Response delete(String path) {
+  public HttpResponse delete(String path) {
     preRequest();
     response = request.delete(toAbsolute(path));
-    return postRequest();
+    return new RestassuredHttpResponse(postRequest());
   }
 
   @Override
@@ -208,7 +209,7 @@ public class DefaultTestHttpClient implements TestHttpClient {
 
   @Override
   public String deleteText(String path) {
-    return delete(path).asString();
+    return delete(path).getBody();
   }
 
   @Override

--- a/ratpack-groovy-test/src/main/java/ratpack/groovy/test/internal/RestassuredHttpResponse.java
+++ b/ratpack-groovy-test/src/main/java/ratpack/groovy/test/internal/RestassuredHttpResponse.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.groovy.test.internal;
+
+import com.jayway.restassured.response.Response;
+import ratpack.groovy.test.HttpHeader;
+import ratpack.groovy.test.HttpResponse;
+
+import java.util.List;
+import java.util.Map;
+
+
+public class RestassuredHttpResponse implements HttpResponse {
+
+  Response response;
+
+  RestassuredHttpResponse(Response response) {
+    this.response = response;
+  }
+
+  @Override
+  public int getStatusCode() {
+    return response.getStatusCode();
+  }
+
+  @Override
+  public String getBody() {
+    return response.asString();
+  }
+
+  @Override
+  public byte[] asByteArray() {
+    return response.asByteArray();
+  }
+
+  @Override
+  public String getHeader(String header) {
+    return response.getHeader(header);
+  }
+
+  @Override
+  public String header(String header) {
+    return this.getHeader(header);
+  }
+
+  @Override
+  public Map<String, String> getCookies() {
+    return response.getCookies();
+  }
+
+
+}

--- a/ratpack-groovy/src/test/groovy/ratpack/groovy/handling/DefaultGroovyErrorHandlingSpec.groovy
+++ b/ratpack-groovy/src/test/groovy/ratpack/groovy/handling/DefaultGroovyErrorHandlingSpec.groovy
@@ -33,7 +33,7 @@ class DefaultGroovyErrorHandlingSpec extends RatpackGroovyAppSpec {
 
     then:
     response.statusCode == 500
-    response.body.asString().contains "html"
+    response.body.contains "html"
   }
 
   def "error handler is registered next() is not called"() {
@@ -51,7 +51,7 @@ class DefaultGroovyErrorHandlingSpec extends RatpackGroovyAppSpec {
 
     then:
     response.statusCode == 500
-    response.body.asString().contains "html"
+    response.body.contains "html"
   }
 
   def "404 page is used"() {
@@ -67,7 +67,7 @@ class DefaultGroovyErrorHandlingSpec extends RatpackGroovyAppSpec {
 
     then:
     response.statusCode == 404
-    response.body.asString().contains "html"
+    response.body.contains "html"
   }
 
 }

--- a/ratpack-groovy/src/test/groovy/ratpack/groovy/markup/MarkupRenderingSpec.groovy
+++ b/ratpack-groovy/src/test/groovy/ratpack/groovy/markup/MarkupRenderingSpec.groovy
@@ -20,6 +20,8 @@ import ratpack.http.internal.DefaultMediaType
 import ratpack.test.internal.RatpackGroovyAppSpec
 
 import static ratpack.groovy.Groovy.htmlBuilder
+import static io.netty.handler.codec.http.HttpHeaders.Names.*
+
 
 class MarkupRenderingSpec extends RatpackGroovyAppSpec {
 
@@ -46,6 +48,6 @@ class MarkupRenderingSpec extends RatpackGroovyAppSpec {
   </body>
 </html>"""
 
-    response.contentType == new DefaultMediaType("text/html", "UTF-8").toString()
+    response.header(CONTENT_TYPE) == new DefaultMediaType("text/html", "UTF-8").toString()
   }
 }

--- a/ratpack-groovy/src/test/groovy/ratpack/groovy/templating/TemplateRenderingSpec.groovy
+++ b/ratpack-groovy/src/test/groovy/ratpack/groovy/templating/TemplateRenderingSpec.groovy
@@ -19,6 +19,7 @@ package ratpack.groovy.templating
 import ratpack.test.internal.RatpackGroovyDslSpec
 import spock.lang.Unroll
 
+import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE
 import static ratpack.groovy.Groovy.groovyTemplate
 
 class TemplateRenderingSpec extends RatpackGroovyDslSpec {
@@ -312,14 +313,14 @@ class TemplateRenderingSpec extends RatpackGroovyDslSpec {
     }
 
     then:
-    get("t.html").contentType == "text/html;charset=UTF-8"
-    get("t.xml").contentType == "application/xml"
-    get("dir/t.html").contentType == "text/html;charset=UTF-8"
-    get("dir/t.xml").contentType == "application/xml"
-    get("dir/t").contentType == "application/octet-stream"
+    get("t.html").header(CONTENT_TYPE) == "text/html;charset=UTF-8"
+    get("t.xml").header(CONTENT_TYPE) == "application/xml"
+    get("dir/t.html").header(CONTENT_TYPE) == "text/html;charset=UTF-8"
+    get("dir/t.xml").header(CONTENT_TYPE) == "application/xml"
+    get("dir/t").header(CONTENT_TYPE) == "application/octet-stream"
 
-    get("t.xml?type=foo/bar").contentType == "foo/bar"
-    get("dir/t.xml?type=foo/bar").contentType == "foo/bar"
+    get("t.xml?type=foo/bar").header(CONTENT_TYPE) == "foo/bar"
+    get("dir/t.xml?type=foo/bar").header(CONTENT_TYPE) == "foo/bar"
   }
 
   def "error in error template produces empty response and right error code"() {

--- a/ratpack-guice/src/test/groovy/ratpack/guice/RendererBindingsSpec.groovy
+++ b/ratpack-guice/src/test/groovy/ratpack/guice/RendererBindingsSpec.groovy
@@ -24,6 +24,8 @@ import ratpack.render.NoSuchRendererException
 import ratpack.render.RendererSupport
 import ratpack.test.internal.RatpackGroovyDslSpec
 
+import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE
+
 class RendererBindingsSpec extends RatpackGroovyDslSpec {
 
   static class IntRenderer extends RendererSupport<Integer> {
@@ -66,16 +68,16 @@ class RendererBindingsSpec extends RatpackGroovyDslSpec {
 
     then:
     with(get("int")) {
-      body.asString() == "1"
-      contentType == "text/integer;charset=UTF-8"
+      body == "1"
+      header(CONTENT_TYPE) == "text/integer;charset=UTF-8"
     }
     with(get("string")) {
-      body.asString() == "abc"
-      contentType == "text/string;charset=UTF-8"
+      body == "abc"
+      header(CONTENT_TYPE) == "text/string;charset=UTF-8"
     }
     with(get("none")) {
       statusCode == 500
-      body.asString().contains(NoSuchRendererException.name)
+      body.contains(NoSuchRendererException.name)
     }
   }
 

--- a/ratpack-handlebars/src/test/groovy/ratpack/handlebars/HandlebarsTemplateRenderingSpec.groovy
+++ b/ratpack-handlebars/src/test/groovy/ratpack/handlebars/HandlebarsTemplateRenderingSpec.groovy
@@ -21,6 +21,7 @@ import ratpack.test.internal.RatpackGroovyDslSpec
 import spock.lang.Unroll
 
 import static Template.handlebarsTemplate
+import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR
 
 class HandlebarsTemplateRenderingSpec extends RatpackGroovyDslSpec {
@@ -132,10 +133,10 @@ class HandlebarsTemplateRenderingSpec extends RatpackGroovyDslSpec {
     }
 
     then:
-    get("simple").contentType == "application/octet-stream"
-    get("simple.json").contentType == "application/json"
-    get("simple.html").contentType == "text/html;charset=UTF-8"
-    get("simple.html?type=application/octet-stream").contentType == "application/octet-stream"
+    get("simple").header(CONTENT_TYPE) == "application/octet-stream"
+    get("simple.json").header(CONTENT_TYPE) == "application/json"
+    get("simple.html").header(CONTENT_TYPE) == "text/html;charset=UTF-8"
+    get("simple.html?type=application/octet-stream").header(CONTENT_TYPE) == "application/octet-stream"
   }
 
   void "templates are reloadable when reloading is enabled"() {

--- a/ratpack-manual/src/content/chapters/16-testing.md
+++ b/ratpack-manual/src/content/chapters/16-testing.md
@@ -46,7 +46,7 @@ class SiteSmokeSpec {
 
 
     assert response.statusCode == 200
-    assert response.body.asString().contains('<title>Ratpack: A toolkit for JVM web applications</title>')
+    assert response.body.contains('<title>Ratpack: A toolkit for JVM web applications</title>')
 
   }
 
@@ -54,7 +54,7 @@ class SiteSmokeSpec {
     get()
 
     assert response.statusCode == 200
-    assert response.body.asString().contains('<title>Ratpack: A toolkit for JVM web applications</title>')
+    assert response.body.contains('<title>Ratpack: A toolkit for JVM web applications</title>')
   }
 
   def cleanup() {

--- a/ratpack-pac4j/src/test/groovy/ratpack/pac4j/openid/OpenIdRpSpec.groovy
+++ b/ratpack-pac4j/src/test/groovy/ratpack/pac4j/openid/OpenIdRpSpec.groovy
@@ -99,7 +99,7 @@ class OpenIdRpSpec extends Specification {
     def response = client.get("noauth")
 
     then: "the page is returned without any redirects, and without authentication"
-    response.asString() == "noauth:null"
+    response.body == "noauth:null"
 
     where:
     aut << [autConstructed, autInjected]

--- a/ratpack-session/src/test/groovy/ratpack/session/SessionSpec.groovy
+++ b/ratpack-session/src/test/groovy/ratpack/session/SessionSpec.groovy
@@ -127,10 +127,10 @@ class SessionSpec extends RatpackGroovyDslSpec {
     }
 
     then:
-    get("foo").cookies().isEmpty()
-    get("bar").cookies().JSESSIONID != null
+    get("foo").cookies.isEmpty()
+    get("bar").cookies.JSESSIONID != null
 
     // null because the session id is already set
-    get("bar").cookies().JSESSIONID == null
+    get("bar").cookies.JSESSIONID == null
   }
 }

--- a/ratpack-site/src/test/groovy/ratpack/site/SiteSmokeSpec.groovy
+++ b/ratpack-site/src/test/groovy/ratpack/site/SiteSmokeSpec.groovy
@@ -32,7 +32,7 @@ class SiteSmokeSpec extends Specification {
 
     then:
     response.statusCode == 200
-    response.body.asString().contains('<title>Ratpack: A toolkit for JVM web applications</title>')
+    response.body.contains('<title>Ratpack: A toolkit for JVM web applications</title>')
 
   }
 
@@ -42,7 +42,7 @@ class SiteSmokeSpec extends Specification {
 
     then:
     response.statusCode == 200
-    response.body.asString().contains('<title>Ratpack: A toolkit for JVM web applications</title>')
+    response.body.contains('<title>Ratpack: A toolkit for JVM web applications</title>')
   }
 
   def cleanup() {

--- a/ratpack-thymeleaf/src/test/groovy/ratpack/thymeleaf/ThymeleafTemplateSpec.groovy
+++ b/ratpack-thymeleaf/src/test/groovy/ratpack/thymeleaf/ThymeleafTemplateSpec.groovy
@@ -23,6 +23,8 @@ import spock.lang.Unroll
 
 import static Template.thymeleafTemplate
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR
+import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE
+
 
 class ThymeleafTemplateSpec extends RatpackGroovyDslSpec {
 
@@ -217,8 +219,8 @@ class ThymeleafTemplateSpec extends RatpackGroovyDslSpec {
     }
 
     then:
-    get("simple?type=text/html").contentType == "text/html;charset=UTF-8"
-    get("simple?type=text/xml").contentType == "text/xml;charset=UTF-8"
+    get("simple?type=text/html").getHeader(CONTENT_TYPE) == "text/html;charset=UTF-8"
+    get("simple?type=text/xml").getHeader(CONTENT_TYPE) == "text/xml;charset=UTF-8"
   }
 
   @Unroll


### PR DESCRIPTION
Adding a response interface for the test http client so we don't bleed the internal implementation to the users.

Converted internal tests to use the new HttpResponse
