### PR TITLE
Timed Methods with asynchronous return types should count async completion time

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -72,7 +72,7 @@ ext {
       dependencies.create("rubygems:compass:1.0.3"),
       dependencies.create("rubygems:chunky_png:1.2.9", {
         force = true
-      }),
+      })
     ]
   ]
 }

--- a/ratpack-dropwizard-metrics/ratpack-dropwizard-metrics.gradle
+++ b/ratpack-dropwizard-metrics/ratpack-dropwizard-metrics.gradle
@@ -28,5 +28,6 @@ dependencies {
   compile "io.dropwizard.metrics:metrics-jvm:${commonVersions.dropwizardMetrics}"
   compile "io.dropwizard.metrics:metrics-annotation:${commonVersions.dropwizardMetrics}"
   compile "io.dropwizard.metrics:metrics-graphite:${commonVersions.dropwizardMetrics}"
+  compile "io.reactivex:rxjava:$commonVersions.rxjava"
 }
 

--- a/ratpack-dropwizard-metrics/ratpack-dropwizard-metrics.gradle
+++ b/ratpack-dropwizard-metrics/ratpack-dropwizard-metrics.gradle
@@ -28,6 +28,5 @@ dependencies {
   compile "io.dropwizard.metrics:metrics-jvm:${commonVersions.dropwizardMetrics}"
   compile "io.dropwizard.metrics:metrics-annotation:${commonVersions.dropwizardMetrics}"
   compile "io.dropwizard.metrics:metrics-graphite:${commonVersions.dropwizardMetrics}"
-  compile "io.reactivex:rxjava:$commonVersions.rxjava"
 }
 

--- a/ratpack-dropwizard-metrics/src/main/java/ratpack/dropwizard/metrics/internal/TimedMethodInterceptor.java
+++ b/ratpack-dropwizard-metrics/src/main/java/ratpack/dropwizard/metrics/internal/TimedMethodInterceptor.java
@@ -25,7 +25,6 @@ import ratpack.exec.Promise;
 
 import javax.inject.Inject;
 import java.lang.reflect.Method;
-import rx.Observable;
 
 /**
  * An implementation of MethodInterceptor that collects {@link com.codahale.metrics.Timer} metrics for any method
@@ -43,9 +42,7 @@ public class TimedMethodInterceptor implements MethodInterceptor {
     Object result;
     try {
       result = invocation.proceed();
-      if (result instanceof Observable<?>) {
-        result = ((Observable) result).finallyDo(timer::stop);
-      } else if (result instanceof Promise<?>) {
+      if (result instanceof Promise<?>) {
         ((Promise<?>) result).result(v -> timer.stop());
       } else {
         timer.stop();

--- a/ratpack-dropwizard-metrics/src/main/java/ratpack/dropwizard/metrics/internal/TimedMethodInterceptor.java
+++ b/ratpack-dropwizard-metrics/src/main/java/ratpack/dropwizard/metrics/internal/TimedMethodInterceptor.java
@@ -45,7 +45,7 @@ public class TimedMethodInterceptor implements MethodInterceptor {
     try {
       result = invocation.proceed();
       if (result instanceof Promise<?>) {
-        ((Promise<?>) result).time(duration ->
+        result = ((Promise<?>) result).time(duration ->
                 timer.update(duration.getNano(), TimeUnit.NANOSECONDS)
         );
       } else {

--- a/ratpack-dropwizard-metrics/src/test/groovy/ratpack/dropwizard/metrics/MetricsSpec.groovy
+++ b/ratpack-dropwizard-metrics/src/test/groovy/ratpack/dropwizard/metrics/MetricsSpec.groovy
@@ -28,6 +28,7 @@ import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import org.slf4j.Logger
 import ratpack.exec.Blocking
+import ratpack.exec.Promise
 import ratpack.test.internal.RatpackGroovyDslSpec
 import ratpack.websocket.RecordingWebSocketClient
 import spock.util.concurrent.PollingConditions
@@ -178,6 +179,12 @@ class MetricsSpec extends RatpackGroovyDslSpec {
     @Timed
     public AnnotatedMetricService triggerTimer3() { this }
 
+    @Timed(name = 'foo.timer.promise', absolute = true)
+    public Promise<String> triggerTimerPromise() { Promise.ofLazy{sleep(50); "resultPromise"} }
+
+    @Timed(name = 'foo.timer.sync', absolute=true)
+    public String triggerTimerSync() {sleep(50); "resultSync"}
+
   }
 
   def "can collect metered annotated metrics"() {
@@ -222,6 +229,7 @@ class MetricsSpec extends RatpackGroovyDslSpec {
       unNamedMeter = arguments[1]
     }
 
+
     absoluteNamedMeter.count == 4
     namedMeter.count == 2
     unNamedMeter.count == 2
@@ -253,10 +261,10 @@ class MetricsSpec extends RatpackGroovyDslSpec {
       }
     }
 
-    when:
+    when: "Calling the service twice"
     2.times { get("timer") }
 
-    then:
+    then: "Timers should be registered only once"
     1 * reporter.onTimerAdded("foo timer", !null) >> { arguments ->
       absoluteNamedTimer = arguments[1]
     }
@@ -269,9 +277,48 @@ class MetricsSpec extends RatpackGroovyDslSpec {
       unNamedTimer = arguments[1]
     }
 
+    and: "Expect the number timers be named, and un-named"
     absoluteNamedTimer.count == 4
     namedTimer.count == 2
     unNamedTimer.count == 2
+
+  }
+
+  def "can properly capture timing events" () {
+    MetricRegistry registry
+
+    given:
+    bindings {
+      module new DropwizardMetricsModule(), {}
+      bind AnnotatedMetricService
+    }
+
+    handlers { MetricRegistry metrics ->
+      registry = metrics
+
+      path("sync") { AnnotatedMetricService service ->
+        render(service.triggerTimerSync())
+
+      }
+
+      path("async") { AnnotatedMetricService service ->
+        render(service.triggerTimerPromise())
+      }
+    }
+
+    when: "Timing synchronous methods"
+    def resultSync = get("sync")
+
+    then: "The synchronous methods should take at least the time they slept"
+    registry.timers.get('foo.timer.sync').count <= 50
+    resultSync.body.text == "resultSync"
+
+    when: "Timing promise methods"
+    def resultPromise = get("async")
+
+    then: "The asynchronous methods should take at least the time they slept"
+    registry.timers.get('foo.timer.promise').count <= 50
+    resultPromise.body.text == "resultPromise"
   }
 
   def "can collect gauge annotated metrics"() {


### PR DESCRIPTION
Currently if you annotate a method with Timed and it returns an async return type (like an Observable or Promise) it will not account for the time it takes to return an actual result. Which can be very misleading. This fix will account for the time it takes to complete an Observable or Promise in the Timer metric reported.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/908)
<!-- Reviewable:end -->