### PR TITLE
View support in JsonRender(er).

### DIFF
--- a/ratpack-core/src/main/java/ratpack/jackson/Jackson.java
+++ b/ratpack-core/src/main/java/ratpack/jackson/Jackson.java
@@ -288,7 +288,7 @@ public abstract class Jackson {
    * @return a renderable wrapper for the given object
    */
   public static JsonRender json(Object object) {
-    return new DefaultJsonRender(object, null);
+    return new DefaultJsonRender(object, null, null);
   }
 
   /**
@@ -305,6 +305,42 @@ public abstract class Jackson {
    */
   public static JsonRender json(Object object, @Nullable ObjectWriter objectWriter) {
     return new DefaultJsonRender(object, objectWriter);
+  }
+
+  /**
+   * Creates a {@link ratpack.handling.Context#render renderable object} to render the given object as JSON.
+   * <p>
+   * The given object will be converted to JSON using an {@link ObjectWriter} obtained from the context registry
+   * with the specified view {@code Class} used to determine which fields are included.
+   * If it is null the default view rendering of the {@link ObjectWriter} will be used.
+   * <p>
+   * See the <a href="#rendering">rendering</a> section for usage examples.
+   *
+   * @param object the object to render as JSON
+   * @param viewClass the view to use when rendering
+   * @return a renderable wrapper for the given object
+   */
+  public static JsonRender json(Object object, @Nullable Class<?> viewClass) {
+    return new DefaultJsonRender(object, viewClass);
+  }
+
+  /**
+   * Creates a {@link ratpack.handling.Context#render renderable object} to render the given object as JSON.
+   * <p>
+   * The given object will be converted to JSON using the given {@link ObjectWriter}
+   * with the specified view {@code Class} used to determine which fields are included.
+   * If the {@link ObjectWriter} is {@code null}, an {@code ObjectWriter} will be obtained from the context registry.
+   * If the view {@code Class} is null the default view rendering of the {@link ObjectWriter} will be used.
+   * <p>
+   * See the <a href="#rendering">rendering</a> section for usage examples.
+   *
+   * @param object the object to render as JSON
+   * @param objectWriter the object writer to use to serialize the object to JSON
+   * @param viewClass the view to use when rendering
+   * @return a renderable wrapper for the given object
+   */
+  public static JsonRender json(Object object, @Nullable ObjectWriter objectWriter, @Nullable Class<?> viewClass) {
+    return new DefaultJsonRender(object, objectWriter, viewClass);
   }
 
   /**

--- a/ratpack-core/src/main/java/ratpack/jackson/JsonRender.java
+++ b/ratpack-core/src/main/java/ratpack/jackson/JsonRender.java
@@ -43,4 +43,14 @@ public interface JsonRender {
   @Nullable
   public ObjectWriter getObjectWriter();
 
+  /**
+   * The view class to use when rendering the object.
+   * <p>
+   * If null, no specific view will be used.
+   *
+   * @return The view class to be used.
+   */
+  @Nullable
+  public Class<?> getViewClass();
+
 }

