### PR TITLE
Should use absolute path in manual/current redirect

### DIFF
--- a/ratpack-site/src/main/groovy/ratpack/site/SiteMain.java
+++ b/ratpack-site/src/main/groovy/ratpack/site/SiteMain.java
@@ -135,7 +135,7 @@ public class SiteMain {
 
             .prefix("manual", c1 -> c1
                 .fileSystem("manual", c2 -> c2
-                    .get(ctx -> ctx.redirect(301, "manual/current"))
+                    .get(ctx -> ctx.redirect(301, "/manual/current"))
                     .prefix(":label", c3 -> c3
                         .all(ctx -> {
                           String label = ctx.getPathTokens().get("label");

--- a/ratpack-site/src/test/groovy/ratpack/site/SiteSmokeSpec.groovy
+++ b/ratpack-site/src/test/groovy/ratpack/site/SiteSmokeSpec.groovy
@@ -48,6 +48,15 @@ class SiteSmokeSpec extends Specification {
     response.body.text.contains('<title>Ratpack: Lean & powerful HTTP apps for the JVM</title>')
   }
 
+  def "Check /manual to manual/current Redirect"() {
+    when:
+    get("manual/")
+
+    then:
+    response.statusCode == 302
+    response.headers.get("location").endsWith("/manual/current/")
+  }
+
   def cleanup() {
     aut.stop()
   }


### PR DESCRIPTION
This is in reference to https://github.com/ratpack/ratpack/issues/813. 

`manual/` is redirecting to `manual/manual/current` instead of `manual/current`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/939)
<!-- Reviewable:end -->