### PR TITLE
Build Pac4JCallbackHandler with a builder

### DIFF
--- a/ratpack-pac4j/src/main/java/ratpack/pac4j/Pac4jCallbackHandlerBuilder.java
+++ b/ratpack-pac4j/src/main/java/ratpack/pac4j/Pac4jCallbackHandlerBuilder.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.pac4j;
+
+import org.pac4j.core.client.Client;
+import org.pac4j.core.credentials.Credentials;
+import org.pac4j.core.profile.UserProfile;
+import ratpack.handling.Context;
+import ratpack.pac4j.internal.Pac4jCallbackHandler;
+import ratpack.pac4j.internal.RatpackWebContext;
+
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+
+/**
+ * Builder for Pac4J callback handler.
+ */
+public class Pac4jCallbackHandlerBuilder {
+  private BiFunction<Context,RatpackWebContext,Client<Credentials, UserProfile>> findClientFunction;
+  private BiConsumer<Context,UserProfile> handleProfileFunction;
+  private BiConsumer<Context,Throwable> handleErrorFunction;
+
+  public Pac4jCallbackHandler build() {
+    return new Pac4jCallbackHandler(findClientFunction, handleProfileFunction, handleErrorFunction);
+  }
+
+  /**
+   * Add function for looking up client given the context.
+   *
+   * <p>e.g.</p>
+   * <pre>
+   * <code>
+   * builder.findClient(((context, ratpackContext) -&gt; context.getRequest().get(Clients.class).findClient(context.getPathTokens().get("clientName"))
+   * </code>
+   * </pre>
+   *
+   * @param findClientFunction the lookup function
+   * @return the builder
+   */
+  @SuppressWarnings("unused")
+  public Pac4jCallbackHandlerBuilder findClient(BiFunction<Context,RatpackWebContext,Client<Credentials, UserProfile>> findClientFunction) {
+    this.findClientFunction = findClientFunction;
+    return this;
+  }
+
+  /**
+   * Add handler for dealing with the newly-looked-up profile
+   *
+   * <p>e.g.</p>
+   * <pre>
+   * <code>
+   * builder.handleProfile(((context, profile) -&gt; context.next(Registries.just(profile))));
+   * </code>
+   * </pre>
+   *
+   * @param handleProfileFunction the handler function
+   * @return the builder
+   */
+  @SuppressWarnings("unused")
+  public Pac4jCallbackHandlerBuilder handleProfile(BiConsumer<Context,UserProfile> handleProfileFunction) {
+    this.handleProfileFunction = handleProfileFunction;
+    return this;
+  }
+
+  /**
+   * Add handler for dealing with errors
+   *
+   * <p>e.g.</p>
+   * <pre>
+   * <code>
+   * this.handleError((context, ex) -&gt; {
+   *     LOGGER.error("Error logging in", ex);
+   *     context.redirect("/some/url");
+   * });
+   * </code>
+   * </pre>
+   *
+   * @param handleErrorFunction the handler function
+   * @return the builder
+   */
+  @SuppressWarnings("unused")
+  public Pac4jCallbackHandlerBuilder handleError(BiConsumer<Context,Throwable> handleErrorFunction) {
+    this.handleErrorFunction = handleErrorFunction;
+    return this;
+  }
+
+}

--- a/ratpack-pac4j/src/main/java/ratpack/pac4j/internal/AbstractPac4jModule.java
+++ b/ratpack-pac4j/src/main/java/ratpack/pac4j/internal/AbstractPac4jModule.java
@@ -28,6 +28,7 @@ import ratpack.handling.Handler;
 import ratpack.handling.Handlers;
 import ratpack.launch.LaunchConfig;
 import ratpack.pac4j.Authorizer;
+import ratpack.pac4j.Pac4jCallbackHandlerBuilder;
 
 /**
  * Base class for pac4j integration modules.
@@ -88,7 +89,7 @@ public abstract class AbstractPac4jModule<C extends Credentials, U extends UserP
     final Client<C, U> client = getClient(injector);
     final Authorizer authorizer = getAuthorizer(injector);
     final Pac4jClientsHandler clientsHandler = new Pac4jClientsHandler(callbackPath, client);
-    final Pac4jCallbackHandler callbackHandler = new Pac4jCallbackHandler();
+    final Pac4jCallbackHandler callbackHandler = new Pac4jCallbackHandlerBuilder().build();
     final Pac4jAuthenticationHandler authenticationHandler = new Pac4jAuthenticationHandler(client.getName(), authorizer);
     return Handlers.chain(clientsHandler, Handlers.path(callbackPath, callbackHandler), authenticationHandler, handler);
   }


### PR DESCRIPTION
Take 2, now with more builders.

Bikeshedding:
- I left the default functions in the handler itself rather than putting them in the builder or separate classes.
- There's still a no-arg constructor to get the current behaviour.
