### PR TITLE
Metrics: Allow several registries

### DIFF
--- a/ratpack-codahale-metrics/src/main/java/ratpack/codahale/metrics/CodaHaleMetricsModule.java
+++ b/ratpack-codahale-metrics/src/main/java/ratpack/codahale/metrics/CodaHaleMetricsModule.java
@@ -16,10 +16,7 @@
 
 package ratpack.codahale.metrics;
 
-import com.codahale.metrics.ConsoleReporter;
-import com.codahale.metrics.CsvReporter;
-import com.codahale.metrics.JmxReporter;
-import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.*;
 import com.codahale.metrics.annotation.Metered;
 import com.codahale.metrics.annotation.Timed;
 import com.codahale.metrics.health.HealthCheckRegistry;
@@ -33,6 +30,7 @@ import com.google.inject.Singleton;
 import com.google.inject.matcher.Matchers;
 import com.google.inject.name.Names;
 import ratpack.codahale.metrics.internal.*;
+import ratpack.codahale.metrics.internal.SharedMetricRegistries;
 import ratpack.func.Action;
 import ratpack.guice.HandlerDecoratingModule;
 import ratpack.guice.internal.GuiceUtil;
@@ -167,6 +165,8 @@ import java.io.File;
  */
 public class CodaHaleMetricsModule extends AbstractModule implements HandlerDecoratingModule {
 
+  private static final String RATPACK_DEFAULT_REGISTRY_NAME = "RATPACK_DEFAULT";
+
   private boolean reportMetricsToJmx;
   private boolean reportMetricsToConsole;
   private File csvReportDirectory;
@@ -182,7 +182,9 @@ public class CodaHaleMetricsModule extends AbstractModule implements HandlerDeco
   @Override
   protected void configure() {
     if (isMetricsEnabled()) {
-      final MetricRegistry metricRegistry = new MetricRegistry();
+      SharedMetricRegistries registries = new SharedMetricRegistries();
+      bind(SharedMetricRegistries.class).toInstance(registries);
+      MetricRegistry metricRegistry = registries.getOrCreate(RATPACK_DEFAULT_REGISTRY_NAME);
       bind(MetricRegistry.class).toInstance(metricRegistry);
 
       MeteredMethodInterceptor meteredMethodInterceptor = new MeteredMethodInterceptor();

--- a/ratpack-codahale-metrics/src/main/java/ratpack/codahale/metrics/internal/SharedMetricRegistries.java
+++ b/ratpack-codahale-metrics/src/main/java/ratpack/codahale/metrics/internal/SharedMetricRegistries.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.codahale.metrics.internal;
+
+import com.codahale.metrics.MetricRegistry;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * A map of shared, named metric registries
+ */
+public class SharedMetricRegistries {
+
+  private final ConcurrentMap<String, MetricRegistry> registries = new ConcurrentHashMap<String, MetricRegistry>();
+
+  public void clear() {
+    registries.clear();
+  }
+
+  public Set<String> names() {
+    return registries.keySet();
+  }
+
+  public void remove(String key) {
+    registries.remove(key);
+  }
+
+  public MetricRegistry add(String name, MetricRegistry registry) {
+    return registries.putIfAbsent(name, registry);
+  }
+
+  public MetricRegistry getOrCreate(String name) {
+    final MetricRegistry existing = registries.get(name);
+    if (existing == null) {
+      final MetricRegistry created = new MetricRegistry();
+      final MetricRegistry raced = add(name, created);
+      if (raced == null) {
+        return created;
+      }
+      return raced;
+    }
+    return existing;
+  }
+
+
+}

--- a/ratpack-manual/src/content/chapters/30-codahale-metrics.md
+++ b/ratpack-manual/src/content/chapters/30-codahale-metrics.md
@@ -34,6 +34,10 @@ Ratpack enables you to capture your own application metrics in two ways:
 
 See [`CodaHaleMetricsModule.metrics()`](api/ratpack/codahale/metrics/CodaHaleMetricsModule.html#metrics\(\)) for more details.
 
+## Own registries
+
+Ratpack allows you to use your own registries, so you can report different metrics to different endpoints. You can inject the `SharedMetricRegistries` via Guice and use the `createOrGet()` method to use your own `MetricRegistry` instances.
+
 ## Reporting metrics
 
 Ratpack supports metric reporters for the following outputs:


### PR DESCRIPTION
This commit adds a new SharedMetricRegistries class, which allows to create own MetricRegistries in case you want to send out application specific metrics split from the standard ones.

Closes #404
