### PR TITLE
fixed issue with #pac4j authenticator and boundTo on path binding

### DIFF
--- a/ratpack-pac4j/src/test/groovy/ratpack/pac4j/internal/Pac4jAuthenticatorSpec.groovy
+++ b/ratpack-pac4j/src/test/groovy/ratpack/pac4j/internal/Pac4jAuthenticatorSpec.groovy
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.pac4j.internal
+
+import ratpack.handling.Context
+import ratpack.pac4j.RatpackPac4j
+import ratpack.path.PathBinding
+import ratpack.server.PublicAddress
+import ratpack.server.internal.ConstantPublicAddress
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import static ratpack.pac4j.RatpackPac4j.DEFAULT_AUTHENTICATOR_PATH
+
+class Pac4jAuthenticatorSpec extends Specification {
+
+  @Unroll("can create clients with callback url given [#path], [#boundTo] and [#uri]")
+  void "can create clients with callback url given context and path binding"() {
+    given:
+      def context = Mock(Context) {
+        _ * get(PublicAddress) >> new ConstantPublicAddress(uri)
+      }
+      def pathBinding = Mock(PathBinding) {
+        _ * getBoundTo() >> boundTo
+      }
+
+    and:
+      def clientsProvider = Mock(RatpackPac4j.ClientsProvider) {
+        _ * get(context) >> []
+      }
+      def authenticator = new Pac4jAuthenticator(path, clientsProvider)
+
+    when:
+      def actual = authenticator.createClients(context, pathBinding)
+
+    then:
+      expected == actual.callbackUrl
+      new URL(actual.callbackUrl)
+
+    where:
+      path                       | uri                          | boundTo | expected
+      DEFAULT_AUTHENTICATOR_PATH | uri("http://some.host:1234") | ""      | "http://some.host:1234/$DEFAULT_AUTHENTICATOR_PATH"
+      DEFAULT_AUTHENTICATOR_PATH | uri("http://some.host:1234") | "app"   | "http://some.host:1234/app/$DEFAULT_AUTHENTICATOR_PATH"
+      "customAuthenticationPath" | uri("https://some.host")     | ""      | "https://some.host/customAuthenticationPath"
+      "customAuthenticationPath" | uri("https://some.host")     | "app"   | "https://some.host/app/customAuthenticationPath"
+  }
+
+  private URI uri(String url) {
+    new URL(url).toURI()
+  }
+
+}

--- a/ratpack-pac4j/src/test/groovy/ratpack/pac4j/openid/OpenIdRpSpec.groovy
+++ b/ratpack-pac4j/src/test/groovy/ratpack/pac4j/openid/OpenIdRpSpec.groovy
@@ -18,9 +18,10 @@ package ratpack.pac4j.openid
 
 import org.pac4j.core.profile.UserProfile
 import org.pac4j.openid.profile.yahoo.YahooOpenIdProfile
-import ratpack.groovy.handling.GroovyChain
+import ratpack.func.Action
+import ratpack.groovy.handling.GroovyChainAction
+import ratpack.http.client.ReceivedResponse
 import ratpack.http.client.RequestSpec
-import ratpack.http.internal.HttpHeaderConstants
 import ratpack.pac4j.RatpackPac4j
 import ratpack.session.SessionModule
 import ratpack.test.internal.RatpackGroovyDslSpec
@@ -30,12 +31,22 @@ import spock.lang.Unroll
 import static io.netty.handler.codec.http.HttpHeaderNames.LOCATION
 import static io.netty.handler.codec.http.HttpResponseStatus.FOUND
 import static io.netty.handler.codec.http.HttpResponseStatus.UNAUTHORIZED
+import static ratpack.http.internal.HttpHeaderConstants.COOKIE
+import static ratpack.http.internal.HttpHeaderConstants.SET_COOKIE
+import static ratpack.http.internal.HttpHeaderConstants.XML_HTTP_REQUEST
+import static ratpack.http.internal.HttpHeaderConstants.X_REQUESTED_WITH
+import static ratpack.pac4j.RatpackPac4j.DEFAULT_AUTHENTICATOR_PATH
 
 /**
  * Tests OpenID Relying Party support.
  */
 class OpenIdRpSpec extends RatpackGroovyDslSpec {
-  private static final String EMAIL = "fake@example.com"
+
+  private static final String EMAIL         = "fake@example.com"
+  private static final String AUTH_PATH     = "auth"
+  private static final String NOAUTH_PATH   = "noauth"
+  private static final String PREFIX_PATH   = "prefix"
+  private static final String PROVIDER_PATH = "/openid_provider"
 
   @AutoCleanup
   EmbeddedProvider provider = new EmbeddedProvider()
@@ -48,24 +59,23 @@ class OpenIdRpSpec extends RatpackGroovyDslSpec {
     }
 
     handlers {
-      prefix 'prefix', {
-        configurePac4j delegate
-      }
+      prefix PREFIX_PATH, new TestAuthenticationChainConfiguration()
 
-      configurePac4j delegate
+      insert new TestAuthenticationChainConfiguration()
     }
 
   }
 
