### PR TITLE
Adjust javadoc.css and <pre> with class language-groovy to unified DOM

### DIFF
--- a/ratpack-manual/src/sass/javadoc.scss
+++ b/ratpack-manual/src/sass/javadoc.scss
@@ -571,6 +571,9 @@ div.description li.blockList > pre {
 	font-size: 120%;
 }
 
+// Javadoc <pre> now contains <code> to be compatible with manual code sample DOM structure
+// Padding for pre is no needed. <code> has own padding. font-size is changed on <code> level too.
 pre.language-groovy {
-	padding: 1em;
+	//padding: 1em;
+        font-size:100%
 }


### PR DESCRIPTION
structure.

Javadoc <pre> element now contains <code> element to have the same DOM
structure as code samples in manual.
Then padding for <pre> is not needed. It is set on the <code> level.
Font size change is not needed on <pre> element too. It is set on the
<code> level.
