### PR TITLE
add ratpack-spring-boot module

### DIFF
--- a/ratpack-spring-boot/ratpack-spring-boot.gradle
+++ b/ratpack-spring-boot/ratpack-spring-boot.gradle
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+description = "Integration with Spring Boot for Ratpack applications - http://projects.spring.io/spring-boot/"
+
+apply from: "$rootDir/gradle/javaModule.gradle"
+
+ext.apiLinks = [
+  "http://docs.spring.io/spring-boot/docs/1.1.x/api/",
+  "http://docs.spring.io/spring-framework/docs/4.0.x/javadoc-api/"
+]
+
+dependencies {
+  compile project(":ratpack-core")
+  compile "org.springframework.boot:spring-boot-autoconfigure:1.1.5.RELEASE"
+}

--- a/ratpack-spring-boot/src/main/java/ratpack/spring/Spring.java
+++ b/ratpack-spring-boot/src/main/java/ratpack/spring/Spring.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.spring;
+
+import org.springframework.beans.factory.ListableBeanFactory;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import ratpack.registry.Registry;
+import ratpack.spring.internal.SpringBackedRegistry;
+
+/**
+ * Static utility methods for using Spring in Ratpack applications.
+ *
+ */
+public abstract class Spring {
+  /**
+   * Adapts a Spring ListableBeanFactory instance to Ratpack's Registry interface
+   *
+   * Spring ListableBeanFactory API doesn't current support looking up beans with generic parameterized types.
+   * The adapted Registry instance doesn't support this because of this limitation. There is a
+   * <a href="https://jira.spring.io/browse/SPR-12147">feature request</a> to add the generics functionality to
+   * the Spring ListableBeanFactory API.
+   *
+   * @param beanFactory
+   * @return
+   */
+  public static Registry registry(ListableBeanFactory beanFactory) {
+    return new SpringBackedRegistry(beanFactory);
+  }
+
+  /**
+   * Runs a Spring Boot application
+   *
+   * @param springApplicationClass Spring Boot Application class
+   * @param args arguments to pass to application
+   * @return Ratpack Registry instance that looks up dependencies in the Spring Boot Application's context
+   */
+  public static Registry run(Class<?> springApplicationClass, String... args) {
+    SpringApplicationBuilder springApplicationBuilder = new SpringApplicationBuilder(springApplicationClass);
+    springApplicationBuilder.main(springApplicationClass);
+    return run(springApplicationBuilder, args);
+  }
+
+  /**
+   * Runs a Spring Boot application
+   *
+   * @param springApplicationBuilder Spring Boot SpringApplicationBuilder instance
+   * @param args arguments to pass to application
+   * @return Ratpack Registry instance that looks up dependencies in the Spring Boot Application's context
+   */
+  public static Registry run(SpringApplicationBuilder springApplicationBuilder, String... args) {
+    return registry(springApplicationBuilder.run(args));
+  }
+}

