### PR TITLE
Add Spring Boot native support via @EnableRatpack

### DIFF
--- a/ratpack-spring-boot/ratpack-spring-boot.gradle
+++ b/ratpack-spring-boot/ratpack-spring-boot.gradle
@@ -25,5 +25,10 @@ ext.apiLinks = [
 
 dependencies {
   compile project(":ratpack-core")
-  compile "org.springframework.boot:spring-boot-autoconfigure:1.1.6.RELEASE"
+  compile project(":ratpack-guice")
+  compile "org.springframework.boot:spring-boot-autoconfigure:1.2.4.RELEASE"
+  testCompile "org.springframework:spring-web:4.1.6.RELEASE"
+  testCompile "org.springframework:spring-test:4.1.6.RELEASE"
+  testCompile project(":ratpack-jackson")
+  testCompile project(":ratpack-groovy")
 }

--- a/ratpack-spring-boot/src/main/java/ratpack/spring/config/EnableRatpack.java
+++ b/ratpack-spring-boot/src/main/java/ratpack/spring/config/EnableRatpack.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2012-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.spring.config;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.context.annotation.Import;
+
+/**
+ * @author Dave Syer
+ *
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Import(RatpackConfiguration.class)
+public @interface EnableRatpack {
+
+}

--- a/ratpack-spring-boot/src/main/java/ratpack/spring/config/RatpackConfiguration.java
+++ b/ratpack-spring-boot/src/main/java/ratpack/spring/config/RatpackConfiguration.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2012-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.spring.config;
+
+import java.util.Collections;
+import java.util.List;
+
+import javax.annotation.PreDestroy;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+import com.google.inject.Module;
+
+import ratpack.func.Function;
+import ratpack.guice.Guice;
+import ratpack.registry.Registry;
+import ratpack.server.RatpackServer;
+import ratpack.server.ServerConfig;
+import ratpack.spring.Spring;
+import ratpack.spring.config.internal.ChainConfigurers;
+
+/**
+ * @author Dave Syer
+ *
+ */
+@Configuration
+@Import(ChainConfigurers.class)
+@EnableConfigurationProperties(RatpackProperties.class)
+public class RatpackConfiguration implements CommandLineRunner {
+
+  @Autowired
+  private RatpackServer server;
+
+  @Override
+  public void run(String... args) throws Exception {
+    server.start();
+  }
+
+  @PreDestroy
+  public void stop() throws Exception {
+    server.stop();
+  }
+
+  @Configuration
+  protected static class ServerConfigConfiguration {
+
+    @Autowired
+    private RatpackProperties ratpack;
+
+    @Autowired(required = false)
+    private List<RatpackServerCustomizer> customizers = Collections.emptyList();
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ServerConfig ratpackServerConfig() throws Exception {
+      ServerConfig.Builder serverConfigBuilder = ServerConfig.baseDir(ratpack.getBasepath())
+          .address(ratpack.getAddress()).threads(ratpack.getMaxThreads());
+
+      if (ratpack.getPort() != null) {
+        serverConfigBuilder.port(ratpack.getPort());
+      }
+
+      for (RatpackServerCustomizer customizer : customizers) {
+        customizer.getServerConfig().execute(serverConfigBuilder);
+      }
+
+      return serverConfigBuilder.build();
+    }
+
+  }
+
+  @Configuration
+  protected static class ServerConfiguration {
+
+    @Autowired
+    private ServerConfig serverConfig;
+
+    @Autowired
+    private ChainConfigurers chainConfigurers;
+
+    @Autowired(required = false)
+    private List<RatpackServerCustomizer> customizers = Collections.emptyList();
+
+    @Bean
+    public RatpackServer ratpackServer(ApplicationContext context) throws Exception {
+      return RatpackServer.of(ratpackServerSpec -> ratpackServerSpec.serverConfig(serverConfig)
+          .registry(joinedRegistry(context)).handlers(chainConfigurers));
+    }
+
+    private Function<Registry, Registry> joinedRegistry(ApplicationContext context) throws Exception {
+      return baseRegistry -> Spring.spring(context).join(Guice.registry(bindingSpec -> {
+        context.getBeansOfType(Module.class).values().forEach(bindingSpec::module);
+        for (RatpackServerCustomizer customizer : customizers) {
+          customizer.getBindings().execute(bindingSpec);
+        }
+      }).apply(baseRegistry));
+    }
+
+  }
+
+}

--- a/ratpack-spring-boot/src/main/java/ratpack/spring/config/RatpackProperties.java
+++ b/ratpack-spring-boot/src/main/java/ratpack/spring/config/RatpackProperties.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2012-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.spring.config;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.Objects;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+import org.springframework.util.StringUtils;
+import org.springframework.validation.Errors;
+import org.springframework.validation.Validator;
+
+import ratpack.server.ServerConfig;
+
+/**
+ * @author Dave Syer
+ * 
+ */
+@ConfigurationProperties(prefix = "ratpack", ignoreUnknownFields = false)
+public class RatpackProperties implements Validator {
+
+  @Value("#{environment.getProperty('server.port')}")
+  private Integer port;
+
+  private InetAddress address;
+
+  private Integer sessionTimeout;
+
+  private Resource basedir = initBaseDir();
+
+  private String contextPath = "";
+
+  private int maxThreads = ServerConfig.DEFAULT_THREADS; // Number of threads in protocol handler
+
+  private String templatesPath = "templates";
+  private int cacheSize = 100;
+  private boolean development;
+  private boolean staticallyCompile;
+
+  @Override
+  public boolean supports(Class<?> clazz) {
+    return clazz.isAssignableFrom(RatpackProperties.class);
+  }
+
+  @Override
+  public void validate(Object target, Errors errors) {
+    RatpackProperties ratpack = (RatpackProperties) target;
+    if (ratpack.contextPath == null) {
+      errors.rejectValue("contextPath", "context.path.null", "Context path cannot be null");
+    }
+  }
+
+  public String getTemplatesPath() {
+    return templatesPath;
+  }
+
+  public void setTemplatesPath(String templatesPath) {
+    this.templatesPath = templatesPath;
+  }
+
+  public int getCacheSize() {
+    return cacheSize;
+  }
+
+  public void setCacheSize(int cacheSize) {
+    this.cacheSize = cacheSize;
+  }
+
+  public boolean isDevelopment() {
+    return development;
+  }
+
+  public void setDevelopment(boolean development) {
+    this.development = development;
+  }
+
+  public boolean isStaticallyCompile() {
+    return staticallyCompile;
+  }
+
+  public void setStaticallyCompile(boolean staticallyCompile) {
+    this.staticallyCompile = staticallyCompile;
+  }
+
+  public int getMaxThreads() {
+    return this.maxThreads;
+  }
+
+  public void setMaxThreads(int maxThreads) {
+    this.maxThreads = maxThreads;
+  }
+
+  public Path getBasepath() {
+    try {
+      return resourceToPath(this.basedir.getURL());
+    } catch (IOException e) {
+      throw new IllegalStateException("Cannot extract base dir URL", e);
+    }
+  }
+
+  public Resource getBasedir() {
+    return this.basedir;
+  }
+
+  public void setBasedir(Resource basedir) {
+    this.basedir = basedir;
+  }
+
+  public String getContextPath() {
+    return this.contextPath;
+  }
+
+  public void setContextPath(String contextPath) {
+    this.contextPath = contextPath;
+  }
+
+  public Integer getPort() {
+    return this.port;
+  }
+
+  public void setPort(Integer port) {
+    this.port = port;
+  }
+
+  public InetAddress getAddress() {
+    return this.address;
+  }
+
+  public void setAddress(InetAddress address) {
+    this.address = address;
+  }
+
+  public Integer getSessionTimeout() {
+    return this.sessionTimeout;
+  }
+
+  public void setSessionTimeout(Integer sessionTimeout) {
+    this.sessionTimeout = sessionTimeout;
+  }
+
+  static Path resourceToPath(URL resource) {
+
+    Objects.requireNonNull(resource, "Resource URL cannot be null");
+    URI uri;
+    try {
+      uri = resource.toURI();
+    } catch (URISyntaxException e) {
+      throw new IllegalArgumentException("Could not extract URI", e);
+    }
+
+    String scheme = uri.getScheme();
+    if (scheme.equals("file")) {
+      String path = uri.toString().substring("file:".length());
+      if (path.contains("//")) {
+        path = StringUtils.cleanPath(path.replace("//", ""));
+      }
+      return Paths.get(new FileSystemResource(path).getFile().toURI());
+    }
+
+    if (!scheme.equals("jar")) {
+      throw new IllegalArgumentException("Cannot convert to Path: " + uri);
+    }
+
+    String s = uri.toString();
+    int separator = s.indexOf("!/");
+    String entryName = s.substring(separator + 2);
+    URI fileURI = URI.create(s.substring(0, separator));
+
+    FileSystem fs;
+    try {
+      fs = FileSystems.newFileSystem(fileURI, Collections.<String, Object>emptyMap());
+      return fs.getPath(entryName);
+    } catch (IOException e) {
+      throw new IllegalArgumentException("Could not create file system for resource: " + resource, e);
+    }
+  }
+
+  static Resource initBaseDir() {
+    ClassPathResource classPath = new ClassPathResource("");
+    try {
+      if (classPath.getURL().toString().startsWith("jar:")) {
+        return classPath;
+      }
+    } catch (IOException e) {
+      // Ignore
+    }
+    FileSystemResource resources = new FileSystemResource("src/main/resources");
+    if (resources.exists()) {
+      return resources;
+    }
+    return new FileSystemResource(".");
+  }
+
+}

--- a/ratpack-spring-boot/src/main/java/ratpack/spring/config/RatpackServerCustomizer.java
+++ b/ratpack-spring-boot/src/main/java/ratpack/spring/config/RatpackServerCustomizer.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2014-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.spring.config;
+
+import java.util.List;
+
+import ratpack.func.Action;
+import ratpack.guice.BindingsSpec;
+import ratpack.handling.Chain;
+import ratpack.server.ServerConfig.Builder;
+
+/**
+ * @author Dave Syer
+ *
+ */
+public interface RatpackServerCustomizer {
+
+  List<Action<Chain>> getHandlers();
+
+  Action<BindingsSpec> getBindings();
+
+  Action<Builder> getServerConfig();
+
+}

--- a/ratpack-spring-boot/src/main/java/ratpack/spring/config/RatpackServerCustomizerAdapter.java
+++ b/ratpack-spring-boot/src/main/java/ratpack/spring/config/RatpackServerCustomizerAdapter.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.spring.config;
+
+import java.util.Collections;
+import java.util.List;
+
+import ratpack.func.Action;
+import ratpack.guice.BindingsSpec;
+import ratpack.handling.Chain;
+import ratpack.server.ServerConfig.Builder;
+
+/**
+ * @author Dave Syer
+ *
+ */
+public class RatpackServerCustomizerAdapter implements RatpackServerCustomizer {
+
+  @Override
+  public List<Action<Chain>> getHandlers() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public Action<BindingsSpec> getBindings() {
+    return spec -> {
+    };
+  }
+
+  @Override
+  public Action<Builder> getServerConfig() {
+    return server -> {
+    };
+  }
+
+}

--- a/ratpack-spring-boot/src/main/java/ratpack/spring/config/internal/ChainConfigurers.java
+++ b/ratpack-spring-boot/src/main/java/ratpack/spring/config/internal/ChainConfigurers.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2012-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.spring.config.internal;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.annotation.AnnotationAwareOrderComparator;
+import org.springframework.stereotype.Component;
+
+import com.google.common.collect.ImmutableMap;
+
+import ratpack.func.Action;
+import ratpack.handling.Chain;
+import ratpack.handling.Handler;
+import ratpack.handling.Handlers;
+import ratpack.path.PathBinder;
+import ratpack.path.PathBinding;
+import ratpack.path.internal.DefaultPathBinding;
+import ratpack.server.ServerConfig;
+import ratpack.spring.config.RatpackServerCustomizer;
+
+/**
+ * @author Dave Syer
+ *
+ */
+@Component
+public class ChainConfigurers implements Action<Chain> {
+
+  @Autowired(required = false)
+  private List<Action<Chain>> delegates = Collections.emptyList();
+
+  @Autowired(required = false)
+  private List<Handler> handlers = Collections.emptyList();
+
+  @Autowired(required = false)
+  private List<RatpackServerCustomizer> customizers = Collections.emptyList();
+
+  @Override
+  public void execute(Chain chain) throws Exception {
+    List<Action<Chain>> delegates = new ArrayList<Action<Chain>>(this.delegates);
+    for (RatpackServerCustomizer customizer : customizers) {
+      delegates.addAll(customizer.getHandlers());
+    }
+    if (handlers.size() == 1 || delegates.isEmpty()) {
+      delegates.add(singleHandlerAction());
+    }
+    delegates.add(staticResourcesAction(chain.getServerConfig()));
+    AnnotationAwareOrderComparator.sort(delegates);
+    for (Action<Chain> delegate : delegates) {
+      if (!(delegate instanceof ChainConfigurers)) {
+        delegate.execute(chain);
+      }
+    }
+  }
+
+  private Action<Chain> staticResourcesAction(final ServerConfig config) {
+    return chain -> {
+      chain.all(Handlers.path(new RootBinder(), Handlers.assets(config, "static", Arrays.asList("index.html"))));
+      chain.all(Handlers.path(new RootBinder(), Handlers.assets(config, "public", Arrays.asList("index.html"))));
+    };
+  }
+
+  protected static class RootBinder implements PathBinder {
+
+    @Override
+    public Optional<PathBinding> bind(String path, Optional<PathBinding> parentBinding) {
+      return Optional.of(new DefaultPathBinding("/" + path, "", ImmutableMap.<String, String>of(), parentBinding));
+    }
+  }
+
+  private Action<Chain> singleHandlerAction() {
+    return chain -> {
+      if (handlers.size() == 1) {
+        chain.get(handlers.get(0));
+      }
+    };
+  }
+
+}

--- a/ratpack-spring-boot/src/test/groovy/ratpack/spring/ApplicationTests.java
+++ b/ratpack-spring-boot/src/test/groovy/ratpack/spring/ApplicationTests.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ratpack.spring;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static ratpack.jackson.Jackson.json;
+
+import java.util.Collections;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.IntegrationTest;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.TestRestTemplate;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import ratpack.func.Action;
+import ratpack.handling.Chain;
+import ratpack.jackson.JacksonModule;
+import ratpack.server.RatpackServer;
+import ratpack.spring.ApplicationTests.Application;
+import ratpack.spring.config.EnableRatpack;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = Application.class)
+@IntegrationTest({ "debug=true", "server.port=0" })
+public class ApplicationTests {
+
+  private TestRestTemplate restTemplate = new TestRestTemplate();
+
+  @Autowired
+  private RatpackServer server;
+
+  @Test
+  public void homePage() {
+    assertEquals(
+        "{" + System.getProperty("line.separator") + "  \"message\" : \"Hello World\""
+            + System.getProperty("line.separator") + "}",
+        restTemplate.getForObject("http://localhost:" + server.getBindPort(), String.class));
+  }
+
+  @Test
+  public void notFound() {
+    ResponseEntity<String> response = restTemplate.getForEntity("http://localhost:" + server.getBindPort() + "/none",
+        String.class);
+    assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+    assertNull("Default 404 handler has null body", response.getBody());
+  }
+
+  @Configuration
+  @EnableAutoConfiguration
+  @EnableRatpack
+  @Import(MessageService.class)
+  protected static class Application {
+
+    @Autowired
+    private MessageService service;
+
+    @Bean
+    public Action<Chain> handler() {
+      return chain -> chain.get(context -> {
+        // We're not using the registry here directly but it's good to
+        // confirm that it contains our service:
+        assertNotNull(context.get(MessageService.class));
+        context.render(json(Collections.singletonMap("message", service.message())));
+      });
+    }
+
+    @Bean
+    public JacksonModule jacksonGuiceModule() {
+      JacksonModule module = new JacksonModule();
+      module.configure(config -> {
+        config.prettyPrint(true);
+      });
+      return module;
+    }
+
+    public static void main(String[] args) throws Exception {
+      SpringApplication.run(Application.class, args);
+    }
+
+  }
+
+  @Service
+  protected static class MessageService {
+
+    public String message() {
+      return "Hello World";
+    }
+
+  }
+
+}

