### PR TITLE
Update 02-quick-start.md

### DIFF
--- a/ratpack-manual/src/content/chapters/02-quick-start.md
+++ b/ratpack-manual/src/content/chapters/02-quick-start.md
@@ -32,7 +32,7 @@ buildscript {
 }
 
 apply plugin: "io.ratpack.ratpack-java"
-apply plugin: "org.gradle.idea"
+apply plugin: "idea"
 
 repositories {
   jcenter()


### PR DESCRIPTION
Using 

apply plugin: "org.gradle.idea" 

results in the following error:

Error:(11, 0) Plugin with id 'org.gradle.idea' not found.

Changing it to 

apply plugin: "idea" 

resolves that.