### PR TITLE
Add spock words and inherit from Specification

### DIFF
--- a/ratpack-manual/src/content/chapters/16-testing.md
+++ b/ratpack-manual/src/content/chapters/16-testing.md
@@ -34,24 +34,28 @@ Note below we use @Delegate so we just need to call `get()` in the when block in
 import ratpack.groovy.test.GroovyRatpackMainApplicationUnderTest
 import ratpack.test.http.TestHttpClient
 import ratpack.test.ServerBackedApplicationUnderTest
+import spock.lang.*
 
-class SiteSmokeSpec {
+class SiteSmokeSpec extends Specification {
 
   ServerBackedApplicationUnderTest aut = new GroovyRatpackMainApplicationUnderTest()
   @Delegate TestHttpClient client = TestHttpClient.testHttpClient(aut)
 
   def "Check Site Index"() {
+	when:
     get("index.html")
 
-
+    then:
     assert response.statusCode == 200
     assert response.body.text.contains('<title>Ratpack: A toolkit for JVM web applications</title>')
 
   }
 
   def "Check Site Root"() {
+	when:
     get()
 
+	then:
     assert response.statusCode == 200
     assert response.body.text.contains('<title>Ratpack: A toolkit for JVM web applications</title>')
   }

--- a/ratpack-manual/src/content/chapters/16-testing.md
+++ b/ratpack-manual/src/content/chapters/16-testing.md
@@ -29,7 +29,7 @@ Ratpack provides [TestHttpClient](api/ratpack/test/http/TestHttpClient.html) in 
 
 Note below we use @Delegate so we just need to call `get()` in the when block instead of `client.get()`.
 
-```language-groovy tested
+```language-groovy tested-dynamic
 
 import ratpack.groovy.test.GroovyRatpackMainApplicationUnderTest
 import ratpack.test.http.TestHttpClient

--- a/ratpack-manual/src/test/groovy/ratpack/manual/ManualCodeSnippetTests.groovy
+++ b/ratpack-manual/src/test/groovy/ratpack/manual/ManualCodeSnippetTests.groovy
@@ -33,6 +33,7 @@ class ManualCodeSnippetTests extends CodeSnippetTestCase {
     "language-groovy groovy-handlers" : new GroovySnippetExecuter(true, new GroovyHandlersFixture()),
     "language-groovy gradle"          : new GroovySnippetExecuter(false, new GradleFixture()),
     "language-groovy tested"          : new GroovySnippetExecuter(true, new GroovyScriptFixture()),
+    "language-groovy tested-dynamic"  : new GroovySnippetExecuter(false, new GroovyScriptFixture()),
     "language-java"                   : new JavaSnippetExecuter(new SnippetFixture()),
     "language-java hello-world"       : new HelloWorldAppSnippetExecuter(new JavaSnippetExecuter(new SnippetFixture())),
     "language-groovy hello-world"     : new HelloWorldAppSnippetExecuter(new GroovySnippetExecuter(true, new GroovyScriptRatpackDslFixture())),


### PR DESCRIPTION
As it is stands the ```SiteSmoketest``` sample from the testing chapter compiles, but if you include it in a project it is not executed (e.g. ```gradle test``` will build with no tests run). It think it should be written as a Spock specification or JUnit test case. I made some small changes so it will be picked up and run as a Spock test.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/811)
<!-- Reviewable:end -->