--- a/ratpack-spring-boot/src/test/groovy/ratpack/spring/DefaultStaticResourceTests.java
+++ b/ratpack-spring-boot/src/test/groovy/ratpack/spring/DefaultStaticResourceTests.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ratpack.spring;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.IntegrationTest;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.TestRestTemplate;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import ratpack.server.RatpackServer;
+import ratpack.spring.DefaultStaticResourceTests.Application;
+import ratpack.spring.config.EnableRatpack;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = Application.class)
+@IntegrationTest("server.port=0")
+public class DefaultStaticResourceTests {
+
+  private TestRestTemplate restTemplate = new TestRestTemplate();
+
+  @Autowired
+  private RatpackServer server;
+
+  @Test
+  public void contextLoads() {
+    ResponseEntity<String> result = restTemplate.getForEntity("http://localhost:" + server.getBindPort() + "/main.css",
+        String.class);
+    assertEquals(HttpStatus.OK, result.getStatusCode());
+    assertTrue("Wrong body" + result.getBody(), result.getBody().contains("background: red;"));
+  }
+
+  @Configuration
+  @EnableRatpack
+  @EnableAutoConfiguration
+  protected static class Application {
+    public static void main(String[] args) throws Exception {
+      SpringApplication.run(Application.class, args);
+    }
+  }
+
+}

