### PR TITLE
Create a file system for root of JAR if app is running from archive

### DIFF
--- a/ratpack-spring-boot/src/test/groovy/ratpack/spring/RatpackPropertiesTests.java
+++ b/ratpack-spring-boot/src/test/groovy/ratpack/spring/RatpackPropertiesTests.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.spring;
+
+import static org.junit.Assert.assertTrue;
+
+import java.net.URI;
+
+import org.junit.Test;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+
+import ratpack.spring.config.RatpackProperties;
+
+public class RatpackPropertiesTests {
+
+  private RatpackProperties ratpack = new RatpackProperties();
+
+  @Test
+  public void defaultBaseDirIsAbsolute() {
+    assertTrue(ratpack.getBasepath().isAbsolute());
+  }
+
+  @Test
+  public void defaultBaseDirIsAbsoluteWhenInJar() throws Exception {
+    Resource basedir = new ClassPathResource("META-INF/io.netty.versions.properties");
+    URI uri = basedir.getURI();
+    assertTrue(uri.toString().startsWith("jar:file"));
+    basedir = new UrlResource(uri.toString().replace("META-INF/io.netty.versions.properties", ""));
+    ratpack.setBasedir(basedir);
+    assertTrue(ratpack.getBasepath().isAbsolute());
+  }
+
+}


### PR DESCRIPTION
If user runs a ratpack app with "java -jar ..." the root of the
classpath is a jar:file:... URI, and this can be converted to a
java.nio.Path, but only with care. This change creates the underlying
Filesystem if necessary and ensures that the JAR URI is in fact valid
before returning it to the Ratpack config.

Users can then use the JAR to store static assets (e.g. in /static
or /public in a Spring Boot app).

Fixes gh-848

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/882)
<!-- Reviewable:end -->
