### PR TITLE
Fixing sass generation and updating ratpack-asset-pipeline dependency …

### DIFF
--- a/ratpack-site/ratpack-site.gradle
+++ b/ratpack-site/ratpack-site.gradle
@@ -25,7 +25,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.bertramlabs.plugins:asset-pipeline-gradle:2.3.0'
+    classpath 'com.bertramlabs.plugins:asset-pipeline-gradle:2.3.4'
     classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.1'
     classpath 'com.bertramlabs.plugins:sass-asset-pipeline:2.3.0'
   }
@@ -63,7 +63,8 @@ configurations {
   newrelicAgent {}
   browserTestCompile.extendsFrom testCompile
   browserTestRuntime.extendsFrom testRuntime
-
+  providedRuntime
+  runtime.extendsFrom providedRuntime
   manualVersions.each {
     delegate."manual-$it"
   }
@@ -91,8 +92,8 @@ dependencies {
   compile project(":ratpack-newrelic")
   compile "org.pegdown:pegdown:${commonVersions.pegdown}"
 
-  compile 'com.bertramlabs.plugins:ratpack-asset-pipeline:2.3.1'
-  runtime 'com.bertramlabs.plugins:sass-asset-pipeline:2.3.0'
+  compile 'com.bertramlabs.plugins:ratpack-asset-pipeline:2.3.4'
+  providedRuntime 'com.bertramlabs.plugins:sass-asset-pipeline:2.3.0'
   
 
   runtime "org.apache.logging.log4j:log4j-slf4j-impl:${commonVersions.log4j}"

--- a/ratpack-site/src/assets/stylesheets/config.rb
+++ b/ratpack-site/src/assets/stylesheets/config.rb
@@ -1,5 +1,8 @@
-images_path = "src/assets/images"
-fonts_path = "src/assets/stylesheets/fonts"
+require 'java'
+
+asset_pipe_path = Java::AssetPipeline::AssetPipelineConfigHolder.getResolvers()[0].getBaseDirectory().getCanonicalPath()
+images_path = "#{asset_pipe_path}/images"
+fonts_path = "#{asset_pipe_path}/stylesheets/fonts"
 
 relative_assets = false
 # http_path = "/"


### PR DESCRIPTION
…so tests pass and heroku works

This does not fix the delayed startup of development mode sass but does fix sass generation (in theory) for the heroku build process. It also adjusts the `ratpack-asset-pipeline` adapter to properly get the location of assets in test mode. I also moved `sass-asset-pipeline` to a providedRuntime dependency so it does not bundle jruby into the final distribution jar.