### PR TITLE
Handle Pac4j direct authentication

### DIFF
--- a/ratpack-pac4j/src/main/java/ratpack/pac4j/internal/Pac4jAuthenticator.java
+++ b/ratpack-pac4j/src/main/java/ratpack/pac4j/internal/Pac4jAuthenticator.java
@@ -56,7 +56,7 @@ public class Pac4jAuthenticator implements Handler {
     String pastBinding = pathBinding.getPastBinding();
 
     if (pastBinding.equals(path)) {
-      RatpackPac4j.webContext(ctx).map(Types::<RatpackWebContext>cast).flatMap(webContext -> {
+      RatpackWebContext.from(ctx, true).flatMap(webContext -> {
         SessionData sessionData = webContext.getSession();
         return createClients(ctx, pathBinding).map(clients ->
           clients.findClient(webContext)


### PR DESCRIPTION
Previously RatpackPac4j would always try to force a redirect to establish auth credentials. If the Pac4j auth client extends `DirectClient` that will just throw an exception as they don't support redirects. Here I've short-circuited the redirect if the client is direct.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/903)
<!-- Reviewable:end -->