--- a/ratpack-spring-boot/src/test/groovy/ratpack/spring/JsonTests.java
+++ b/ratpack-spring-boot/src/test/groovy/ratpack/spring/JsonTests.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ratpack.spring;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static ratpack.jackson.Jackson.fromJson;
+import static ratpack.jackson.Jackson.json;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.IntegrationTest;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.TestRestTemplate;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import ratpack.func.Action;
+import ratpack.handling.Chain;
+import ratpack.handling.Handler;
+import ratpack.jackson.JacksonModule;
+import ratpack.server.RatpackServer;
+import ratpack.spring.JsonTests.Application;
+import ratpack.spring.config.EnableRatpack;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = Application.class)
+@IntegrationTest("server.port=0")
+public class JsonTests {
+
+  private TestRestTemplate restTemplate = new TestRestTemplate();
+
+  @Autowired
+  private RatpackServer server;
+
+  @Test
+  public void get() {
+    String body = restTemplate.getForObject("http://localhost:" + server.getBindPort(), String.class);
+    assertTrue("Wrong body" + body, body.contains("{"));
+    assertFalse("Wrong body" + body, body.toLowerCase().contains("<html"));
+  }
+
+  @Test
+  public void post() {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    HttpEntity<Map<String, String>> entity = new HttpEntity<Map<String, String>>(Collections.singletonMap("foo", "bar"),
+        headers);
+    ResponseEntity<String> result = restTemplate.postForEntity("http://localhost:" + server.getBindPort(), entity,
+        String.class);
+    assertEquals(HttpStatus.OK, result.getStatusCode());
+    String body = restTemplate.getForObject("http://localhost:" + server.getBindPort(), String.class);
+    assertTrue("Wrong body" + body, body.contains("foo"));
+  }
+
+  @Configuration
+  @EnableRatpack
+  @EnableAutoConfiguration
+  protected static class Application {
+
+    private Map<String, Object> map = new LinkedHashMap<String, Object>();
+
+    @Bean
+    public Action<Chain> chain() {
+      return chain -> chain.all(handler());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Bean
+    public Handler handler() {
+      // @formatter:off
+      return context -> context.byMethod(spec -> spec.get(() -> context.render(json(map))).post(() -> {
+        map.putAll(context.parse(fromJson(Map.class)));
+        context.render(json(map));
+      }));
+      // @formatter:on
+    }
+
+    @Bean
+    public JacksonModule jacksonGuiceModule() {
+      return new JacksonModule();
+    }
+
+    public static void main(String[] args) throws Exception {
+      SpringApplication.run(Application.class, args);
+    }
+
+  }
+
+}

--- a/ratpack-spring-boot/src/test/groovy/ratpack/spring/MarkupTests.java
+++ b/ratpack-spring-boot/src/test/groovy/ratpack/spring/MarkupTests.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ratpack.spring;
+
+import static org.junit.Assert.assertTrue;
+import static ratpack.groovy.Groovy.groovyMarkupTemplate;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.IntegrationTest;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.TestRestTemplate;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import ratpack.groovy.template.MarkupTemplateModule;
+import ratpack.handling.Context;
+import ratpack.handling.Handler;
+import ratpack.server.RatpackServer;
+import ratpack.spring.MarkupTests.Application;
+import ratpack.spring.config.EnableRatpack;
+import ratpack.spring.config.RatpackProperties;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = Application.class)
+@IntegrationTest("server.port=0")
+public class MarkupTests {
+
+  private TestRestTemplate restTemplate = new TestRestTemplate();
+
+  @Autowired
+  private RatpackServer server;
+
+  @Test
+  public void contextLoads() {
+    String body = restTemplate.getForObject("http://localhost:" + server.getBindPort(), String.class);
+    assertTrue("Wrong body" + body, body.contains("<body>Home"));
+  }
+
+  @Configuration
+  @EnableRatpack
+  @EnableAutoConfiguration
+  protected static class Application {
+
+    @Bean
+    public Handler handler() {
+      return new Handler() {
+        @Override
+        public void handle(Context context) throws Exception {
+          context.render(groovyMarkupTemplate("markup.html"));
+        }
+      };
+    }
+
+    @Bean
+    public MarkupTemplateModule markupTemplateGuiceModule(RatpackProperties ratpack) {
+      MarkupTemplateModule module = new MarkupTemplateModule();
+      module.configure(config -> {
+        config.setTemplatesDirectory(ratpack.getTemplatesPath());
+      });
+      return module;
+    }
+
+    public static void main(String[] args) throws Exception {
+      SpringApplication.run(Application.class, args);
+    }
+
+  }
+
+}

