### PR TITLE
Request logger enhancements

### DIFF
--- a/ratpack-core/ratpack-core.gradle
+++ b/ratpack-core/ratpack-core.gradle
@@ -55,6 +55,7 @@ dependencies {
   testCompile 'org.mockito:mockito-core:1.10.19'
   testCompile 'com.opencsv:opencsv:3.3'
   testCompile 'com.github.tomakehurst:wiremock:1.56'
+  testCompile "org.apache.logging.log4j:log4j-core:${commonVersions.log4j}:tests"
 }
 
 test {

--- a/ratpack-core/src/main/java/ratpack/handling/internal/NcsaRequestLogger.java
+++ b/ratpack-core/src/main/java/ratpack/handling/internal/NcsaRequestLogger.java
@@ -36,7 +36,7 @@ import java.util.Optional;
 
 public class NcsaRequestLogger implements RequestLogger {
 
-  private static final DateTimeFormatter FORMATTER = DateTimeFormatter
+  private final DateTimeFormatter formatter = DateTimeFormatter
     .ofPattern("dd/MMM/yyyy:HH:mm:ss Z")
     .withZone(ZoneId.systemDefault());
 
@@ -88,11 +88,20 @@ public class NcsaRequestLogger implements RequestLogger {
       client.getHostText(),
       rfc1413Ident,
       userId.orElse("-"),
-      FORMATTER.format(timestamp),
+      formatter.format(timestamp),
       method.getName(),
       uri,
       httpProtocol,
       status.getCode(),
       responseSize);
   }
+
+  /*
+   * Left package-private so formatter can be tested separately.
+   * Not static so testing with different locales/timezones is possible.
+   */
+  String getTimestampString(Instant instant) {
+    return formatter.format(instant);
+  }
+
 }

--- a/ratpack-core/src/main/java/ratpack/handling/internal/NcsaRequestLogger.java
+++ b/ratpack-core/src/main/java/ratpack/handling/internal/NcsaRequestLogger.java
@@ -16,26 +16,88 @@
 
 package ratpack.handling.internal;
 
-import com.google.common.net.HostAndPort;
 import org.slf4j.Logger;
+import org.slf4j.Marker;
+import org.slf4j.MarkerFactory;
 import ratpack.handling.RequestId;
 import ratpack.handling.RequestLogger;
 import ratpack.handling.RequestOutcome;
 import ratpack.handling.UserId;
-import ratpack.http.HttpMethod;
 import ratpack.http.Request;
 import ratpack.http.SentResponse;
-import ratpack.http.Status;
 import ratpack.http.internal.HttpHeaderConstants;
