### PR TITLE
Add support for specifying Thymeleaf template fragments

### DIFF
--- a/ratpack-thymeleaf/src/main/java/ratpack/thymeleaf/Template.java
+++ b/ratpack-thymeleaf/src/main/java/ratpack/thymeleaf/Template.java
@@ -18,6 +18,8 @@ package ratpack.thymeleaf;
 
 import com.google.common.collect.ImmutableMap;
 import org.thymeleaf.context.Context;
+import org.thymeleaf.fragment.IFragmentSpec;
+import org.thymeleaf.fragment.WholeFragmentSpec;
 
 import java.util.Collections;
 import java.util.Map;
@@ -28,6 +30,7 @@ public class Template {
   private final String name;
   private final Context model;
   private final String contentType;
+  private final IFragmentSpec fragmentSpec;
 
   public String getName() {
     return name;
@@ -41,36 +44,62 @@ public class Template {
     return contentType;
   }
 
-  private Template(String name, Context model, String contentType) {
+  public IFragmentSpec getFragmentSpec() {
+    return fragmentSpec;
+  }
+
+  private Template(String name, Context model, String contentType, IFragmentSpec fragmentSpec) {
     this.name = name;
     this.model = model;
     this.contentType = contentType;
+    this.fragmentSpec = fragmentSpec;
   }
 
   public static Template thymeleafTemplate(String name) {
     return thymeleafTemplate(Collections.emptyMap(), name);
   }
 
-  public static Template thymeleafTemplate(String name, Consumer<? super ImmutableMap.Builder<String, Object>> modelBuilder) {
-    return thymeleafTemplate(name, null, modelBuilder);
+  public static Template thymeleafTemplate(String name, IFragmentSpec fragmentSpec) {
+    return thymeleafTemplate(Collections.emptyMap(), name, fragmentSpec);
   }
 
   public static Template thymeleafTemplate(Map<String, ?> model, String name) {
-    return thymeleafTemplate(model, name, null);
+    return thymeleafTemplate(model, name, (String) null);
+  }
+
+  public static Template thymeleafTemplate(Map<String, ?> model, String name, IFragmentSpec fragmentSpec) {
+    return thymeleafTemplate(model, name, null, fragmentSpec);
+  }
+
+  public static Template thymeleafTemplate(String name, Consumer<? super ImmutableMap.Builder<String, Object>> modelBuilder) {
+    return thymeleafTemplate(name, modelBuilder, WholeFragmentSpec.INSTANCE);
+  }
+
+  public static Template thymeleafTemplate(String name, Consumer<? super ImmutableMap.Builder<String, Object>> modelBuilder, IFragmentSpec fragmentSpec) {
+    return thymeleafTemplate(name, null, modelBuilder, fragmentSpec);
   }
 
   public static Template thymeleafTemplate(String name, String contentType, Consumer<? super ImmutableMap.Builder<String, Object>> modelBuilder) {
+    return thymeleafTemplate(name, contentType, modelBuilder, WholeFragmentSpec.INSTANCE);
+  }
+
+  public static Template thymeleafTemplate(String name, String contentType, Consumer<? super ImmutableMap.Builder<String, Object>> modelBuilder, IFragmentSpec fragmentSpec) {
     ImmutableMap.Builder<String, Object> builder = ImmutableMap.builder();
     modelBuilder.accept(builder);
-    return thymeleafTemplate(builder.build(), name, contentType);
+    return thymeleafTemplate(builder.build(), name, contentType, fragmentSpec);
   }
 
   public static Template thymeleafTemplate(Map<String, ?> model, String name, String contentType) {
+    return thymeleafTemplate(model, name, contentType, WholeFragmentSpec.INSTANCE);
+  }
+
+
+  public static Template thymeleafTemplate(Map<String, ?> model, String name, String contentType, IFragmentSpec fragmentSpec) {
     Context context = new Context();
     if (model != null) {
       context.setVariables(model);
     }
 
-    return new Template(name, context, contentType);
+    return new Template(name, context, contentType, fragmentSpec);
   }
 }

--- a/ratpack-thymeleaf/src/main/java/ratpack/thymeleaf/internal/ThymeleafTemplateRenderer.java
+++ b/ratpack-thymeleaf/src/main/java/ratpack/thymeleaf/internal/ThymeleafTemplateRenderer.java
@@ -37,7 +37,7 @@ public class ThymeleafTemplateRenderer extends RendererSupport<Template> {
     String contentType = template.getContentType();
     contentType = contentType == null ? "text/html" : contentType;
     try {
-      context.getResponse().send(contentType, thymeleaf.process(template.getName(), template.getModel()));
+      context.getResponse().send(contentType, thymeleaf.process(template.getName(), template.getModel(), template.getFragmentSpec()));
     } catch (Exception e) {
       context.error(e);
     }

--- a/ratpack-thymeleaf/src/test/groovy/ratpack/thymeleaf/ThymeleafTemplateSpec.groovy
+++ b/ratpack-thymeleaf/src/test/groovy/ratpack/thymeleaf/ThymeleafTemplateSpec.groovy
@@ -18,6 +18,7 @@ package ratpack.thymeleaf
 
 import org.thymeleaf.TemplateEngine
 import org.thymeleaf.cache.StandardCacheManager
+import org.thymeleaf.fragment.DOMSelectorFragmentSpec
 import ratpack.test.internal.RatpackGroovyDslSpec
 import spock.lang.Unroll
 
@@ -299,5 +300,29 @@ class ThymeleafTemplateSpec extends RatpackGroovyDslSpec {
 
     then:
     text == '<p>Hello, World!</p>'
+  }
+
+  void 'can select a template fragment'() {
+    given:
+    file 'thymeleaf/with-fragment.html', '''
+      <html>
+        <head><title>Whatever</title></head>
+        <body>Just show me this bit</body>
+      </html>'''
+
+    when:
+    bindings {
+      add new ThymeleafModule()
+    }
+
+    handlers {
+      handler {
+        render thymeleafTemplate('with-fragment', new DOMSelectorFragmentSpec('body'))
+      }
+    }
+
+    then:
+    text == '<body>Just show me this bit</body>'
+
   }
 }


### PR DESCRIPTION
As discussed in #619, this adds overloads to ``Template.thymeleafTemplate()`` allowing a fragment spec to be passed, supporting e.g. partial HTML returned to an XHR call.