--- a/ratpack-spring-boot/src/test/groovy/ratpack/spring/StaticResourceTests.java
+++ b/ratpack-spring-boot/src/test/groovy/ratpack/spring/StaticResourceTests.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ratpack.spring;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.IntegrationTest;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.TestRestTemplate;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import ratpack.func.Action;
+import ratpack.handling.Chain;
+import ratpack.server.RatpackServer;
+import ratpack.spring.StaticResourceTests.Application;
+import ratpack.spring.config.EnableRatpack;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = Application.class)
+@IntegrationTest("server.port=0")
+public class StaticResourceTests {
+
+  private TestRestTemplate restTemplate = new TestRestTemplate();
+
+  @Autowired
+  private RatpackServer server;
+
+  @Test
+  public void contextLoads() {
+    String body = restTemplate.getForObject("http://localhost:" + server.getBindPort() + "/root/main.css",
+        String.class);
+    assertTrue("Wrong body" + body, body.contains("background"));
+  }
+
+  @Configuration
+  @EnableRatpack
+  @EnableAutoConfiguration
+  protected static class Application {
+
+    @Bean
+    public Action<Chain> handlers() {
+      return new Action<Chain>() {
+        @Override
+        public void execute(Chain chain) throws Exception {
+          chain.prefix("root", new Action<Chain>() {
+            @Override
+            public void execute(Chain chain) throws Exception {
+              chain.assets("root", "index.html");
+            }
+          });
+        }
+      };
+    }
+
+    public static void main(String[] args) throws Exception {
+      SpringApplication.run(Application.class, args);
+    }
+
+  }
+
+}

