### PR TITLE
Fixing handlebars template cache bug

### DIFF
--- a/ratpack-handlebars/src/main/java/ratpack/handlebars/internal/FileSystemBindingTemplateLoader.java
+++ b/ratpack-handlebars/src/main/java/ratpack/handlebars/internal/FileSystemBindingTemplateLoader.java
@@ -40,7 +40,7 @@ public class FileSystemBindingTemplateLoader extends AbstractTemplateLoader {
     if (path == null || !Files.exists(path)) {
       throw new IOException("No template at " + resolved + " for binding " + fileSystemBinding);
     } else {
-      return new PathTemplateSource(path);
+      return new PathTemplateSource(path, fileSystemBinding.getFile());
     }
   }
 

--- a/ratpack-handlebars/src/main/java/ratpack/handlebars/internal/PathTemplateSource.java
+++ b/ratpack-handlebars/src/main/java/ratpack/handlebars/internal/PathTemplateSource.java
@@ -27,9 +27,11 @@ import java.nio.file.Path;
 public class PathTemplateSource implements TemplateSource {
 
   private final Path path;
+  private final Path bindingPath;
 
-  public PathTemplateSource(Path path) {
+  public PathTemplateSource(Path path, Path bindingPath) {
     this.path = path;
+    this.bindingPath = bindingPath;
   }
 
   @Override
@@ -44,7 +46,7 @@ public class PathTemplateSource implements TemplateSource {
 
   @Override
   public String filename() {
-    return path.getFileName().toString();
+    return bindingPath.relativize(path).toString();
   }
 
   @Override

--- a/ratpack-handlebars/src/test/groovy/ratpack/handlebars/HandlebarsTemplateRenderingSpec.groovy
+++ b/ratpack-handlebars/src/test/groovy/ratpack/handlebars/HandlebarsTemplateRenderingSpec.groovy
@@ -188,6 +188,29 @@ class HandlebarsTemplateRenderingSpec extends RatpackGroovyDslSpec {
     then:
     text == 'A'
   }
+
+  void "template cache allows templates with the same filename with different paths"() {
+    given:
+    file 'handlebars/foo/simple.hbs', 'A'
+    file 'handlebars/bar/simple.hbs', 'B'
+
+    when:
+    bindings {
+      add new HandlebarsModule(reloadable: false, cacheSize: 20)
+    }
+    handlers {
+      get('foo') {
+        render handlebarsTemplate('foo/simple')
+      }
+      get('bar') {
+        render handlebarsTemplate('bar/simple')
+      }
+    }
+
+    then:
+    get('foo').body.text == 'A'
+    get('bar').body.text == 'B'
+  }
 }
 
 class TestHelper implements NamedHelper {


### PR DESCRIPTION
The template cache currently caches by filename alone, which breaks when
you organize templates according to subdirectory. This adds the relative
path to the filename as part of the template cache key.
