### PR TITLE
Removed Slf4j annotation from ratpack.groovy

### DIFF
--- a/ratpack-lazybones/templates/ratpack/src/ratpack/Ratpack.groovy
+++ b/ratpack-lazybones/templates/ratpack/src/ratpack/Ratpack.groovy
@@ -1,13 +1,10 @@
 import static ratpack.groovy.Groovy.groovyTemplate
 import static ratpack.groovy.Groovy.ratpack
-import groovy.util.logging.Slf4j
 
-@Slf4j
 ratpack {
   handlers {
     get {
       render groovyTemplate("index.html", title: "My Ratpack App")
-      log.debug "your debug info"
     }
         
     assets "public"


### PR DESCRIPTION
Possible fix for issue #373

This pull request may not be the best solution, as it removes the logging entirely from Ratpack.groovy. If someone has a better solution that keeps logging working correctly, that would be preferred.