--- a/ratpack-spring-boot/src/test/groovy/ratpack/spring/TemplateTests.java
+++ b/ratpack-spring-boot/src/test/groovy/ratpack/spring/TemplateTests.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ratpack.spring;
+
+import static org.junit.Assert.assertTrue;
+import static ratpack.groovy.Groovy.groovyTemplate;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.IntegrationTest;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.boot.test.TestRestTemplate;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import ratpack.groovy.template.TextTemplateModule;
+import ratpack.handling.Context;
+import ratpack.handling.Handler;
+import ratpack.server.RatpackServer;
+import ratpack.spring.TemplateTests.Application;
+import ratpack.spring.config.EnableRatpack;
+import ratpack.spring.config.RatpackProperties;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = Application.class)
+@IntegrationTest("server.port=0")
+public class TemplateTests {
+
+  private TestRestTemplate restTemplate = new TestRestTemplate();
+
+  @Autowired
+  private RatpackServer server;
+
+  @Test
+  public void contextLoads() {
+    String body = restTemplate.getForObject("http://localhost:" + server.getBindPort(), String.class);
+    assertTrue("Wrong body" + body, body.contains("<body>Home"));
+  }
+
+  @Configuration
+  @EnableRatpack
+  @EnableAutoConfiguration
+  protected static class Application {
+
+    @Bean
+    public Handler handler() {
+      return new Handler() {
+        @Override
+        public void handle(Context context) throws Exception {
+          context.render(groovyTemplate("index.html"));
+        }
+      };
+    }
+
+    @Bean
+    public TextTemplateModule textTemplateGuiceModule(RatpackProperties ratpack) {
+      TextTemplateModule module = new TextTemplateModule();
+      module.configure(config -> {
+        config.setTemplatesPath(ratpack.getTemplatesPath());
+        config.setStaticallyCompile(ratpack.isStaticallyCompile());
+      });
+      return module;
+    }
+
+    public static void main(String[] args) throws Exception {
+      SpringApplication.run(Application.class, args);
+    }
+
+  }
+
+}

