### PR TITLE
Specify the default port in the manual

### DIFF
--- a/ratpack-manual/src/content/chapters/02-quick-start.md
+++ b/ratpack-manual/src/content/chapters/02-quick-start.md
@@ -36,6 +36,8 @@ You can now start the app by running the following on the command line:
 groovy ratpack.groovy
 ```
 
+The server will be available via `http://localhost:5050/`.
+
 The [`handlers()` method](api/ratpack/groovy/Groovy.Ratpack.html#handlers-groovy.lang.Closure-) takes a closure that delegates to a [`GroovyChain`](api/ratpack/groovy/handling/GroovyChain.html) object.
 The “Groovy Handler Chain DSL” is used to build the response handling strategy.
 
@@ -107,6 +109,8 @@ public class Main {
 You can now start the application either by executing the `run` task with Gradle (i.e. `gradle run` on the command line),
 or by importing the project into your IDE and executing the `my.app.Main` class.
 
+When run, the server will be available via `http://localhost:5050/`.
+
 The [`handlers()` method](api/ratpack/server/RatpackServerSpec.html#handlers-ratpack.func.Action-) takes a function that receives a [`Chain`](api/ratpack/handling/Chain.html) object.
 The “Handler Chain API” is used to build the response handling strategy.
 
@@ -155,6 +159,8 @@ ratpack {
 
 You can now start the application either by executing the `run` task with Gradle (i.e. `gradle run` on the command line),
 or by importing the project into your IDE and executing the [`ratpack.groovy.GroovyRatpackMain`](api/ratpack/groovy/GroovyRatpackMain.html) class.
+
+When run, the server will be available via `http://localhost:5050/`.
 
 The [`handlers()` method](api/ratpack/groovy/Groovy.Ratpack.html#handlers-groovy.lang.Closure-) takes a closure that delegates to a [`GroovyChain`](api/ratpack/groovy/handling/GroovyChain.html) object.
 The “Groovy Handler Chain DSL” is used to build the response handling strategy.

--- a/ratpack-manual/src/content/chapters/10-launching.md
+++ b/ratpack-manual/src/content/chapters/10-launching.md
@@ -102,6 +102,11 @@ A real main method would simply call `BaseDir.find()`, relying on whatever launc
 Ratpack accesses the base dir via the Java 7 [Path](http://docs.oracle.com/javase/8/docs/api/java/nio/file/Path.html) API,
 allowing transparent use of JAR contents as the file system.
 
+#### Port
+
+The [port(int)](api/ratpack/server/ServerConfigBuilder.html#port-int-) method allows setting the port used to connect to the server.
+If not configured, the default value is 5050.
+
 ### Registry
 
 A [`registry`](api/ratpack/registry/Registry.html) is a store of objects stored by type.


### PR DESCRIPTION
Fixes #771

I added the port to the two sections that I felt like I would look for info if I was just getting started: "Quickstart" and "Launching".

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/830)
<!-- Reviewable:end -->
