### PR TITLE
Support protocol relative redirects

### DIFF
--- a/ratpack-core/src/main/java/ratpack/handling/internal/DefaultRedirector.java
+++ b/ratpack-core/src/main/java/ratpack/handling/internal/DefaultRedirector.java
@@ -39,23 +39,29 @@ public class DefaultRedirector implements Redirector {
   private String generateRedirectLocation(Context ctx, Request request, String path) {
     //Rules
     //1. Given absolute URL use it
+    //1a. Protocol Relative URL given starting of // we use the protocol from the request
     //2. Given Starting Slash prepend public facing domain:port if provided if not use base URL of request
     //3. Given relative URL prepend public facing domain:port plus parent path of request URL otherwise full parent path
 
     PublicAddress publicAddress = ctx.get(PublicAddress.class);
     String generatedPath;
-    URI host = publicAddress.get();
 
     if (ABSOLUTE_PATTERN.matcher(path).matches()) {
       //Rule 1 - Path is absolute
       generatedPath = path;
     } else {
-      if (path.charAt(0) == '/') {
-        //Rule 2 - Starting Slash
-        generatedPath = host.toString() + path;
+      URI host = publicAddress.get();
+      if (path.startsWith("//")) {
+        //Rule 1a - Protocol relative url
+        generatedPath = host.getScheme() + ":" + path;
       } else {
-        //Rule 3
-        generatedPath = host.toString() + getParentPath(request.getUri()) + path;
+        if (path.charAt(0) == '/') {
+          //Rule 2 - Starting Slash
+          generatedPath = host.toString() + path;
+        } else {
+          //Rule 3
+          generatedPath = host.toString() + getParentPath(request.getUri()) + path;
+        }
       }
     }
 

--- a/ratpack-core/src/test/groovy/ratpack/handling/RedirectHandlingSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/handling/RedirectHandlingSpec.groovy
@@ -16,6 +16,7 @@
 package ratpack.handling
 
 import io.netty.handler.codec.http.HttpResponseStatus
+import ratpack.http.MutableHeaders
 import ratpack.http.client.RequestSpec
 import ratpack.test.internal.RatpackGroovyDslSpec
 
@@ -144,5 +145,45 @@ class RedirectHandlingSpec extends RatpackGroovyDslSpec {
     response.statusCode == HttpResponseStatus.OK.code()
     response.body.text == 'Ratpack'
   }
+
+
+  def "Protocol relative url"() {
+    when:
+
+    handlers {
+      get {
+        redirect("//google.com/")
+      }
+    }
+
+    then:
+    def resp = get("")
+    resp.statusCode == 302
+    resp.headers.get("Location") == "http://google.com/"
+  }
+
+
+  def "Protocol relative url with x-forwarded-proto"() {
+    when:
+
+    handlers {
+      get {
+        redirect("//google.com/")
+      }
+    }
+
+    and:
+    requestSpec{ RequestSpec requestSpec ->
+      requestSpec.headers { MutableHeaders headers ->
+        headers.set("x-forwarded-proto", "https")
+      }
+    }
+
+    then:
+    def resp = get("")
+    resp.statusCode == 302
+    resp.headers.get("Location") == "https://google.com/"
+  }
+
 
 }

--- a/ratpack-manual/src/content/chapters/13-http.md
+++ b/ratpack-manual/src/content/chapters/13-http.md
@@ -12,6 +12,15 @@ For example, they both provide a `getHeaders()` method that returns a model of t
 The [`Request`](api/ratpack/http/Request.html) exposes other metadata attributes such as the [HTTP method](api/ratpack/http/Request.html#getMethod--),
 the [URI](api/ratpack/http/Request.html#getUri--) and a key/value model of the [query string parameters](api/ratpack/http/Request.html#getQueryParams--) among other things.
 
+## Redirecting
+
+The context object provides options for responding with redirects. These methods all delegate to a [Redirector](api/ratpack/handling/Redirector.html), by default Ratpack provides a Redircetor that acts in the following ways:
+
+  * An absolute URL will be used as the location.
+  * A protocol relative URL will use the protocol of the incoming request, ex: `\\example.com\foo`.
+  * A starting slash will have the URL provided by the [PublicAddress.get()](api/ratpack/server/PublicAddress.html#get--) method prepended. 
+  * A relative url will have the URL provided by [PublicAddress.get()](api/ratpack/server/PublicAddress.html#get--) and then the parent path of the request prepended. 
+
 ## Reading the request
 
 The body of the request is available via [`Request.getBody()`](api/ratpack/http/Request.html#getBody--).


### PR DESCRIPTION
This depends on the public address which can be infering or just set it will use that scheme the public address provides.

This fixes #910

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/915)
<!-- Reviewable:end -->
