### PR TITLE
Renderer docs

### DIFF
--- a/ratpack-core/src/main/java/ratpack/handling/Context.java
+++ b/ratpack-core/src/main/java/ratpack/handling/Context.java
@@ -302,8 +302,10 @@ public interface Context extends Registry {
    * <ul>
    * <li>{@link java.nio.file.Path}</li>
    * <li>{@link java.lang.CharSequence}</li>
+   * <li>{@link ratpack.jackson.JsonRender} (Typically created via {@link ratpack.jackson.Jackson#json(Object)})</li>
    * <li>{@link Promise} (renders the promised value, using this {@code render()} method)</li>
    * <li>{@link org.reactivestreams.Publisher} (converts the publisher to a promise using {@link ratpack.stream.Streams#toPromise(Publisher)} and renders it)</li>
+   * <li>{@link ratpack.render.Renderable} (Delegates to the {@link ratpack.render.Renderable#render(Context)} method of the object)</li>
    * </ul>
    * <p>
    * See {@link ratpack.render.Renderer} for more on how to contribute to the rendering framework.

--- a/ratpack-manual/src/content/chapters/13-http.md
+++ b/ratpack-manual/src/content/chapters/13-http.md
@@ -248,7 +248,10 @@ public class Example {
 }
 ```
 
-TODO introduce Jackson module and methods to help render arbitrary types to json
+### Sending JSON
+
+Support for rendering arbitrary objects as JSON is based on Jackson.
+See [`Jackson rendering`](api/ratpack/jackson/Jackson.html#rendering) for examples.
 
 ### Sending files
 


### PR DESCRIPTION
Fixes #508 

I compared the set already documented with the set added in the ServerRegistry and found that only two classes were missing. It seems like this is a prominent enough place to document the list. 

I'm not sure if you want to document all of these renderers in the manual, but I saw that the JSON section was stubbed out with a TODO and replaced that one.

I can do the Files section too, but one is going to take more time as I didn't find an example already documented somewhere.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/799)
<!-- Reviewable:end -->
