### PR TITLE
'Connection: Close' directive is not being respected

### DIFF
--- a/ratpack-core/src/main/java/ratpack/http/internal/HttpHeaderConstants.java
+++ b/ratpack-core/src/main/java/ratpack/http/internal/HttpHeaderConstants.java
@@ -30,6 +30,7 @@ public abstract class HttpHeaderConstants {
   public static final CharSequence ACCEPT = HttpHeaderNames.ACCEPT;
   public static final CharSequence LAST_MODIFIED = HttpHeaderNames.LAST_MODIFIED;
   public static final CharSequence CONNECTION = HttpHeaderNames.CONNECTION;
+  public static final CharSequence CLOSE = HttpHeaderValues.CLOSE;
   public static final CharSequence KEEP_ALIVE = HttpHeaderValues.KEEP_ALIVE;
   public static final CharSequence CONTENT_ENCODING = HttpHeaderNames.CONTENT_ENCODING;
   public static final CharSequence IDENTITY = HttpHeaderValues.IDENTITY;

--- a/ratpack-core/src/main/java/ratpack/server/internal/DefaultResponseTransmitter.java
+++ b/ratpack-core/src/main/java/ratpack/server/internal/DefaultResponseTransmitter.java
@@ -55,9 +55,9 @@ public class DefaultResponseTransmitter implements ResponseTransmitter {
   private final Request ratpackRequest;
   private final HttpHeaders responseHeaders;
   private final DefaultEventController<RequestOutcome> requestOutcomeEventController;
-  private final boolean isKeepAlive;
   private final boolean isSsl;
 
+  private boolean isKeepAlive;
   private Instant stopTime;
 
   private Runnable onWritabilityChanged = NOOP_RUNNABLE;
@@ -77,6 +77,10 @@ public class DefaultResponseTransmitter implements ResponseTransmitter {
   private ChannelFuture pre(HttpResponseStatus responseStatus) {
     if (transmitted.compareAndSet(false, true)) {
       stopTime = Instant.now();
+
+      if (responseHeaders.contains(HttpHeaderConstants.CONNECTION, HttpHeaderConstants.CLOSE, true)) {
+        isKeepAlive = false;
+      }
 
       HttpResponse headersResponse = new CustomHttpResponse(responseStatus, responseHeaders);
 

--- a/ratpack-core/src/test/groovy/ratpack/http/internal/DefaultResponseSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/http/internal/DefaultResponseSpec.groovy
@@ -20,8 +20,10 @@ import io.netty.buffer.Unpooled
 import ratpack.exec.Blocking
 import ratpack.test.internal.RatpackGroovyDslSpec
 
+import static io.netty.handler.codec.http.HttpHeaders.Names.CONNECTION
 import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_LENGTH
 import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE
+import static io.netty.handler.codec.http.HttpHeaders.Values.CLOSE
 import static io.netty.handler.codec.http.HttpResponseStatus.ACCEPTED
 import static io.netty.handler.codec.http.HttpResponseStatus.OK
 
@@ -293,6 +295,24 @@ class DefaultResponseSpec extends RatpackGroovyDslSpec {
     then:
     with(response) {
       headers.get("foo") == "1:2:3"
+    }
+  }
+
+  def "can set connection close response header"() {
+    given:
+    handlers {
+      get {
+        response.headers.set(CONNECTION, CLOSE)
+        response.send()
+      }
+    }
+
+    when:
+    get()
+
+    then:
+    with(response) {
+      headers.get(CONNECTION) == CLOSE
     }
   }
 }


### PR DESCRIPTION
Changed pre method in DefaultResponseTransmitter to disable keep-alive if the response headers contain a "Connection: close" header.

https://github.com/ratpack/ratpack/issues/817

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/820)
<!-- Reviewable:end -->
