### PR TITLE
Convert Rx Observables to Ratpack Promises. (Issue 468)

### DIFF
--- a/ratpack-rx/src/test/groovy/ratpack/rx/RxExecHarnessSpec.groovy
+++ b/ratpack-rx/src/test/groovy/ratpack/rx/RxExecHarnessSpec.groovy
@@ -1,0 +1,45 @@
+package ratpack.rx
+
+import ratpack.test.exec.ExecHarness
+import rx.Observable
+import spock.lang.Specification
+
+import static ratpack.rx.RxRatpack.promise
+
+class RxExecHarnessSpec extends Specification {
+
+  private AsyncService service = new AsyncService()
+
+  static class AsyncService {
+
+    public Observable<Void> fail() {
+      Observable.error(new RuntimeException("!!!"))
+    }
+
+    public <T> Observable<T> observe(T value) {
+      Observable.just(value)
+    }
+  }
+
+  def "can test async service"() {
+    when:
+    def result = ExecHarness.yieldSingle {
+      promise(service.observe("foo"))
+    }
+
+    then:
+    result.value == ["foo"]
+  }
+
+  def "failed observable causes exception to be thrown"() {
+    when:
+    ExecHarness.yieldSingle {
+      promise(service.fail())
+    }.valueOrThrow
+
+    then:
+    def e = thrown RuntimeException
+    e.message == "!!!"
+  }
+
+}

--- a/ratpack-test/src/main/java/ratpack/test/exec/ExecHarness.java
+++ b/ratpack-test/src/main/java/ratpack/test/exec/ExecHarness.java
@@ -94,6 +94,9 @@ public interface ExecHarness extends ExecControl, AutoCloseable {
    * }
    * }</pre>
    *
+   * When using Ratpack's RxJava integration, ExecHarness can be used to test {@code rx.Observable} instances by first converting them to a promise.
+   * See the {@code ratpack.rx.RxRatpack.promise(Observable)} documentation for an example of testing observables.
+   *
    * @return a new execution harness
    */
   public static ExecHarness harness() {


### PR DESCRIPTION
Supports testing observables by converting them to promises and using
the existing ExecHarness methods. (Issue 384)
