### PR TITLE
Support for extended list of encryption algorithms used by  cookie-sessions

### DIFF
--- a/ratpack-session/src/main/java/ratpack/session/clientside/internal/DefaultCrypto.java
+++ b/ratpack-session/src/main/java/ratpack/session/clientside/internal/DefaultCrypto.java
@@ -110,8 +110,11 @@ public class DefaultCrypto implements Crypto {
 
       int count = cipher.doFinal(message.readBytes(messageLength).nioBuffer(), nioDecMessageBuf);
       for (int i = count - 1; i >= 0; i--) {
-        if (nioDecMessageBuf.get(i) == 0x00) count--;
-        else break;
+        if (nioDecMessageBuf.get(i) == 0x00) {
+          count--;
+        } else {
+          break;
+        }
       }
       byte[] decrypted = new byte[count];
       nioDecMessageBuf.position(0);

--- a/ratpack-session/src/test/groovy/ratpack/session/clientside/ClientSideSessionSpec.groovy
+++ b/ratpack-session/src/test/groovy/ratpack/session/clientside/ClientSideSessionSpec.groovy
@@ -25,6 +25,7 @@ import ratpack.http.internal.HttpHeaderConstants
 import ratpack.session.store.SessionStorage
 import ratpack.test.internal.RatpackGroovyDslSpec
 import spock.lang.Ignore
+import spock.lang.IgnoreRest
 import spock.lang.Unroll
 
 class ClientSideSessionSpec extends RatpackGroovyDslSpec {
@@ -312,7 +313,6 @@ class ClientSideSessionSpec extends RatpackGroovyDslSpec {
 
   }
 
-  @Ignore
   @Unroll
   def "sessions with value of length #length can be serialized/deserialized"() {
     given:
@@ -349,6 +349,7 @@ class ClientSideSessionSpec extends RatpackGroovyDslSpec {
     length << (1..256)
   }
 
+  @IgnoreRest
   @Unroll
   def "secretKey with #algorithm renders session unreadable"() {
     given:
@@ -411,13 +412,13 @@ class ClientSideSessionSpec extends RatpackGroovyDslSpec {
 //      "AES/ECB/NoPadding",
       "AES/ECB/PKCS5Padding",
 //      "DES/CBC/NoPadding",
-//      "DES/CBC/PKCS5Padding",
+      "DES/CBC/PKCS5Padding",
 //      "DES/ECB/NoPadding",
-//      "DES/ECB/PKCS5Padding",
+      "DES/ECB/PKCS5Padding",
 //      "DESede/CBC/NoPadding",
-//      "DESede/CBC/PKCS5Padding",
+      "DESede/CBC/PKCS5Padding",
 //      "DESede/ECB/NoPadding",
-//      "DESede/ECB/PKCS5Padding"
+      "DESede/ECB/PKCS5Padding"
       ]
 
   }

--- a/ratpack-session/src/test/groovy/ratpack/session/clientside/ClientSideSessionSpec.groovy
+++ b/ratpack-session/src/test/groovy/ratpack/session/clientside/ClientSideSessionSpec.groovy
@@ -406,18 +406,18 @@ class ClientSideSessionSpec extends RatpackGroovyDslSpec {
 
     where:
     algorithm << [
-//      "Blowfish",
-//      "AES/CBC/NoPadding",
+      "Blowfish",
+      "AES/CBC/NoPadding",
       "AES/CBC/PKCS5Padding",
-//      "AES/ECB/NoPadding",
+      "AES/ECB/NoPadding",
       "AES/ECB/PKCS5Padding",
-//      "DES/CBC/NoPadding",
+      "DES/CBC/NoPadding",
       "DES/CBC/PKCS5Padding",
-//      "DES/ECB/NoPadding",
+      "DES/ECB/NoPadding",
       "DES/ECB/PKCS5Padding",
-//      "DESede/CBC/NoPadding",
+      "DESede/CBC/NoPadding",
       "DESede/CBC/PKCS5Padding",
-//      "DESede/ECB/NoPadding",
+      "DESede/ECB/NoPadding",
       "DESede/ECB/PKCS5Padding"
       ]
 

--- a/ratpack-session/src/test/groovy/ratpack/session/clientside/ClientSideSessionSpec.groovy
+++ b/ratpack-session/src/test/groovy/ratpack/session/clientside/ClientSideSessionSpec.groovy
@@ -349,7 +349,6 @@ class ClientSideSessionSpec extends RatpackGroovyDslSpec {
     length << (1..256)
   }
 
-  @IgnoreRest
   @Unroll
   def "secretKey with #algorithm renders session unreadable"() {
     given:

--- a/ratpack-session/src/test/groovy/ratpack/session/clientside/ClientSideSessionSpec.groovy
+++ b/ratpack-session/src/test/groovy/ratpack/session/clientside/ClientSideSessionSpec.groovy
@@ -24,8 +24,6 @@ import ratpack.http.client.RequestSpec
 import ratpack.http.internal.HttpHeaderConstants
 import ratpack.session.store.SessionStorage
 import ratpack.test.internal.RatpackGroovyDslSpec
-import spock.lang.Ignore
-import spock.lang.IgnoreRest
 import spock.lang.Unroll
 
 class ClientSideSessionSpec extends RatpackGroovyDslSpec {


### PR DESCRIPTION
#504 cookie-sessions longer than buffer size (specified for the given algorithm), encrypt and decrypt without runtime exception. Algorithms with NoPadding are supported too.

Supported algorithms:

* Blowfish
* AES/CBC/NoPadding
* AES/CBC/PKCS5Padding
* AES/ECB/NoPadding
* AES/ECB/PKCS5Padding
* DES/CBC/NoPadding
* DES/CBC/PKCS5Padding
* DES/ECB/NoPadding
* DES/ECB/PKCS5Padding
* DESede/CBC/NoPadding
* DESede/CBC/PKCS5Padding
* DESede/ECB/NoPadding
* DESede/ECB/PKCS5Padding