### PR TITLE
update Spring Loaded repository url and version to most recent

### DIFF
--- a/ratpack-lazybones/src/templates/ratpack/build.gradle
+++ b/ratpack-lazybones/src/templates/ratpack/build.gradle
@@ -13,13 +13,13 @@ apply plugin: "eclipse"
 
 repositories {
   jcenter()
-  maven { url "http://repo.springsource.org/repo" } // for springloaded
+  maven { url "https://repo.spring.io/repo" } // for springloaded
 }
 
 dependencies {
   // SpringLoaded enables runtime hot reloading.
   // It is not part of the app runtime and is not shipped in the distribution.
-  springloaded "org.springframework:springloaded:1.2.0.RELEASE"
+  springloaded "org.springframework:springloaded:1.2.1.RELEASE"
 
   // Default SLF4J binding.  Note that this is a blocking implementation.
   // See here for a non blocking appender http://logging.apache.org/log4j/2.x/manual/async.html

--- a/ratpack-manual/src/content/chapters/60-gradle.md
+++ b/ratpack-manual/src/content/chapters/60-gradle.md
@@ -272,7 +272,7 @@ runShadow {
 ## Class reloading via SpringLoaded
 
 With a little extra configuration, you can enable reloading of changed classes at development time without restarting the server.
-This is achieved by leveraging [SpringLoaded, by Pivotal Labs](https://github.com/spring-projects/spring-loaded).
+This is achieved by leveraging [SpringLoaded, by Pivotal](https://github.com/spring-projects/spring-loaded).
 To use SpringLoaded in your Ratpack project, you need to add a dependency on the SpringLoaded agent.
 
 ```language-groovy gradle
@@ -289,11 +289,11 @@ apply plugin: "io.ratpack.ratpack-java"
 
 repositories {
   jcenter()
-  maven { url "http://repo.springsource.org/repo" } // for springloaded
+  maven { url "https://repo.spring.io/repo" } // for springloaded
 }
 
 dependencies {
-  springloaded "org.springsource.loaded:springloaded:1.1.5.RELEASE"
+  springloaded "org.springframework:springloaded:1.2.1.RELEASE"
 }
 ```
 

--- a/ratpack-site/ratpack-site.gradle
+++ b/ratpack-site/ratpack-site.gradle
@@ -41,7 +41,7 @@ apply plugin: "geb-saucelabs"
 apply plugin: 'com.github.johnrengelman.shadow'
 
 repositories {
-  maven { url "http://repo.springsource.org/repo" } // for springloaded
+  maven { url "https://repo.spring.io/repo" } // for springloaded
   maven { url "http://repo.gradle.org/gradle/javascript-public/" } // for coffeescript plugin
   maven { url "http://repository-saucelabs.forge.cloudbees.com/release" }
 }
@@ -79,7 +79,7 @@ sourceSets {
 }
 
 dependencies {
-  springloaded "org.springframework:springloaded:1.2.0.RELEASE"
+  springloaded "org.springframework:springloaded:1.2.1.RELEASE"
   compile project(":ratpack-groovy")
   compile project(":ratpack-codahale-metrics")
   compile project(":ratpack-jackson")


### PR DESCRIPTION
This updates Spring Loaded repository url to https://repo.spring.io/repo and the most recent version 1.2.1.RELEASE.
