### PR TITLE
setting the content type on server error responses

### DIFF
--- a/ratpack-groovy/src/main/java/ratpack/groovy/templating/internal/TemplateRenderingServerErrorHandler.java
+++ b/ratpack-groovy/src/main/java/ratpack/groovy/templating/internal/TemplateRenderingServerErrorHandler.java
@@ -47,6 +47,7 @@ public class TemplateRenderingServerErrorHandler implements ServerErrorHandler {
       response.status(500);
     }
 
+    response.contentType("text/html");
     final ByteBuf byteBuf = byteBufAllocator.buffer();
     renderer.renderError(byteBuf, model).onError(new Action<Throwable>() {
       @Override


### PR DESCRIPTION
without this they are returned as application/octet-stream which
won't be rendered as html by most modern browsers.

I couldn't really workout how to test this from a spec manually. I did the following:

Run the following:

``` groovy
import static ratpack.groovy.Groovy.ratpack

ratpack {
  handlers {
    get {
      throw new Exception("BANG")
    }
  }
}
```

before the change

```
$ curl -v http://localhost:5050 > /dev/null
* Adding handle: conn: 0x7fc76200c400
* Adding handle: send: 0
* Adding handle: recv: 0
* Curl_addHandleToPipeline: length: 1
* - Conn 0 (0x7fc76200c400) send_pipe: 1, recv_pipe: 0
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0* About to connect() to localhost port 5050 (#0)
*   Trying ::1...
* Connected to localhost (::1) port 5050 (#0)
> GET / HTTP/1.1
> User-Agent: curl/7.30.0
> Host: localhost:5050
> Accept: */*
>
< HTTP/1.1 500 Internal Server Error
< Content-Type: application/octet-stream
< Content-Length: 8175
< Connection: keep-alive
```

after the change:

```
$ curl -v http://localhost:5050 > /dev/null
* Adding handle: conn: 0x7fde8400c400
* Adding handle: send: 0
* Adding handle: recv: 0
* Curl_addHandleToPipeline: length: 1
* - Conn 0 (0x7fde8400c400) send_pipe: 1, recv_pipe: 0
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0* About to connect() to localhost port 5050 (#0)
*   Trying ::1...
* Connected to localhost (::1) port 5050 (#0)
> GET / HTTP/1.1
> User-Agent: curl/7.30.0
> Host: localhost:5050
> Accept: */*
>
< HTTP/1.1 500 Internal Server Error
< Content-Type: text/html;charset=UTF-8
< Content-Length: 8175
< Connection: keep-alive
<
{ [data not shown]
100  8175  100  8175    0     0  36704      0 --:--:-- --:--:-- --:--:-- 36824
* Connection #0 to host localhost left intact
```