-import ratpack.util.Types;
 
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
-import java.util.Optional;
+import java.util.Objects;
 
 public class NcsaRequestLogger implements RequestLogger {
+
+  public static final String ACCESS_MARKER_NAME ="access";
+  public static final String STATUS_1XX_MARKER_NAME ="status-1xx";
+  public static final String STATUS_2XX_MARKER_NAME ="status-2xx";
+  public static final String STATUS_3XX_MARKER_NAME ="status-3xx";
+  public static final String STATUS_4XX_MARKER_NAME ="status-4xx";
+  public static final String STATUS_5XX_MARKER_NAME ="status-5xx";
+  public static final String STATUS_UNKNOWN_MARKER_NAME ="status-unknown-code";
+
+  private static final Marker ACCESS_MARKER;
+  private static final Marker STATUS_1XX_MARKER;
+  private static final Marker STATUS_2XX_MARKER;
+  private static final Marker STATUS_3XX_MARKER;
+  private static final Marker STATUS_4XX_MARKER;
+  private static final Marker STATUS_5XX_MARKER;
+  private static final Marker STATUS_UNKNOWN_MARKER;
+
+  static {
+    // the markers below should rather be detached markers but log4j2 does not currently support those.
+    // WARN Log4j does not support detached Markers. Returned Marker [access] will be unchanged.
+    ACCESS_MARKER = MarkerFactory.getMarker(ACCESS_MARKER_NAME);
+
+    STATUS_1XX_MARKER = MarkerFactory.getMarker(STATUS_1XX_MARKER_NAME);
+    STATUS_1XX_MARKER.add(ACCESS_MARKER);
+
+    STATUS_2XX_MARKER = MarkerFactory.getMarker(STATUS_2XX_MARKER_NAME);
+    STATUS_2XX_MARKER.add(ACCESS_MARKER);
+
+    STATUS_3XX_MARKER = MarkerFactory.getMarker(STATUS_3XX_MARKER_NAME);
+    STATUS_3XX_MARKER.add(ACCESS_MARKER);
+
+    STATUS_4XX_MARKER = MarkerFactory.getMarker(STATUS_4XX_MARKER_NAME);
+    STATUS_4XX_MARKER.add(ACCESS_MARKER);
+
+    STATUS_5XX_MARKER = MarkerFactory.getMarker(STATUS_5XX_MARKER_NAME);
+    STATUS_5XX_MARKER.add(ACCESS_MARKER);
+
+    STATUS_UNKNOWN_MARKER = MarkerFactory.getMarker(STATUS_UNKNOWN_MARKER_NAME);
+    STATUS_UNKNOWN_MARKER.add(ACCESS_MARKER);
+  }
+
+  public static final String MESSAGE_PATTERN_WITHOUT_ID = "{} {} {} [{}] \"{} /{} {}\" {} {}";
+  public static final String MESSAGE_PATTERN_WITH_ID = MESSAGE_PATTERN_WITHOUT_ID + " id={}";
+  private static final String NOT_AVAILABLE = "-";
+
+  private static Marker resolveStatusMarker(int statusCode) {
+    if(statusCode < 100 || statusCode > 599) {
+      // broken status code, just return STATUS_UNKNOWN_MARKER.
+      return STATUS_UNKNOWN_MARKER;
+    }
+    if(statusCode < 200) {
+      return STATUS_1XX_MARKER;
+    }
+    if(statusCode < 300) {
+      return STATUS_2XX_MARKER;
+    }
+    if(statusCode < 400) {
+      return STATUS_3XX_MARKER;
+    }
+    if(statusCode < 500) {
+      return STATUS_4XX_MARKER;
+    }
+    return STATUS_5XX_MARKER;
+  }
 
   private final DateTimeFormatter formatter = DateTimeFormatter
     .ofPattern("dd/MMM/yyyy:HH:mm:ss Z")
@@ -43,59 +105,69 @@ public class NcsaRequestLogger implements RequestLogger {
     .withLocale(Locale.ENGLISH);
 
   private final Logger logger;
+  private final boolean loggingErrorStatusCodesAsWarn;
 
   public NcsaRequestLogger(Logger logger) {
+    this(logger, false);
+  }
+
+  public NcsaRequestLogger(Logger logger, boolean loggingErrorStatusCodesAsWarn) {
+    Objects.requireNonNull(logger, "logger must not be null!");
     this.logger = logger;
+    this.loggingErrorStatusCodesAsWarn = loggingErrorStatusCodesAsWarn;
   }
 
   @Override
   public void log(RequestOutcome outcome) {
-    if (!logger.isInfoEnabled()) {
-      return;
+
+    SentResponse response = outcome.getResponse();
+    final int statusCode = response.getStatus().getCode();
+    final boolean logAtWarnLevel = loggingErrorStatusCodesAsWarn && (statusCode < 100 || statusCode > 399);
+
+    Marker statusMarker = resolveStatusMarker(statusCode);
+    if (logAtWarnLevel) {
+      if(!logger.isWarnEnabled(statusMarker)) {
+        return;
+      }
+    } else {
+      if (!logger.isInfoEnabled(statusMarker)) {
+        return;
+      }
     }
 
-    // TODO - use one string builder here and remove use of String.format()
-
     Request request = outcome.getRequest();
-    SentResponse response = outcome.getResponse();
-    String responseSize = "-";
+
+    final String remoteAddress = request.getRemoteAddress().getHostText();
+    final String rfc1413Ident = NOT_AVAILABLE;
+    final String userId = request.maybeGet(UserId.class).map(CharSequence::toString).orElse(NOT_AVAILABLE);
+    final String dateTime = getTimestampString(request.getTimestamp());
+    final String method = request.getMethod().getName();
+    final String path = request.getPath(); // The '/' is already contained in the pattern.
+    final String protocol = request.getProtocol();
+
+    final String responseSize;
     String contentLength = response.getHeaders().get(HttpHeaderConstants.CONTENT_LENGTH);
     if (contentLength != null) {
       responseSize = contentLength;
+    } else {
+      responseSize = NOT_AVAILABLE;
     }
 
-    StringBuilder logLine = new StringBuilder()
-      .append(
-        ncsaLogFormat(
-          request.getRemoteAddress(),
-          "-",
-          request.maybeGet(UserId.class).map(Types::cast),
-          request.getTimestamp(),
-          request.getMethod(),
-          "/" + request.getPath(),
-          request.getProtocol(),
-          outcome.getResponse().getStatus(),
-          responseSize));
+    final String requestId = request.maybeGet(RequestId.class).map(CharSequence::toString).orElse(null);
 
-    request.maybeGet(RequestId.class).ifPresent(id1 -> {
-      logLine.append(" id=");
-      logLine.append(id1);
-    });
-
-    logger.info(logLine.toString());
-  }
-
-  String ncsaLogFormat(HostAndPort client, String rfc1413Ident, Optional<CharSequence> userId, Instant timestamp, HttpMethod method, String uri, String httpProtocol, Status status, String responseSize) {
-    return String.format("%s %s %s [%s] \"%s %s %s\" %d %s",
-      client.getHostText(),
-      rfc1413Ident,
-      userId.orElse("-"),
-      formatter.format(timestamp),
-      method.getName(),
-      uri,
-      httpProtocol,
-      status.getCode(),
-      responseSize);
+    if(logAtWarnLevel) {
+      if (requestId == null) {
+        logger.warn(statusMarker, MESSAGE_PATTERN_WITHOUT_ID, remoteAddress, rfc1413Ident, userId, dateTime, method, path, protocol, statusCode, responseSize);
+      } else {
+        logger.warn(statusMarker, MESSAGE_PATTERN_WITH_ID, remoteAddress, rfc1413Ident, userId, dateTime, method, path, protocol, statusCode, responseSize, requestId);
+      }
+    } else {
+      if (requestId == null) {
+        logger.info(statusMarker, MESSAGE_PATTERN_WITHOUT_ID, remoteAddress, rfc1413Ident, userId, dateTime, method, path, protocol, statusCode, responseSize);
+      } else {
+        logger.info(statusMarker, MESSAGE_PATTERN_WITH_ID, remoteAddress, rfc1413Ident, userId, dateTime, method, path, protocol, statusCode, responseSize, requestId);
+      }
+    }
   }
 
   /*

--- a/ratpack-core/src/main/java/ratpack/handling/internal/NcsaRequestLogger.java
+++ b/ratpack-core/src/main/java/ratpack/handling/internal/NcsaRequestLogger.java
@@ -32,13 +32,15 @@ import ratpack.util.Types;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 import java.util.Optional;
 
 public class NcsaRequestLogger implements RequestLogger {
 
   private final DateTimeFormatter formatter = DateTimeFormatter
     .ofPattern("dd/MMM/yyyy:HH:mm:ss Z")
-    .withZone(ZoneId.systemDefault());
+    .withZone(ZoneId.systemDefault())
+    .withLocale(Locale.ENGLISH);
 
   private final Logger logger;
 

--- a/ratpack-core/src/test/groovy/ratpack/handling/RequestIdSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/handling/RequestIdSpec.groovy
@@ -17,6 +17,8 @@
 package ratpack.handling
 
 import org.slf4j.Logger
+import org.slf4j.Marker
+import org.slf4j.helpers.MessageFormatter
 import ratpack.http.client.ReceivedResponse
 import ratpack.test.internal.RatpackGroovyDslSpec
 
@@ -62,8 +64,8 @@ class RequestIdSpec extends RatpackGroovyDslSpec {
     given:
     def msgQueue = new ArrayBlockingQueue<String>(2)
     def logger = Mock(Logger) {
-      isInfoEnabled() >> true
-      info(_ as String) >> { String msg -> msgQueue << msg }
+      isInfoEnabled(_ as Marker) >> true
+      info(_ as Marker, _ as String, _ as Object[] ) >> { Marker marker, String msgPattern, Object[] params -> msgQueue << MessageFormatter.arrayFormat(msgPattern, params).message }
     }
 
     int count = 0

--- a/ratpack-core/src/test/groovy/ratpack/handling/RequestLogSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/handling/RequestLogSpec.groovy
@@ -17,6 +17,8 @@
 package ratpack.handling
 
 import org.slf4j.Logger
+import org.slf4j.Marker
+import org.slf4j.helpers.MessageFormatter
 import ratpack.test.internal.RatpackGroovyDslSpec
 
 import java.util.concurrent.CountDownLatch
@@ -28,8 +30,8 @@ class RequestLogSpec extends RatpackGroovyDslSpec {
     def messages = []
     def latch = new CountDownLatch(2)
     def logger = Mock(Logger) {
-      _ * isInfoEnabled() >> true
-      2 * info(_) >> { String m -> messages << m; latch.countDown() }
+      _ * isInfoEnabled(_ as Marker) >> true
+      2 * info(_ as Marker, _ as String, _ as Object[] ) >> { Marker marker, String msgPattern, Object[] params -> messages << MessageFormatter.arrayFormat(msgPattern, params).message; latch.countDown() }
     }
 
     given:

--- a/ratpack-core/src/test/groovy/ratpack/handling/internal/NcsaRequestLoggerSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/handling/internal/NcsaRequestLoggerSpec.groovy
@@ -20,6 +20,7 @@ import io.netty.handler.codec.http.DefaultHttpHeaders
 import io.netty.handler.codec.http.HttpMethod
 import io.netty.handler.codec.http.HttpResponseStatus
 import io.netty.handler.codec.http.HttpVersion
+import org.apache.logging.log4j.Level
 import org.apache.logging.log4j.junit.LoggerContextRule
 import org.apache.logging.log4j.test.appender.ListAppender
 import org.apache.logging.slf4j.Log4jLogger
@@ -179,6 +180,297 @@ class NcsaRequestLoggerSpec extends Specification {
     ex.message == 'logger must not be null!'
   }
 
+
+  @Unroll
+  def '"#expectedMessage" is generated correctly using message pattern "#expectedPattern".'() {
+    setup:
+    def logger = retrieveLogger(INFO_LOGGER_NAME)
+    TimeZone.setDefault(TimeZone.getTimeZone('America/New_York'))
+
+    def requestOutcome = createRequestOutcome(host, user, timestamp, httpMethod, path, httpVersion, statusCode, responseSize, requestId)
+    def instance = new NcsaRequestLogger(logger)
+    def events = requestListAppender.getEvents()
+
+
+    when:
+    instance.log(requestOutcome)
+
+
+    then:
+    events.size() == 1
+
+    def event = events[0]
+    event.message.formattedMessage == expectedMessage
+    event.message.format == expectedPattern
+
+
+    where:
+    host        | user        | timestamp      | httpMethod | path         | httpVersion | statusCode | responseSize | requestId    | expectedMessage
+    '127.0.0.1' | null        | TEST_TIMESTAMP | 'GET'      | 'huhu'       | 'HTTP/1.1'  | 100        | -1           | null         | '127.0.0.1 - - [17/Mar/2016:17:31:33 -0400] "GET /huhu HTTP/1.1" 100 -'
+    '127.0.0.1' | null        | TEST_TIMESTAMP | 'PUT'      | 'foo'        | 'HTTP/1.1'  | 200        | -1           | null         | '127.0.0.1 - - [17/Mar/2016:17:31:33 -0400] "PUT /foo HTTP/1.1" 200 -'
+    '127.0.0.1' | null        | TEST_TIMESTAMP | 'POST'     | 'bar'        | 'HTTP/1.1'  | 300        | -1           | 'request-id' | '127.0.0.1 - - [17/Mar/2016:17:31:33 -0400] "POST /bar HTTP/1.1" 300 - id=request-id'
+    '127.0.0.1' | 'dnadams'   | TEST_TIMESTAMP | 'GET'      | 'coffee'     | 'HTTP/1.1'  | 418        | 42           | null         | '127.0.0.1 - dnadams [17/Mar/2016:17:31:33 -0400] "GET /coffee HTTP/1.1" 418 42'
+    '127.0.0.1' | 'rbradbury' | TEST_TIMESTAMP | 'GET'      | 'fahrenheit' | 'HTTP/1.1'  | 451        | -1           | null         | '127.0.0.1 - rbradbury [17/Mar/2016:17:31:33 -0400] "GET /fahrenheit HTTP/1.1" 451 -'
+    '127.0.0.1' | 'sfalken'   | TEST_TIMESTAMP | 'GET'      | 'wopr'       | 'HTTP/1.1'  | 500        | 0            | 'joshua'     | '127.0.0.1 - sfalken [17/Mar/2016:17:31:33 -0400] "GET /wopr HTTP/1.1" 500 0 id=joshua'
+
+    expectedPattern = requestId ? NcsaRequestLogger.MESSAGE_PATTERN_WITH_ID : NcsaRequestLogger.MESSAGE_PATTERN_WITHOUT_ID
+  }
+
+  @Unroll
+  def '#statusCode is logged at level "#expectedLevel" with error status codes emitted as "#logLevel"'() {
+    setup:
+    def logger = retrieveLogger(INFO_LOGGER_NAME)
+    TimeZone.setDefault(TimeZone.getTimeZone('America/New_York'))
+
+    def requestOutcome = createRequestOutcome(statusCode)
+    def instance = new NcsaRequestLogger(logger, warnLogging)
+    def events = requestListAppender.getEvents()
+
+
+    when:
+    instance.log(requestOutcome)
+
+
+    then:
+    events.size() == 1
+
+    def event = events[0]
+    event.level == expectedLevel
+
+
+    where:
+    statusCode | warnLogging
+    99         | true
+    99         | false
+    100        | true
+    100        | false
+    199        | true
+    199        | false
+    200        | true
+    200        | false
+    299        | true
+    299        | false
+    300        | true
+    300        | false
+    399        | true
+    399        | false
+    400        | true
+    400        | false
+    499        | true
+    499        | false
+    500        | true
+    500        | false
+    599        | true
+    599        | false
+    600        | true
+    600        | false
+
+    expectedLevel = resolveExpectedLevel(statusCode, warnLogging)
+    logLevel = warnLogging ? 'WARN' : 'INFO'
+  }
+
+  @Unroll
+  def 'event with status #statusCode is routed correctly using logger "#loggerName" with error status codes emitted as "#logLevel"'() {
+    setup:
+    TimeZone.setDefault(TimeZone.getTimeZone('America/New_York'))
+
+    def logger = retrieveLogger(loggerName)
+    def instance = new NcsaRequestLogger(logger, warnLogging)
+
+    def requestOutcome = createRequestOutcome(statusCode)
+
+
+    when:
+    instance.log(requestOutcome)
+
+
+    then:
+    if(inInfo) {
+      assert requestListAppender.getEvents().size() == 1
+    } else {
+      assert requestListAppender.getEvents().size() == 0
+    }
+
+    if(inServerError) {
+      assert serverErrorRequestListAppender.getEvents().size() == 1
+    } else {
+      assert serverErrorRequestListAppender.getEvents().size() == 0
+    }
+
+    if(inError) {
+      assert errorRequestListAppender.getEvents().size() == 1
+    } else {
+      assert errorRequestListAppender.getEvents().size() == 0
+    }
+
+
+    where:
+    statusCode | loggerName           | warnLogging | inInfo | inServerError | inError
+    99         | INFO_LOGGER_NAME     | true        | true   | false         | false
+    100        | INFO_LOGGER_NAME     | true        | true   | false         | false
+    199        | INFO_LOGGER_NAME     | true        | true   | false         | false
+    200        | INFO_LOGGER_NAME     | true        | true   | false         | false
+    299        | INFO_LOGGER_NAME     | true        | true   | false         | false
+    300        | INFO_LOGGER_NAME     | true        | true   | false         | false
+    399        | INFO_LOGGER_NAME     | true        | true   | false         | false
+    400        | INFO_LOGGER_NAME     | true        | true   | false         | true
+    499        | INFO_LOGGER_NAME     | true        | true   | false         | true
+    500        | INFO_LOGGER_NAME     | true        | true   | true          | true
+    599        | INFO_LOGGER_NAME     | true        | true   | true          | true
+    600        | INFO_LOGGER_NAME     | true        | true   | false         | false
+
+    99         | WARN_LOGGER_NAME     | true        | true   | false         | false
+    100        | WARN_LOGGER_NAME     | true        | false  | false         | false
+    199        | WARN_LOGGER_NAME     | true        | false  | false         | false
+    200        | WARN_LOGGER_NAME     | true        | false  | false         | false
+    299        | WARN_LOGGER_NAME     | true        | false  | false         | false
+    300        | WARN_LOGGER_NAME     | true        | false  | false         | false
+    399        | WARN_LOGGER_NAME     | true        | false  | false         | false
+    400        | WARN_LOGGER_NAME     | true        | true   | false         | true
+    499        | WARN_LOGGER_NAME     | true        | true   | false         | true
+    500        | WARN_LOGGER_NAME     | true        | true   | true          | true
+    599        | WARN_LOGGER_NAME     | true        | true   | true          | true
+    600        | WARN_LOGGER_NAME     | true        | true   | false         | false
+
+    99         | WARN_5XX_LOGGER_NAME | true        | false  | false         | false
+    100        | WARN_5XX_LOGGER_NAME | true        | false  | false         | false
+    199        | WARN_5XX_LOGGER_NAME | true        | false  | false         | false
+    200        | WARN_5XX_LOGGER_NAME | true        | false  | false         | false
+    299        | WARN_5XX_LOGGER_NAME | true        | false  | false         | false
+    300        | WARN_5XX_LOGGER_NAME | true        | false  | false         | false
+    399        | WARN_5XX_LOGGER_NAME | true        | false  | false         | false
+    400        | WARN_5XX_LOGGER_NAME | true        | false  | false         | false
+    499        | WARN_5XX_LOGGER_NAME | true        | false  | false         | false
+    500        | WARN_5XX_LOGGER_NAME | true        | true   | true          | true
+    599        | WARN_5XX_LOGGER_NAME | true        | true   | true          | true
+    600        | WARN_5XX_LOGGER_NAME | true        | false  | false         | false
+
+    99         | ERROR_LOGGER_NAME    | true        | false  | false         | false
+    100        | ERROR_LOGGER_NAME    | true        | false  | false         | false
+    199        | ERROR_LOGGER_NAME    | true        | false  | false         | false
+    200        | ERROR_LOGGER_NAME    | true        | false  | false         | false
+    299        | ERROR_LOGGER_NAME    | true        | false  | false         | false
+    300        | ERROR_LOGGER_NAME    | true        | false  | false         | false
+    399        | ERROR_LOGGER_NAME    | true        | false  | false         | false
+    400        | ERROR_LOGGER_NAME    | true        | false  | false         | false
+    499        | ERROR_LOGGER_NAME    | true        | false  | false         | false
+    500        | ERROR_LOGGER_NAME    | true        | false  | false         | false
+    599        | ERROR_LOGGER_NAME    | true        | false  | false         | false
+    600        | ERROR_LOGGER_NAME    | true        | false  | false         | false
+
+    99         | INFO_LOGGER_NAME     | false       | true   | false         | false
+    100        | INFO_LOGGER_NAME     | false       | true   | false         | false
+    199        | INFO_LOGGER_NAME     | false       | true   | false         | false
+    200        | INFO_LOGGER_NAME     | false       | true   | false         | false
+    299        | INFO_LOGGER_NAME     | false       | true   | false         | false
+    300        | INFO_LOGGER_NAME     | false       | true   | false         | false
+    399        | INFO_LOGGER_NAME     | false       | true   | false         | false
+    400        | INFO_LOGGER_NAME     | false       | true   | false         | true
+    499        | INFO_LOGGER_NAME     | false       | true   | false         | true
+    500        | INFO_LOGGER_NAME     | false       | true   | true          | true
+    599        | INFO_LOGGER_NAME     | false       | true   | true          | true
+    600        | INFO_LOGGER_NAME     | false       | true   | false         | false
+
+    99         | WARN_LOGGER_NAME     | false       | false  | false         | false
+    100        | WARN_LOGGER_NAME     | false       | false  | false         | false
+    199        | WARN_LOGGER_NAME     | false       | false  | false         | false
+    200        | WARN_LOGGER_NAME     | false       | false  | false         | false
+    299        | WARN_LOGGER_NAME     | false       | false  | false         | false
+    300        | WARN_LOGGER_NAME     | false       | false  | false         | false
+    399        | WARN_LOGGER_NAME     | false       | false  | false         | false
+    400        | WARN_LOGGER_NAME     | false       | false  | false         | false
+    499        | WARN_LOGGER_NAME     | false       | false  | false         | false
+    500        | WARN_LOGGER_NAME     | false       | false  | false         | false
+    599        | WARN_LOGGER_NAME     | false       | false  | false         | false
+    600        | WARN_LOGGER_NAME     | false       | false  | false         | false
+
+    99         | WARN_5XX_LOGGER_NAME | false       | false  | false         | false
+    100        | WARN_5XX_LOGGER_NAME | false       | false  | false         | false
+    199        | WARN_5XX_LOGGER_NAME | false       | false  | false         | false
+    200        | WARN_5XX_LOGGER_NAME | false       | false  | false         | false
+    299        | WARN_5XX_LOGGER_NAME | false       | false  | false         | false
+    300        | WARN_5XX_LOGGER_NAME | false       | false  | false         | false
+    399        | WARN_5XX_LOGGER_NAME | false       | false  | false         | false
+    400        | WARN_5XX_LOGGER_NAME | false       | false  | false         | false
+    499        | WARN_5XX_LOGGER_NAME | false       | false  | false         | false
+    500        | WARN_5XX_LOGGER_NAME | false       | false  | false         | false
+    599        | WARN_5XX_LOGGER_NAME | false       | false  | false         | false
+    600        | WARN_5XX_LOGGER_NAME | false       | false  | false         | false
+
+    99         | ERROR_LOGGER_NAME    | false       | false  | false         | false
+    100        | ERROR_LOGGER_NAME    | false       | false  | false         | false
+    199        | ERROR_LOGGER_NAME    | false       | false  | false         | false
+    200        | ERROR_LOGGER_NAME    | false       | false  | false         | false
+    299        | ERROR_LOGGER_NAME    | false       | false  | false         | false
+    300        | ERROR_LOGGER_NAME    | false       | false  | false         | false
+    399        | ERROR_LOGGER_NAME    | false       | false  | false         | false
+    400        | ERROR_LOGGER_NAME    | false       | false  | false         | false
+    499        | ERROR_LOGGER_NAME    | false       | false  | false         | false
+    500        | ERROR_LOGGER_NAME    | false       | false  | false         | false
+    599        | ERROR_LOGGER_NAME    | false       | false  | false         | false
+    600        | ERROR_LOGGER_NAME    | false       | false  | false         | false
+
+    logLevel = warnLogging ? 'WARN' : 'INFO'
+  }
+
+  @Unroll
+  def '#statusCode has the correct marker "#markerName" with error status codes emitted as "#logLevel"'() {
+    setup:
+    def logger = retrieveLogger(INFO_LOGGER_NAME)
+    TimeZone.setDefault(TimeZone.getTimeZone('America/New_York'))
+
+    def requestOutcome = createRequestOutcome(statusCode)
+    def instance = new NcsaRequestLogger(logger, warnLogging)
+    def events = requestListAppender.getEvents()
+
+
+    when:
+    instance.log(requestOutcome)
+
+
+    then:
+    events.size() == 1
+
+    def event = events[0]
+    def marker = event.marker
+    marker != null
+    marker.isInstanceOf(markerName)
+    // all status markers have ACCESS_MARKER_NAME as parent
+    marker.isInstanceOf(NcsaRequestLogger.ACCESS_MARKER_NAME)
+
+
+    where:
+    statusCode | markerName                                   | warnLogging
+    99         | NcsaRequestLogger.STATUS_UNKNOWN_MARKER_NAME | false
+    100        | NcsaRequestLogger.STATUS_1XX_MARKER_NAME     | false
+    199        | NcsaRequestLogger.STATUS_1XX_MARKER_NAME     | false
+    200        | NcsaRequestLogger.STATUS_2XX_MARKER_NAME     | false
+    299        | NcsaRequestLogger.STATUS_2XX_MARKER_NAME     | false
+    300        | NcsaRequestLogger.STATUS_3XX_MARKER_NAME     | false
+    399        | NcsaRequestLogger.STATUS_3XX_MARKER_NAME     | false
+    400        | NcsaRequestLogger.STATUS_4XX_MARKER_NAME     | false
+    499        | NcsaRequestLogger.STATUS_4XX_MARKER_NAME     | false
+    500        | NcsaRequestLogger.STATUS_5XX_MARKER_NAME     | false
+    599        | NcsaRequestLogger.STATUS_5XX_MARKER_NAME     | false
+    600        | NcsaRequestLogger.STATUS_UNKNOWN_MARKER_NAME | false
+
+    99         | NcsaRequestLogger.STATUS_UNKNOWN_MARKER_NAME | true
+    100        | NcsaRequestLogger.STATUS_1XX_MARKER_NAME     | true
+    199        | NcsaRequestLogger.STATUS_1XX_MARKER_NAME     | true
+    200        | NcsaRequestLogger.STATUS_2XX_MARKER_NAME     | true
+    299        | NcsaRequestLogger.STATUS_2XX_MARKER_NAME     | true
+    300        | NcsaRequestLogger.STATUS_3XX_MARKER_NAME     | true
+    399        | NcsaRequestLogger.STATUS_3XX_MARKER_NAME     | true
+    400        | NcsaRequestLogger.STATUS_4XX_MARKER_NAME     | true
+    499        | NcsaRequestLogger.STATUS_4XX_MARKER_NAME     | true
+    500        | NcsaRequestLogger.STATUS_5XX_MARKER_NAME     | true
+    599        | NcsaRequestLogger.STATUS_5XX_MARKER_NAME     | true
+    600        | NcsaRequestLogger.STATUS_UNKNOWN_MARKER_NAME | true
+
+    logLevel = warnLogging ? 'WARN' : 'INFO'
+
+  }
+
   // helper methods below
   private Logger retrieveLogger(String loggerName) {
     final org.apache.logging.log4j.core.Logger log4jLogger = loggerContextRule.getLogger(loggerName)
@@ -194,6 +486,20 @@ class NcsaRequestLoggerSpec extends Specification {
     requestListAppender.clear()
     serverErrorRequestListAppender.clear()
     errorRequestListAppender.clear()
+  }
+
+  private static Level resolveExpectedLevel(int statusCode, boolean warnLogging) {
+    if(!warnLogging) {
+      return Level.INFO
+    }
+    if(statusCode>=100 && statusCode<400) {
+      return Level.INFO
+    }
+    return Level.WARN
+  }
+
+  private static createRequestOutcome(int statusCode) {
+    return createRequestOutcome('127.0.0.1', 'sfalken', TEST_TIMESTAMP, 'GET', 'wopr','HTTP/1.1', statusCode, 1337, 'request-id')
   }
 
   private static RequestOutcome createRequestOutcome(String host, String user, long timestamp, String httpMethod, String path, String httpVersion, int statusCode, long responseSize, String requestId) {

--- a/ratpack-core/src/test/groovy/ratpack/handling/internal/NcsaRequestLoggerSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/handling/internal/NcsaRequestLoggerSpec.groovy
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.handling.internal
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+import java.time.Instant
+
+@Subject(NcsaRequestLogger)
+class NcsaRequestLoggerSpec extends Specification {
+
+  private static final Long TEST_TIMESTAMP = 1458250293458L
+  private static final String INFO_LOGGER_NAME = 'ratpack.request.info'
+
+  @Shared
+  private Locale originalDefaultLocale
+
+  @Shared
+  private TimeZone originalDefaultTimeZone
+
+  def setupSpec() {
+    // save original state of locale and timezone
+    originalDefaultLocale = Locale.getDefault()
+    originalDefaultTimeZone = TimeZone.getDefault()
+  }
+
+  def setup() {
+    restoreOriginalLocaleAndTimeZone()
+  }
+
+  def cleanupSpec() {
+    restoreOriginalLocaleAndTimeZone()
+  }
+
+  @Unroll
+  def 'timestamp is formatted correctly with locale "#locale" and timezone "#zoneId".'() {
+    setup:
+    def logger = retrieveLogger(INFO_LOGGER_NAME)
+    Locale.setDefault(locale)
+    TimeZone.setDefault(TimeZone.getTimeZone(zoneId))
+    def instance = new NcsaRequestLogger(logger)
+
+    when:
+    def timestamp = instance.getTimestampString(instant)
+
+    then:
+    timestamp == expectedResult
+
+    where:
+    instant                              | locale         | zoneId             || expectedResult
+    Instant.ofEpochMilli(TEST_TIMESTAMP) | Locale.US      | 'America/New_York' || '17/Mar/2016:17:31:33 -0400'
+    Instant.ofEpochMilli(TEST_TIMESTAMP) | Locale.FRANCE  | 'America/New_York' || '17/Mar/2016:17:31:33 -0400'
+    Instant.ofEpochMilli(TEST_TIMESTAMP) | Locale.GERMANY | 'America/New_York' || '17/Mar/2016:17:31:33 -0400'
+
+    Instant.ofEpochMilli(TEST_TIMESTAMP) | Locale.US      | 'Europe/Berlin'    || '17/Mar/2016:22:31:33 +0100'
+    Instant.ofEpochMilli(TEST_TIMESTAMP) | Locale.FRANCE  | 'Europe/Berlin'    || '17/Mar/2016:22:31:33 +0100'
+    Instant.ofEpochMilli(TEST_TIMESTAMP) | Locale.GERMANY | 'Europe/Berlin'    || '17/Mar/2016:22:31:33 +0100'
+  }
+
+  // helper methods below
+  private static Logger retrieveLogger(String loggerName) {
+    return LoggerFactory.getLogger(loggerName)
+  }
+
+  private void restoreOriginalLocaleAndTimeZone() {
+    Locale.setDefault(originalDefaultLocale)
+    TimeZone.setDefault(originalDefaultTimeZone)
+  }
+}

--- a/ratpack-core/src/test/resources/ratpack/handling/internal/logging.xml
+++ b/ratpack-core/src/test/resources/ratpack/handling/internal/logging.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2016 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<Configuration status="INFO">
+
+  <Appenders>
+    <Console name="STDOUT" target="SYSTEM_OUT">
+      <PatternLayout pattern="%m%n"/>
+    </Console>
+    <List name="requestList" />
+    <List name="serverErrorRequestList">
+      <MarkerFilter marker="status-5xx" onMatch="ACCEPT" onMismatch="DENY"/>
+    </List>
+    <List name="errorRequestList">
+      <Filters>
+        <MarkerFilter marker="status-5xx" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="status-4xx" onMatch="ACCEPT" onMismatch="DENY"/>
+      </Filters>
+    </List>
+  </Appenders>
+
+  <Loggers>
+    <Logger name="ratpack.request.info" level="INFO" additivity="false">
+      <AppenderRef ref="STDOUT"/>
+      <AppenderRef ref="requestList"/>
+      <AppenderRef ref="serverErrorRequestList"/>
+      <AppenderRef ref="errorRequestList"/>
+    </Logger>
+
+    <Logger name="ratpack.request.warn" level="WARN" additivity="false">
+      <AppenderRef ref="requestList"/>
+      <AppenderRef ref="serverErrorRequestList"/>
+      <AppenderRef ref="errorRequestList"/>
+    </Logger>
+
+    <Logger name="ratpack.request.warn.5xx" level="WARN" additivity="false">
+      <MarkerFilter marker="status-5xx" onMatch="ACCEPT" onMismatch="DENY"/>
+      <AppenderRef ref="requestList"/>
+      <AppenderRef ref="serverErrorRequestList"/>
+      <AppenderRef ref="errorRequestList"/>
+    </Logger>
+
+    <Logger name="ratpack.request.error" level="ERROR" additivity="false">
+      <AppenderRef ref="requestList"/>
+      <AppenderRef ref="serverErrorRequestList"/>
+      <AppenderRef ref="errorRequestList"/>
+    </Logger>
+
+    <Root level="INFO"/>
+  </Loggers>
+
+</Configuration>


### PR DESCRIPTION
This implements the changes discussed in #937.

This does not yet expose logging of status code 4xx and 5xx in the public API.

The functionality is there, though. Everything is tested and tests broken by this change have been fixed.

I'd suggest to merge this already and discuss how it should be exposed in the public API separately.