--- a/ratpack-spring-boot/src/test/resources/application.properties
+++ b/ratpack-spring-boot/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+ratpack.basedir: file://./src/test/resources

--- a/ratpack-spring-boot/src/test/resources/root/main.css
+++ b/ratpack-spring-boot/src/test/resources/root/main.css
@@ -1,0 +1,1 @@
+body { background: red; }

--- a/ratpack-spring-boot/src/test/resources/static/main.css
+++ b/ratpack-spring-boot/src/test/resources/static/main.css
@@ -1,0 +1,1 @@
+body { background: red; }

--- a/ratpack-spring-boot/src/test/resources/templates/index.html
+++ b/ratpack-spring-boot/src/test/resources/templates/index.html
@@ -1,0 +1,6 @@
+<html>
+  <head>
+    <title>${model.title}</title>
+  </head>
+<body>Home page</body>
+</html>

--- a/ratpack-spring-boot/src/test/resources/templates/markup.html
+++ b/ratpack-spring-boot/src/test/resources/templates/markup.html
@@ -1,0 +1,6 @@
+html {
+  head {
+    title(title)
+  }
+  body { yield 'Home page' }
+}


### PR DESCRIPTION
User can now (optionally) embed Ratpack as a server in a Spring
Boot application natively (as opposed to the other way round
which was already provided by Spring.spring()). Adding
@EnableRatpack should be enough to get it working with static
resources in classpath:static/ or classpath:/public (just like
in other Spring Boot servers). To use existing Ratpack guice modules
just add beans of type Module, e.g. for JSON add a @Bean of type
JacksonModule, etc.

Most of the features of dsyer/spring-boot-ratpack are here, except the
autoconfiguration (Jackson and Groovy templates) and the Groovy DSL
for Spring Boot CLI.