### PR TITLE
change reference to java 7 to java 8

### DIFF
--- a/ratpack-manual/src/content/chapters/70-heroku.md
+++ b/ratpack-manual/src/content/chapters/70-heroku.md
@@ -26,10 +26,10 @@ If the wrapper scripts are present in your project, Heroku will detect that your
 Heroku allows the required Java version to be set via `system.properties` file in the root of the source tree.
 
 ```
-java.runtime.version=1.7
+java.runtime.version=1.8
 ```
 
-At the time of writing, this file is required as Heroku defaults to Java 6 and Ratpack requires Java 7.
+At the time of writing, this file is required as Heroku defaults to Java 6 and Ratpack requires Java 8.
 
 ### Building
 


### PR DESCRIPTION
Manual says ratpack needs java 7 but latest builds requires java 8
