### PR TITLE
Add Spring Boot starter to build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ out/
 *.ipr
 *.iws
 *.idea
+.factorypath
+pom.xml
+target/
 db/
 starth2
 .gradletasknamecache

--- a/ratpack-spring-boot-starter/ratpack-spring-boot-starter.gradle
+++ b/ratpack-spring-boot-starter/ratpack-spring-boot-starter.gradle
@@ -27,3 +27,5 @@ dependencies {
   compile project(":ratpack-spring-boot")
   compile "org.springframework.boot:spring-boot-starter:1.2.7.RELEASE"
 }
+
+configurations.testCompile.exclude module: 'log4j-slf4j-impl'

--- a/ratpack-spring-boot-starter/ratpack-spring-boot-starter.gradle
+++ b/ratpack-spring-boot-starter/ratpack-spring-boot-starter.gradle
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+description = "Spring Boot starter for Ratpack - http://projects.spring.io/spring-boot/"
+
+apply from: "$rootDir/gradle/javaModule.gradle"
+
+ext.apiLinks = [
+  "http://docs.spring.io/spring-boot/docs/1.2.x/api/",
+]
+
+dependencies {
+  compile project(":ratpack-core")
+  compile project(":ratpack-spring-boot")
+  compile "org.springframework.boot:spring-boot-starter:1.2.7.RELEASE"
+}

--- a/ratpack.gradle
+++ b/ratpack.gradle
@@ -109,7 +109,7 @@ ext {
     "ratpack-core", "ratpack-groovy", "ratpack-guice", "ratpack-session", "ratpack-session-redis", "ratpack-test", "ratpack-groovy-test",
     "ratpack-manual", "ratpack-gradle", "ratpack-handlebars", "ratpack-remote", "ratpack-remote-test",
     "ratpack-dropwizard-metrics", "ratpack-h2", "ratpack-thymeleaf", "ratpack-rx", "ratpack-hikari", "ratpack-newrelic",
-    "ratpack-pac4j", "ratpack-hystrix", "ratpack-spring-boot"
+    "ratpack-pac4j", "ratpack-hystrix", "ratpack-spring-boot", "ratpack-spring-boot-starter"
   ].collect { project(it) }
 
   apiModules = publishedModules.findAll { !(it.name in ["ratpack-manual", "ratpack-gradle"]) }

--- a/ratpack.gradle
+++ b/ratpack.gradle
@@ -112,7 +112,7 @@ ext {
     "ratpack-pac4j", "ratpack-hystrix", "ratpack-spring-boot", "ratpack-spring-boot-starter"
   ].collect { project(it) }
 
-  apiModules = publishedModules.findAll { !(it.name in ["ratpack-manual", "ratpack-gradle"]) }
+  apiModules = publishedModules.findAll { !(it.name in ["ratpack-manual", "ratpack-gradle", "ratpack-spring-boot-starter"]) }
 
   localRepoUrl = "${buildDir.toURI()}/localrepo"
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -39,6 +39,7 @@ include \
     "ratpack-pac4j",
     "ratpack-hystrix",
     "ratpack-spring-boot",
+    "ratpack-spring-boot-starter",
     "ratpack-benchmark"
 
 include "perf"


### PR DESCRIPTION
Spring Boot users find it convenient to consume "features" of apps
as empty starter poms. Depending on this one artifact
'io.ratpack:ratpack-spring-boot-starter' will bring everything you
need to get started coding an app with Ratpack and Spring Boot.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/844)
<!-- Reviewable:end -->