--- a/ratpack-spring-boot/src/main/java/ratpack/spring/internal/SpringBackedRegistry.java
+++ b/ratpack-spring-boot/src/main/java/ratpack/spring/internal/SpringBackedRegistry.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.spring.internal;
+
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.reflect.TypeToken;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactoryUtils;
+import org.springframework.beans.factory.ListableBeanFactory;
+import org.springframework.beans.factory.ObjectFactory;
+import ratpack.api.Nullable;
+import ratpack.func.Action;
+import ratpack.registry.NotInRegistryException;
+import ratpack.registry.PredicateCacheability;
+import ratpack.registry.Registry;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import static ratpack.util.ExceptionUtils.toException;
+import static ratpack.util.ExceptionUtils.uncheck;
+
+public class SpringBackedRegistry implements Registry {
+
+  private final ListableBeanFactory beanFactory;
+
+  public SpringBackedRegistry(ListableBeanFactory beanFactory) {
+    this.beanFactory = beanFactory;
+  }
+
+  private final LoadingCache<TypeToken<?>, List<ObjectFactory<?>>> objectFactoryCache = CacheBuilder.newBuilder().build(new CacheLoader<TypeToken<?>, List<ObjectFactory<?>>>() {
+    @Override
+    public List<ObjectFactory<?>> load(@SuppressWarnings("NullableProblems") TypeToken<?> key) throws Exception {
+      @SuppressWarnings({"unchecked", "RedundantCast"})
+      ImmutableList.Builder<ObjectFactory<?>> builder = ImmutableList.builder();
+      for (final String beanName : BeanFactoryUtils.beanNamesForTypeIncludingAncestors(beanFactory,
+        key.getRawType())) {
+        builder.add(new ObjectFactory<Object>() {
+          @Override
+          public Object getObject() throws BeansException {
+            return beanFactory.getBean(beanName);
+          }
+        });
+      }
+      return builder.build();
+    }
+  });
+
+  private final LoadingCache<PredicateCacheability.CacheKey<?>, List<ObjectFactory<?>>> predicateCache = CacheBuilder.newBuilder().build(new CacheLoader<PredicateCacheability.CacheKey<?>, List<ObjectFactory<?>>>() {
+    @Override
+    public List<ObjectFactory<?>> load(@SuppressWarnings("NullableProblems") PredicateCacheability.CacheKey<?> key) throws Exception {
+      return get(key);
+    }
+
+    private <T> List<ObjectFactory<?>> get(PredicateCacheability.CacheKey<T> key) throws ExecutionException {
+      List<ObjectFactory<?>> objectFactories = getObjectFactories(key.type);
+      if (objectFactories.isEmpty()) {
+        return Collections.emptyList();
+      } else {
+        ImmutableList.Builder<ObjectFactory<?>> builder = ImmutableList.builder();
+        Predicate<? super T> predicate = key.predicate;
+        for (ObjectFactory<?> objectFactory : objectFactories) {
+          @SuppressWarnings("unchecked") ObjectFactory<T> castObjectFactory = (ObjectFactory<T>) objectFactory;
+          if (predicate.apply(castObjectFactory.getObject())) {
+            builder.add(castObjectFactory);
+          }
+        }
+
+        return builder.build();
+      }
+    }
+
+  });
+
+  @Override
+  public <O> O get(Class<O> type) throws NotInRegistryException {
+    return get(TypeToken.of(type));
+  }
+
+  @Override
+  public <O> O get(TypeToken<O> type) throws NotInRegistryException {
+    O object = maybeGet(type);
+    if (object == null) {
+      throw new NotInRegistryException(type);
+    } else {
+      return object;
+    }
+  }
+
+  public <T> T maybeGet(Class<T> type) {
+    return maybeGet(TypeToken.of(type));
+  }
+
+  public <T> T maybeGet(TypeToken<T> type) {
+    List<ObjectFactory<?>> objectFactories = getObjectFactories(type);
+    if (objectFactories.isEmpty()) {
+      return null;
+    } else {
+      @SuppressWarnings("unchecked") T cast = (T) objectFactories.get(0).getObject();
+      return cast;
+    }
+  }
+
+  private <T> List<ObjectFactory<?>> getObjectFactories(TypeToken<T> type) {
+    try {
+      return objectFactoryCache.get(type);
+    } catch (ExecutionException | UncheckedExecutionException e) {
+      throw uncheck(toException(e.getCause()));
+    }
+  }
+
+  @Override
+  public <O> Iterable<? extends O> getAll(Class<O> type) {
+    return getAll(TypeToken.of(type));
+  }
+
+  @Override
+  public <O> Iterable<? extends O> getAll(TypeToken<O> type) {
+    final List<ObjectFactory<?>> objectFactories = getObjectFactories(type);
+    if (objectFactories.isEmpty()) {
+      return Collections.emptyList();
+    } else {
+      return transformToInstances(objectFactories);
+    }
+  }
+
+  private <O> Iterable<O> transformToInstances(Iterable<ObjectFactory<?>> objectFactories) {
+    return Iterables.transform(objectFactories, new Function<ObjectFactory<?>, O>() {
+      @Override
+      public O apply(ObjectFactory<?> input) {
+        @SuppressWarnings("unchecked") O cast = (O) input.getObject();
+        return cast;
+      }
+    });
+  }
+
+  private <T> List<ObjectFactory<?>> getAll(TypeToken<T> type, Predicate<? super T> predicate) {
+    try {
+      return predicateCache.get(new PredicateCacheability.CacheKey<>(type, predicate));
+    } catch (ExecutionException | UncheckedExecutionException e) {
+      throw uncheck(toException(e.getCause()));
+    }
+  }
+
+  @Nullable
+  @Override
+  public <T> T first(TypeToken<T> type, Predicate<? super T> predicate) {
+    Iterator<? extends T> matching = all(type, predicate).iterator();
+    if (!matching.hasNext()) {
+      return null;
+    } else {
+      return matching.next();
+    }
+  }
+
+  @Override
+  public <T> Iterable<? extends T> all(TypeToken<T> type, Predicate<? super T> predicate) {
+    if (PredicateCacheability.isCacheable(predicate)) {
+      return transformToInstances(getAll(type, predicate));
+    } else {
+      return Iterables.filter(getAll(type), predicate);
+    }
+  }
+
+  @Override
+  public <T> boolean each(TypeToken<T> type, Predicate<? super T> predicate, Action<? super T> action) throws Exception {
+    if (PredicateCacheability.isCacheable(predicate)) {
+      Iterable<? extends T> all = all(type, predicate);
+      boolean any = false;
+      for (T t : all) {
+        any = true;
+        action.execute(t);
+      }
+      return any;
+    } else {
+      boolean foundMatch = false;
+      List<ObjectFactory<?>> objectFactories = getObjectFactories(type);
+      for (ObjectFactory<?> objectFactory : objectFactories) {
+        @SuppressWarnings("unchecked") T cast = (T) objectFactory.getObject();
+        if (predicate.apply(cast)) {
+          action.execute(cast);
+          foundMatch = true;
+        }
+      }
+      return foundMatch;
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    SpringBackedRegistry that = (SpringBackedRegistry) o;
+
+    return beanFactory.equals(that.beanFactory);
+  }
+
+  @Override
+  public int hashCode() {
+    return beanFactory.hashCode();
+  }
+
+}

--- a/ratpack-spring-boot/src/test/groovy/ratpack/spring/internal/SpringBackedRegistrySpec.groovy
+++ b/ratpack-spring-boot/src/test/groovy/ratpack/spring/internal/SpringBackedRegistrySpec.groovy
@@ -1,0 +1,142 @@
+package ratpack.spring.internal
+
+import com.google.common.base.Predicates
+import com.google.common.reflect.TypeToken
+import org.springframework.context.support.StaticApplicationContext
+import ratpack.func.Action
+import ratpack.registry.NotInRegistryException
+import ratpack.registry.Registry
+import spock.lang.Specification
+
+class SpringBackedRegistrySpec extends Specification {
+  def appContext = new StaticApplicationContext()
+  def r = new SpringBackedRegistry(appContext)
+  def beanFactory = appContext.getBeanFactory()
+
+  def "empty registry"() {
+    expect:
+    r.maybeGet(String) == null
+
+    when:
+    r.get(String)
+
+    then:
+    thrown NotInRegistryException
+  }
+
+  def "get and getAll should support implemented interfaces besides actual class"() {
+    when:
+    beanFactory.registerSingleton("foo", "foo")
+
+    then:
+    r.get(String) == "foo"
+    r.get(CharSequence) == "foo"
+    r.getAll(String).toList() == ["foo"]
+    r.getAll(CharSequence).toList() == ["foo"]
+  }
+
+  def "search empty registry with always false predicate"() {
+    expect:
+    r.first(TypeToken.of(Object), Predicates.alwaysFalse()) == null
+    r.all(TypeToken.of(Object), Predicates.alwaysFalse()) as List == []
+  }
+
+  def "search with one item"() {
+    given:
+    TypeToken type = TypeToken.of(String)
+    TypeToken other = TypeToken.of(Number)
+    def value = "Something"
+
+    beanFactory.registerSingleton("value", value)
+
+    expect:
+    r.first(type, Predicates.alwaysTrue()) == value
+    r.first(type, Predicates.alwaysFalse()) == null
+    r.first(other, Predicates.alwaysTrue()) == null
+    r.first(other, Predicates.alwaysFalse()) == null
+
+    r.all(type, Predicates.alwaysTrue()) as List == [value]
+    r.all(type, Predicates.alwaysFalse()) as List == []
+    r.all(other, Predicates.alwaysTrue()) as List == []
+    r.all(other, Predicates.alwaysFalse()) as List == []
+  }
+
+  def "search with multiple items"() {
+    given:
+    TypeToken string = TypeToken.of(String)
+    TypeToken number = TypeToken.of(Number)
+    def a = "A"
+    def b = "B"
+    def c = 42
+    def d = 16
+    beanFactory.registerSingleton("a", a)
+    beanFactory.registerSingleton("b", b)
+    beanFactory.registerSingleton("c", c)
+    beanFactory.registerSingleton("d", d)
+
+    expect:
+    r.first(string, Predicates.alwaysTrue()) == a
+    r.first(string, { s -> s.startsWith('B') }) == b
+    r.first(number, Predicates.alwaysTrue()) == c
+    r.first(number, { n -> n < 20 }) == d
+
+    r.all(string, Predicates.alwaysTrue()) as List == [a, b]
+    r.all(string, { s -> s.startsWith('B') }) as List == [b]
+    r.all(number, { n -> n < 50 })  as List == [c, d]
+    r.all(number, Predicates.alwaysFalse()) as List == []
+  }
+
+  def "each with action"() {
+    given:
+    Action action = Mock()
+    def sameType = TypeToken.of(String)
+    def differentType = TypeToken.of(Number)
+    def value = "Something"
+    beanFactory.registerSingleton("value", value)
+
+    when:
+    r.each(sameType, Predicates.alwaysTrue(), action)
+
+    then:
+    1 * action.execute(value)
+
+    when:
+    r.each(sameType, Predicates.alwaysFalse(), action)
+
+    then:
+    0 * action.execute(_)
+
+    when:
+    r.each(differentType, Predicates.alwaysTrue(), action)
+    r.each(differentType, Predicates.alwaysFalse(), action)
+
+    then:
+    0 * action.execute(_)
+  }
+
+  def "find first"() {
+    given:
+    def sameType = TypeToken.of(String)
+    def differentType = TypeToken.of(Number)
+    def value = "Something"
+    beanFactory.registerSingleton("value", value)
+    expect:
+    r.first(sameType, Predicates.alwaysTrue()) == value
+    r.first(sameType, Predicates.alwaysFalse()) == null
+    r.first(differentType, Predicates.alwaysTrue()) == null
+    r.first(differentType, Predicates.alwaysFalse()) == null
+  }
+
+  def "find all"() {
+    given:
+    def sameType = TypeToken.of(String)
+    def differentType = TypeToken.of(Number)
+    def value = "Something"
+    beanFactory.registerSingleton("value", value)
+    expect:
+    r.all(sameType, Predicates.alwaysTrue()).toList() == [value]
+    r.all(sameType, Predicates.alwaysFalse()).toList() == []
+    r.all(differentType, Predicates.alwaysTrue()).toList() == []
+    r.all(differentType, Predicates.alwaysFalse()).toList() == []
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -38,7 +38,8 @@ include \
     "ratpack-hikari",
     "ratpack-newrelic",
     "ratpack-pac4j",
-    "ratpack-hystrix"
+    "ratpack-hystrix",
+    "ratpack-spring-boot"
 
 include "perf"
 


### PR DESCRIPTION
This PR adds a SpringBackedRegistry implementation and a simple helper for starting a Spring Boot application embedded in Ratpack. The ratpack.spring.Spring.run method returns a Registry instance that can be passed to the "register" DSL method. 
usage example: https://github.com/lhotari/ratpack-gorm-example/blob/dc4ebfafec36976cdc77924d1c9c9da9f6e9fda1/src/ratpack/Ratpack.groovy#L10

Based on discussion in Ratpack Forum: http://forum.ratpack.io/Preparation-of-Spring-Boot-module-for-Ratpack-tp569p587.html , I've now re-implemented SpringBackedRegistry by copying the InjectorBackedRegistry and "porting" that to use Spring and re-using some code from [the version of SpringBackedRegistry that is implemented by Dave Syer](https://github.com/dsyer/spring-boot-ratpack/blob/master/spring-boot-ratpack/src/main/java/ratpack/spring/internal/SpringBackedRegistry.java).
I added tests for SpringBackedRegistry by picking some test methods from the tests of the different Registry implementations that Ratpack already contains. 
