### PR TITLE
Updating LaunchConfigsInternalSpec to fix tests on MacOs

### DIFF
--- a/ratpack-core/src/test/groovy/ratpack/launch/internal/LaunchConfigsInternalSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/launch/internal/LaunchConfigsInternalSpec.groovy
@@ -305,7 +305,7 @@ class LaunchConfigsInternalSpec extends Specification {
 
     then:
     data.classLoader == classLoader
-    data.baseDir.normalize() == configFile.parent
+    data.baseDir.normalize().toFile().canonicalPath == configFile.parent.toFile().canonicalPath
     data.properties.getProperty(HANDLER_FACTORY)
     data.envVars == System.getenv()
   }
@@ -318,7 +318,7 @@ class LaunchConfigsInternalSpec extends Specification {
 
     then:
     data.classLoader == classLoader
-    data.baseDir == currentDir
+    data.baseDir.toFile().canonicalPath == currentDir.toFile().canonicalPath
     data.properties.getProperty(PORT) == "3456"
     data.envVars == System.getenv()
 
@@ -327,7 +327,7 @@ class LaunchConfigsInternalSpec extends Specification {
 
     then:
     data.classLoader == classLoader
-    data.baseDir == currentDir
+    data.baseDir.toFile().canonicalPath == currentDir.toFile().canonicalPath
     data.properties.getProperty(PORT) == "3456"
     data.envVars == System.getenv()
   }
@@ -340,7 +340,7 @@ class LaunchConfigsInternalSpec extends Specification {
 
     then:
     data.classLoader == classLoader
-    data.baseDir == currentDir
+    data.baseDir.toFile().canonicalPath == currentDir.toFile().canonicalPath
     data.properties.getProperty(PORT) == "3456"
     data.envVars == System.getenv()
   }


### PR DESCRIPTION
OS X maps tmpdir to a different path -- must resolve canonical path to ensure path matching
