### PR TITLE
Put encoder before aggregator in NettyRatpackServer pipeline.

### DIFF
--- a/ratpack-core/src/main/java/ratpack/server/internal/NettyRatpackServer.java
+++ b/ratpack-core/src/main/java/ratpack/server/internal/NettyRatpackServer.java
@@ -204,8 +204,8 @@ public class NettyRatpackServer implements RatpackServer {
           }
 
           pipeline.addLast("decoder", new HttpRequestDecoder(4096, 8192, 8192, false));
-          pipeline.addLast("aggregator", new HttpObjectAggregator(serverConfig.getMaxContentLength()));
           pipeline.addLast("encoder", new HttpResponseEncoder());
+          pipeline.addLast("aggregator", new HttpObjectAggregator(serverConfig.getMaxContentLength()));
           pipeline.addLast("deflater", new SmartHttpContentCompressor());
           pipeline.addLast("chunkedWriter", new ChunkedWriteHandler());
           pipeline.addLast("adapter", handlerAdapter);

--- a/ratpack-core/src/test/groovy/ratpack/server/internal/NettyRatpackServiceSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/server/internal/NettyRatpackServiceSpec.groovy
@@ -21,6 +21,7 @@ import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import ratpack.server.RatpackServer
 import ratpack.server.ServerConfig
+import ratpack.test.ApplicationUnderTest
 import spock.lang.IgnoreIf
 import spock.lang.Specification
 
@@ -51,6 +52,28 @@ class NettyRatpackServiceSpec extends Specification {
         it.stop()
       }
     }
+  }
+
+  def "responds to Expect: 100-continue header"() {
+    given:
+    def config = ServerConfig.embedded().port(0)
+    def client = ApplicationUnderTest.of(
+      RatpackServer.of {
+        it.serverConfig(config).handlers {
+          it.post { it.render("Hello") }
+        }
+      }
+    ).getHttpClient()
+    .requestSpec{
+      it.headers.add("Expect", "100-continue")
+    }
+
+    when:
+    client.post()
+
+    then:
+    client.response.statusCode == 100
+    client.response.body.text == ""
   }
 
 }


### PR DESCRIPTION
I'm getting this log error when trying to post a `multipart/form-data` to an endpoint.

```
23228 [ratpack-compute-1-2] WARN io.netty.channel.DefaultChannelPipeline  - An exceptionCaught() event was fired, and it reached at the tail of the pipeline. It usually means the last handler in the pipeline did not handle the exception.
java.lang.UnsupportedOperationException: unsupported message type: DefaultFullHttpResponse (expected: ByteBuf, FileRegion)
	at io.netty.channel.nio.AbstractNioByteChannel.filterOutboundMessage(AbstractNioByteChannel.java:277)
	at io.netty.channel.AbstractChannel$AbstractUnsafe.write(AbstractChannel.java:734)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.write(DefaultChannelPipeline.java:1221)
	at io.netty.channel.ChannelHandlerInvokerUtil.invokeWriteNow(ChannelHandlerInvokerUtil.java:158)
	at io.netty.channel.DefaultChannelHandlerInvoker.invokeWrite(DefaultChannelHandlerInvoker.java:337)
	at io.netty.channel.AbstractChannelHandlerContext.writeAndFlush(AbstractChannelHandlerContext.java:353)
	at io.netty.channel.AbstractChannelHandlerContext.writeAndFlush(AbstractChannelHandlerContext.java:360)
	at io.netty.handler.codec.MessageAggregator.decode(MessageAggregator.java:224)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:89)
	at io.netty.channel.ChannelHandlerInvokerUtil.invokeChannelReadNow(ChannelHandlerInvokerUtil.java:84)
	at io.netty.channel.DefaultChannelHandlerInvoker.invokeChannelRead(DefaultChannelHandlerInvoker.java:153)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:187)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:242)
	at io.netty.channel.ChannelHandlerInvokerUtil.invokeChannelReadNow(ChannelHandlerInvokerUtil.java:84)
	at io.netty.channel.DefaultChannelHandlerInvoker.invokeChannelRead(DefaultChannelHandlerInvoker.java:153)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:187)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:947)
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:127)
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:510)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:467)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:381)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:353)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:703)
	at ratpack.exec.internal.DefaultExecController$ExecControllerBindingThreadFactory.lambda$newThread$121(DefaultExecController.java:82)
	at ratpack.exec.internal.DefaultExecController$ExecControllerBindingThreadFactory$$Lambda$30/2084663827.run(Unknown Source)
	at io.netty.util.concurrent.DefaultThreadFactory$DefaultRunnableDecorator.run(DefaultThreadFactory.java:137)
	at java.lang.Thread.run(Thread.java:745)
```

Code
```java
public class TestApp {
    public static void main(String[] args) throws NoSuchRendererException, Exception {
        Logger.getRootLogger().setLevel(Level.INFO);
        Logger.getRootLogger().addAppender(new ConsoleAppender(new PatternLayout(PatternLayout.TTCC_CONVERSION_PATTERN)));

        RatpackServer.of(b -> b
            .handlers(chain -> chain
                .post(ctx -> ctx.render("Received: " + ctx.parse(Form.class).get("f")))))
            .start();
    }
}
```

Doing this causes the log message.
```
curl -F f=hello localhost:5050
```

According to netty/netty#2219, it's because NettyRatpackServer put the `HttpResponseEncoder` after the `HttpObjectAggregator` in the pipeline. Also relevant [javadoc](http://netty.io/4.1/api/io/netty/handler/codec/http/HttpObjectAggregator.html).

This PR just switches the order of the two things around.