### PR TITLE
Make datasource decoration possible in built-in modules

### DIFF
--- a/ratpack-h2/src/main/java/ratpack/h2/H2Module.java
+++ b/ratpack-h2/src/main/java/ratpack/h2/H2Module.java
@@ -42,7 +42,12 @@ public class H2Module extends AbstractModule {
 
   @Provides
   DataSource dataSource() {
-    return JdbcConnectionPool.create(url, username, password);
+    return createDataSource();
   }
 
+  // separate from above to allow decoration of the datasource by extending the module
+  // Guice does not allow overriding @Provides methods
+  protected DataSource createDataSource() {
+    return JdbcConnectionPool.create(url, username, password);
+  }
 }

--- a/ratpack-hikari/src/main/java/ratpack/hikari/HikariModule.java
+++ b/ratpack-hikari/src/main/java/ratpack/hikari/HikariModule.java
@@ -117,6 +117,12 @@ public class HikariModule extends ConfigurableModule<HikariConfig> {
   @Provides
   @Singleton
   public DataSource dataSource(HikariService service) {
+    return getDataSource(service);
+  }
+
+  // separate from above to allow decoration of the datasource by extending the module
+  // Guice does not allow overriding @Provides methods
+  protected DataSource getDataSource(HikariService service) {
     return service.getDataSource();
   }
 


### PR DESCRIPTION
This allows decorating DataSources with e.g. profiling wrappers.

Required as Guice does not allow overriding @Provides methods.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/765)
<!-- Reviewable:end -->