-  GroovyChain configurePac4j(GroovyChain chain) {
-    chain.with {
+  final class TestAuthenticationChainConfiguration extends GroovyChainAction {
+
+    void execute() {
       all(RatpackPac4j.authenticator(new OpenIdTestClient(provider.port)))
-      get("noauth") {
+      get(NOAUTH_PATH) {
         def typedUserProfile = maybeGet(YahooOpenIdProfile).orElse(null)
         def genericUserProfile = maybeGet(UserProfile).orElse(null)
         response.send "noauth:${typedUserProfile?.email}:${genericUserProfile?.attributes?.email}"
       }
-      prefix("auth") {
+      prefix(AUTH_PATH) {
         all(RatpackPac4j.requireAuth(OpenIdTestClient))
         get {
           def typedUserProfile = maybeGet(YahooOpenIdProfile).orElse(null)
@@ -75,90 +85,107 @@ class OpenIdRpSpec extends RatpackGroovyDslSpec {
       }
     }
 
-    chain
   }
 
-
-
+  @Unroll("test no auth given prefix path [#prefix]")
   def "test noauth"() {
     when:
-    def response = client.get("prefix/noauth")
+    def response = client.get("$prefix$NOAUTH_PATH")
 
     then:
     response.body.text == "noauth:null:null"
+
+    where:
+    prefix << ["", "$PREFIX_PATH/"]
   }
 
-  @Unroll('successful auth using prefix #prefix')
+  @Unroll("successful auth using prefix #prefix")
   def "test successful auth"() {
     setup:
-    client.requestSpec { it.redirects(0) }
+    reset { request -> noRedirects request }
     provider.addResult(true, EMAIL)
 
     when:
-    def response1 = client.get("${prefix}auth")
+    def initialResponse = client.get("$prefix$AUTH_PATH")
 
     then:
-    response1.statusCode == FOUND.code()
-    response1.headers.get(LOCATION).contains("/openid_provider")
+    initialResponse.statusCode == FOUND.code()
+    location(initialResponse).contains PROVIDER_PATH
 
     when:
-    def response2 = client.get(response1.headers.get(LOCATION))
+    def providerResponse = client.get(location(initialResponse))
 
     then:
-    response2.statusCode == FOUND.code()
-    response2.headers.get(LOCATION).contains(RatpackPac4j.DEFAULT_AUTHENTICATOR_PATH)
+    providerResponse.statusCode == FOUND.code()
+    location(providerResponse).contains DEFAULT_AUTHENTICATOR_PATH
 
     when:
-    client.resetRequest()
-    client.requestSpec {
-      it.headers.set("Cookie", response1.headers.getAll("Set-Cookie"))
-      it.redirects(0)
+    reset { request ->
+      copyCookie initialResponse, request
+      noRedirects request
     }
-    def response3 = client.get(response2.headers.get(LOCATION))
+    def authenticatorResponse = client.get(location(providerResponse))
 
     then:
-    response3.statusCode == FOUND.code()
-    response3.headers.get(LOCATION).contains("${prefix}auth")
+    authenticatorResponse.statusCode == FOUND.code()
+    location(authenticatorResponse).contains("$prefix$AUTH_PATH")
 
     when:
-    client.resetRequest()
-    client.requestSpec {
-      it.headers.set("Cookie", response1.headers.getAll("Set-Cookie"))
+    reset { request ->
+      copyCookie initialResponse, request
     }
-    def response4 = client.get(response3.headers.get(LOCATION))
+    def protectedResourceResponse = client.get(location(authenticatorResponse))
 
     then:
-    response4.body.text == "auth:${EMAIL}:${EMAIL}"
+    protectedResourceResponse.body.text == "auth:${EMAIL}:${EMAIL}"
 
     when:
-    client.resetRequest()
-    client.requestSpec {
-      it.headers.set("Cookie", response1.headers.getAll("Set-Cookie"))
+    reset { request ->
+      copyCookie initialResponse, request
     }
-    def response5 = client.get("${prefix}noauth")
+    def unprotectedResourceResponse = client.get("$prefix$NOAUTH_PATH")
 
     then:
-    response5.body.text == "noauth:null:null"
+    unprotectedResourceResponse.body.text == "noauth:null:null"
 
     where:
-    prefix << ['', 'prefix/']
+    prefix << ["", "$PREFIX_PATH/"]
   }
 
   def "it should not redirect ajax requests"() {
     setup:
-    // Set AJAX request header.
-    client.requestSpec { RequestSpec requestSpec ->
-      requestSpec.headers.add(
-        HttpHeaderConstants.X_REQUESTED_WITH,
-        HttpHeaderConstants.XML_HTTP_REQUEST
-      )
-    }
+    ajaxRequest()
 
     when: "make a request that requires authentication"
-    def response = client.get("auth")
+    def response = client.get(AUTH_PATH)
 
     then: "a 401 response is returned and no redirect is made"
-    assert response.statusCode == UNAUTHORIZED.code()
+    response.statusCode == UNAUTHORIZED.code()
+  }
+
+  private void ajaxRequest() {
+    client.requestSpec { RequestSpec requestSpec ->
+      requestSpec.headers.add(X_REQUESTED_WITH, XML_HTTP_REQUEST)
+    }
+  }
+
+  private RequestSpec copyCookie(ReceivedResponse from, RequestSpec to) {
+    to.headers.set COOKIE, from.headers.getAll(SET_COOKIE)
+    to
+  }
+
+  private RequestSpec noRedirects(RequestSpec request) {
+    request.redirects 0
+    request
+  }
+
+  private String location(ReceivedResponse response) {
+    response.headers.get LOCATION
+  }
+
+  private void reset(Action<? super RequestSpec> requestAction) {
+    client.resetRequest()
+    client.requestSpec requestAction
   }
 
 }


### PR DESCRIPTION
I ran into an issue using the Pac4jAuthenticator with prefixes - it does not correctly form callbackUrls when there is a boundTo value on the path binding.

I have added tests to cover these use cases and modified the implementation accordingly.

G.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/867)
<!-- Reviewable:end -->
