### PR TITLE
Add template resolution caching for faster rendering of simple templates

### DIFF
--- a/ratpack-groovy/src/main/java/ratpack/groovy/markuptemplates/MarkupTemplatingModule.java
+++ b/ratpack-groovy/src/main/java/ratpack/groovy/markuptemplates/MarkupTemplatingModule.java
@@ -19,7 +19,6 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import groovy.text.markup.MarkupTemplateEngine;
 import groovy.text.markup.TemplateConfiguration;
-import groovy.text.markup.TemplateResolver;
 import ratpack.groovy.markuptemplates.internal.MarkupTemplateRenderer;
 import ratpack.launch.LaunchConfig;
 
@@ -151,7 +150,7 @@ public class MarkupTemplatingModule extends AbstractModule {
    * been queried before. This improves performance if caching is enabled in the configuration.
    */
   private static class CachingTemplateResolver extends MarkupTemplateEngine.DefaultTemplateResolver {
-    private final Map<String,URL> cachedResources = new ConcurrentHashMap<>();
+    private final Map<String, URL> cachedResources = new ConcurrentHashMap<>();
     private boolean cache;
 
     @Override


### PR DESCRIPTION
As an answer to the performance issue illustrated in the comments of #363, I propose to introduce caching at the resolver level too. This should probably be something that the default template resolver in groovy should do too.

Here is the result:

![perf](https://cloud.githubusercontent.com/assets/316357/3455592/36bc3e3a-01e4-11e4-9117-e75c798ea44a.png)
