### PR TITLE
Fix bug on pac4j support for SAML provider

### DIFF
--- a/ratpack-pac4j/src/main/java/ratpack/pac4j/internal/RatpackWebContext.java
+++ b/ratpack-pac4j/src/main/java/ratpack/pac4j/internal/RatpackWebContext.java
@@ -129,8 +129,7 @@ public class RatpackWebContext implements WebContext {
 
   @Override
   public String getFullRequestURL() {
-    final PublicAddress publicAddress = context.get(PublicAddress.class);
-    return publicAddress.getAddress(context).toString() + context.getRequest().getUri();
+    return getAddress().toString() + context.getRequest().getUri();
   }
 
   public void sendResponse(RequiresHttpAction action) {


### PR DESCRIPTION
The getFullRequestUrl method should return the scheme+host+port.

Tested with: https://github.com/leleuj/ratpack-pac4j-demo
