### PR TITLE
Add tests for PredicateCacheability and fix issue with Predicates.alwaysTrue()

### DIFF
--- a/ratpack-core/src/test/groovy/ratpack/registry/EnumPredicates.java
+++ b/ratpack-core/src/test/groovy/ratpack/registry/EnumPredicates.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.registry;
+
+import com.google.common.base.Predicate;
+
+
+/**
+ * Class for testing special cases of PredicateCacheability.isCacheable (in PredicateCacheabilitySpec)
+ *
+ * Created by lari on 02/09/14.
+ */
+public class EnumPredicates {
+
+  // code copied from private com.google.common.base.Predicates.ObjectPredicates class, for testing special case Predicates
+  enum ObjectPredicate implements Predicate<Object> {
+    /** @see com.google.common.base.Predicates#alwaysTrue() */
+    ALWAYS_TRUE {
+      @Override public boolean apply(Object o) {
+        return true;
+      }
+      @Override public String toString() {
+        return "Predicates.alwaysTrue()";
+      }
+    },
+    /** @see com.google.common.base.Predicates#alwaysFalse() */
+    ALWAYS_FALSE {
+      @Override public boolean apply(Object o) {
+        return false;
+      }
+      @Override public String toString() {
+        return "Predicates.alwaysFalse()";
+      }
+    },
+    /** @see com.google.common.base.Predicates#isNull() */
+    IS_NULL {
+      @Override public boolean apply(Object o) {
+        return o == null;
+      }
+      @Override public String toString() {
+        return "Predicates.isNull()";
+      }
+    },
+    /** @see com.google.common.base.Predicates#notNull() */
+    NOT_NULL {
+      @Override public boolean apply(Object o) {
+        return o != null;
+      }
+      @Override public String toString() {
+        return "Predicates.notNull()";
+      }
+    };
+
+    @SuppressWarnings("unchecked") // safe contravariant cast
+    <T> Predicate<T> withNarrowedType() {
+      return (Predicate<T>) this;
+    }
+  }
+
+}

--- a/ratpack-core/src/test/groovy/ratpack/registry/PredicateCacheabilitySpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/registry/PredicateCacheabilitySpec.groovy
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.registry
+
+import com.google.common.base.Predicate
+import com.google.common.base.Predicates
+import groovy.transform.EqualsAndHashCode
+import spock.lang.Specification
+
+class PredicateCacheabilitySpec extends Specification {
+  def "isCacheable should work with Predicates.alwaysTrue/False methods"() {
+    expect:
+      PredicateCacheability.isCacheable(Predicates.alwaysTrue()) == true
+      PredicateCacheability.isCacheable(Predicates.alwaysFalse()) == true
+  }
+
+  def "Predicate classes without an equals method aren't cacheable"() {
+    expect:
+      PredicateCacheability.isCacheable(new NonCacheablePredicate()) == false
+  }
+
+  def "Predicate classes with an equals method should be cacheable"() {
+    expect:
+    PredicateCacheability.isCacheable(new CacheablePredicate()) == true
+  }
+
+  def "Predicates in enum inner class should not throw exception"() {
+    given:
+      def pred = EnumPredicates.ObjectPredicate.ALWAYS_TRUE.withNarrowedType()
+    expect:
+      PredicateCacheability.isCacheable(pred) == false
+  }
+
+  def "closure predicates are cacheable"() {
+     given:
+      def pred = {String s -> false} as Predicate<String>
+     expect:
+      PredicateCacheability.isCacheable(pred) == true
+  }
+}
+
+class NonCacheablePredicate implements Predicate<Number> {
+  @Override
+  boolean apply(Number input) {
+    return false
+  }
+}
+
+@EqualsAndHashCode
+class CacheablePredicate implements Predicate<Number> {
+  @Override
+  boolean apply(Number input) {
+    return false
+  }
+}
+
+
+


### PR DESCRIPTION
There aren't currently any unit tests for ratpack.registry.PredicateCacheability . This PR contains some unit tests in a Spock Spec and fixes some issues that the unit tests reveal.