--- a/ratpack-core/src/main/java/ratpack/jackson/internal/DefaultJsonRender.java
+++ b/ratpack-core/src/main/java/ratpack/jackson/internal/DefaultJsonRender.java
@@ -24,10 +24,20 @@ public class DefaultJsonRender implements JsonRender {
 
   private final Object object;
   private final ObjectWriter objectWriter;
+  private final Class<?> viewClass;
 
   public DefaultJsonRender(Object object, @Nullable ObjectWriter objectWriter) {
+    this(object, objectWriter, null);
+  }
+
+  public DefaultJsonRender(Object object, @Nullable Class<?> viewClass) {
+    this(object, null, viewClass);
+  }
+
+  public DefaultJsonRender(Object object, @Nullable ObjectWriter objectWriter, @Nullable Class<?> viewClass) {
     this.object = object;
     this.objectWriter = objectWriter;
+    this.viewClass = viewClass;
   }
 
   public Object getObject() {
@@ -36,5 +46,9 @@ public class DefaultJsonRender implements JsonRender {
 
   public ObjectWriter getObjectWriter() {
     return objectWriter;
+  }
+
+  public Class<?> getViewClass() {
+    return viewClass;
   }
 }

--- a/ratpack-core/src/main/java/ratpack/jackson/internal/JsonRenderer.java
+++ b/ratpack-core/src/main/java/ratpack/jackson/internal/JsonRenderer.java
@@ -42,6 +42,10 @@ public class JsonRenderer extends RendererSupport<JsonRender> {
     if (writer == null) {
       writer = defaultObjectWriter;
     }
+    Class<?> viewClass = object.getViewClass();
+    if(viewClass != null) {
+      writer = writer.withView(viewClass);
+    }
 
     ByteBuf buffer = context.get(ByteBufAllocator.class).buffer();
     OutputStream outputStream = new ByteBufOutputStream(buffer);

--- a/ratpack-core/src/test/groovy/ratpack/jackson/internal/JsonRendererSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/jackson/internal/JsonRendererSpec.groovy
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.jackson.internal
+import com.fasterxml.jackson.annotation.JsonView
+import com.fasterxml.jackson.databind.ObjectMapper
+import groovy.json.JsonSlurper
+import groovy.transform.Canonical
+import io.netty.buffer.ByteBuf
+import io.netty.buffer.ByteBufAllocator
+import io.netty.buffer.UnpooledByteBufAllocator
+import ratpack.handling.Context
+import ratpack.http.Response
+import spock.lang.Specification
+/**
+ * @author Raniz
+ */
+class JsonRendererSpec extends Specification {
+
+  static class Views {
+    static class Public {}
+    static class Secret extends Public {}
+  }
+
+  @Canonical
+  static class Model {
+    @JsonView(Views.Public)
+    String open
+    @JsonView(Views.Secret)
+    String secret
+  }
+
+  def objectMapper = new ObjectMapper()
+  def renderer = new JsonRenderer(objectMapper.writer())
+
+  Context context = Mock()
+  Response response = Mock()
+
+  def setup() {
+    context.get(ByteBufAllocator) >> new UnpooledByteBufAllocator(false)
+    context.getResponse() >> response
+    response.contentTypeIfNotSet((CharSequence)_) >> response
+  }
+
+  def json(ByteBuf json, Closure<?> closure) {
+    def object = new JsonSlurper().parse(json.array)
+    closure.call(object)
+    return true
+  }
+
+  def "no view renders all fields"() {
+    given: "an object to render"
+    def object = new Model("foo", "bar")
+
+    when: "the object is rendered without views"
+    renderer.render context, new DefaultJsonRender(object, null, null)
+
+    then: "all fields of the object are rendered"
+    1 * response.send({ buffer ->
+      json(buffer) {
+        assert it["open"] == "foo"
+        assert it["secret"] == "bar"
+      }
+    })
+  }
+
+  def "secret view renders all fields"() {
+    given: "an object to render"
+    def object = new Model("foo", "bar")
+
+    when: "the object is rendered with the secret view"
+    renderer.render context, new DefaultJsonRender(object, null, Views.Secret)
+
+    then: "all fields of the object are rendered"
+    1 * response.send({ buffer ->
+      json(buffer) {
+        assert it["open"] == "foo"
+        assert it["secret"] == "bar"
+      }
+    })
+  }
+
+  def "public view renders only public field"() {
+    given: "an object to render"
+    def object = new Model("foo", "bar")
+
+    when: "the object is rendered with the public view"
+    renderer.render context, new DefaultJsonRender(object, null, Views.Public)
+
+    then: "only public fields of the object are rendered"
+    1 * response.send({ buffer ->
+      json(buffer) {
+        assert it["open"] == "foo"
+        assert !("secret" in it)
+      }
+    })
+  }
+
+}


### PR DESCRIPTION
Added a viewClass property to JsonRender and implemented support for it
in JsonRenderer.

If the view class is non-null it will be used to create a new
ObjectWriter using that view from the supplied ObjectWriter (either
default or supplied in the JsonRender). If the view class is null
everything will work as before.

This fixes #733