### PR TITLE
Provide support for RFC2616 Content-Type media type parsing.

### DIFF
--- a/ratpack-core/src/main/java/ratpack/http/MediaType.java
+++ b/ratpack-core/src/main/java/ratpack/http/MediaType.java
@@ -16,9 +16,8 @@
 
 package ratpack.http;
 
+import com.google.common.collect.ImmutableListMultimap;
 import ratpack.api.Nullable;
-
-import java.util.Map;
 
 /**
  * A structured value for a Content-Type header value.
@@ -61,16 +60,16 @@ public interface MediaType {
   String getType();
 
   /**
-   * The parameters of the mime type.
+   * The multimap containing parameters of the mime type.
    * <p>
-   * Given a mime type of "application/json;charset=utf-8", returns {@code [charset: "utf-8"]}".
+   * Given a mime type of "application/json;charset=utf-8", the {@code get("charset")} returns {@code  ["utf-8"]}".
    * May be empty, never null.
    * <p>
-   * All param names have been lower cased.
+   * All param names have been lower cased. The {@code charset} parameter values has been lower cased too.
    *
-   * @return the media type params.
+   * @return the immutable multimap of the media type params.
    */
-  Map<String, String> getParams();
+  ImmutableListMultimap<String, String> getParams();
 
   /**
    * The value of the "charset" parameter.

--- a/ratpack-core/src/test/groovy/ratpack/http/DefaultMediaTypeSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/http/DefaultMediaTypeSpec.groovy
@@ -18,29 +18,65 @@ package ratpack.http
 
 import ratpack.http.internal.DefaultMediaType
 import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.nio.charset.Charset
 
 class DefaultMediaTypeSpec extends Specification {
 
   def "parsing"() {
     expect:
+    println "1:" + ct(" application/json ").type
     ct(" application/json ").type == "application/json"
     ct(" application/json ").params.isEmpty()
     ct(null).type == null
     ct(null).params.isEmpty()
     ct(" ").type == null
     ct(" ").params.isEmpty()
-    ct(" application/json;charset=foo ").params.charset == "foo"
-    ct(" application/json;charset ;foo=bar ").params == [charset: "", foo: "bar"]
+    ct(" application/json;charset=foo ").params.get("charset") == ["foo"]
+    with(ct(" application/json;charset=foo; bar=baz ").params) {
+      get("charset") == ["foo"]
+      get("bar") == ["baz"]
+    }
+    ct(" application/json;foo=bar; foo=baz ").params.get("foo") == ["bar", "baz"]
+  }
 
+  def "parsing illegal content type throws exception"() {
+    when:
+    ct(" application/json;charset ;foo=bar ")
+
+    then:
+    thrown IllegalArgumentException
+
+    when:
+    ct(" application/json;charset=foo ; bar=baz ")
+
+    then:
+    thrown IllegalArgumentException
   }
 
   def "to string"() {
     expect:
     cts("") == ""
     cts("  application/json   ") == "application/json"
-    cts("application/json;foo=bar") == "application/json;foo=bar"
-    cts("application/json;foo") == "application/json;foo"
-    cts("application/json;a=1 ; b=2") == "application/json;a=1;b=2"
+    cts("application/json;foo=bar") == "application/json; foo=bar"
+    cts("application/json;a=1; b=2") == "application/json; a=1; b=2"
+  }
+
+  @Unroll
+  def "charset #charset parses without errors"() {
+    when:
+    MediaType mt = ct("application/json;charset=${charset}")
+
+    then:
+    mt.getCharset() == expectedCharset
+    Charset.checkName(mt.getCharset())
+
+    where:
+    charset       | expectedCharset
+    "utf-8"       | "UTF-8"
+    "UTF-8"       | "UTF-8"
+    "\"utf-8\""   | "UTF-8"
   }
 
   private MediaType ct(s) {

--- a/ratpack-core/src/test/groovy/ratpack/http/DefaultMediaTypeSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/http/DefaultMediaTypeSpec.groovy
@@ -26,7 +26,6 @@ class DefaultMediaTypeSpec extends Specification {
 
   def "parsing"() {
     expect:
-    println "1:" + ct(" application/json ").type
     ct(" application/json ").type == "application/json"
     ct(" application/json ").params.isEmpty()
     ct(null).type == null

--- a/ratpack-core/src/test/groovy/ratpack/http/FormHandlingSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/http/FormHandlingSpec.groovy
@@ -180,7 +180,7 @@ class FormHandlingSpec extends RatpackGroovyDslSpec {
       requestSpec.body.buffer(Unpooled.wrappedBuffer(chunks as ByteBuf[]))
     }
     then:
-    postText() == "File type: text/plain;charset=UTF-8"
+    postText() == "File type: text/plain; charset=utf-8"
   }
 
   def "respects custom encoding"() {
@@ -214,7 +214,7 @@ class FormHandlingSpec extends RatpackGroovyDslSpec {
       requestSpec.body.buffer(Unpooled.wrappedBuffer(chunks as ByteBuf[]))
     }
     then:
-    postText() == "File type: text/plain;charset=US-ASCII"
+    postText() == "File type: text/plain; charset=us-ascii"
   }
 
   @Unroll

--- a/ratpack-core/src/test/groovy/ratpack/http/client/HttpClientSmokeSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/http/client/HttpClientSmokeSpec.groovy
@@ -223,7 +223,7 @@ class HttpClientSmokeSpec extends HttpClientSpec {
     otherApp {
       post {
         request.body.then { body ->
-          assert body.contentType.toString() == "text/plain;charset=UTF-8"
+          assert body.contentType.toString() == "text/plain; charset=utf-8"
           render body.text
         }
       }


### PR DESCRIPTION
#741 
Parser supports RFC2616 (sec 3.7) media type format.
Parameter value may be a token or quated string.
Internally Guava Media Type is used for parsing.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/742)
<!-- Reviewable:end -->
