### PR TITLE
CsvReporter should only be provided when configuration is valid

### DIFF
--- a/ratpack-codahale-metrics/src/main/java/ratpack/codahale/metrics/internal/CsvReporterProvider.java
+++ b/ratpack-codahale-metrics/src/main/java/ratpack/codahale/metrics/internal/CsvReporterProvider.java
@@ -19,11 +19,9 @@ package ratpack.codahale.metrics.internal;
 import com.codahale.metrics.CsvReporter;
 import com.codahale.metrics.MetricRegistry;
 import ratpack.codahale.metrics.CodaHaleMetricsModule;
-import ratpack.server.ServerConfig;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
-import java.io.File;
 
 /**
  * A Provider implementation that sets up a {@link CsvReporter} for a {@link MetricRegistry}.
@@ -31,27 +29,27 @@ import java.io.File;
 public class CsvReporterProvider implements Provider<CsvReporter> {
   private final MetricRegistry metricRegistry;
   private final CodaHaleMetricsModule.Config config;
-  private final File defaultReportDirectory;
 
   @Inject
-  public CsvReporterProvider(MetricRegistry metricRegistry, CodaHaleMetricsModule.Config config, ServerConfig serverConfig) {
+  public CsvReporterProvider(MetricRegistry metricRegistry, CodaHaleMetricsModule.Config config) {
     this.metricRegistry = metricRegistry;
     this.config = config;
-    this.defaultReportDirectory = serverConfig.getBaseDir().getFile().toFile();
   }
 
   @Override
   public CsvReporter get() {
+    if(!config.getCsv().isPresent()) {
+      return null;
+    }
+
     CsvReporter.Builder builder = CsvReporter.forRegistry(metricRegistry);
-    config.getConsole().ifPresent(csv -> {
-      if (csv.getFilter() != null) {
-        builder.filter(new RegexMetricFilter(csv.getFilter()));
+    config.getConsole().ifPresent(cfg -> {
+      if (cfg.getFilter() != null) {
+        builder.filter(new RegexMetricFilter(cfg.getFilter()));
       }
     });
 
-    return builder.build(
-      config.getCsv().isPresent() ? config.getCsv().get().getReportDirectory() : defaultReportDirectory
-    );
+    return builder.build(config.getCsv().get().getReportDirectory());
   }
 }
 


### PR DESCRIPTION
Fixes #610 

In the issue, I mentioned throwing an exception if the CSV config was not present. Instead, I am returning null if not configured. This is because the CsvReporter binding is marked as a Singleton, and guice singletons are eager singletons. Throwing an exception like I mentioned makes a csv configuration required.

That said, binding to null means that all attempts to get the CsvReporter instance when the csv configuration is not enabled will return null instead of providing a clear error message.

The alternative to returning null is to make the CsvReporterProvider a singleton and have it lazily create the CsvReporter singleton. If you would prefer that approach, I can make the necessary changes