### PR TITLE
add the simplest support of custom Guice Injector factory

### DIFF
--- a/ratpack-guice/src/main/java/ratpack/guice/AbstractGuiceInjectorFactory.java
+++ b/ratpack-guice/src/main/java/ratpack/guice/AbstractGuiceInjectorFactory.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.guice;
+
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import ratpack.func.Function;
+import ratpack.server.ServerConfig;
+
+public abstract class AbstractGuiceInjectorFactory implements Function<Module, Injector> {
+  protected final ServerConfig serverConfig;
+
+  public AbstractGuiceInjectorFactory(ServerConfig serverConfig) {
+    this.serverConfig = serverConfig;
+  }
+}


### PR DESCRIPTION
What allows to use extensions like https://github.com/Netflix/governator.

ratpack.groovy part example:
```groovy
serverConfig {
  props "server.GuiceInjectorFactory": GuiceInjectorFactory.name
}
```
Custom factory example:
```groovy
import com.netflix.governator.guice.LifecycleInjector

class GuiceInjectorFactory extends AbstractGuiceInjectorFactory {
  GuiceInjectorFactory(ServerConfig serverConfig) {
    super(serverConfig)
  }

  @Override
  Injector apply(Module module) throws Exception {
    def builder = LifecycleInjector.builder()
        .inStage(serverConfig.isDevelopment() ? DEVELOPMENT : PRODUCTION)
        .usingBasePackages(GuiceInjectorFactory.package.name)
    if (module)
      builder.withModules(module)
    builder.build().createInjector()
  }
}
```

Initially, I thought of basic registry usage where you optionally put custom factory, but I was not able to quickly get how to implement such approach. As a result I ended up with quick dirty solution based on server config. Please, propose better way if possible.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/767)
<!-- Reviewable:end -->
