### PR TITLE
Route Errors during DefaultPromise.then to the execution error handler

### DIFF
--- a/ratpack-core/src/main/java/ratpack/exec/internal/DefaultPromise.java
+++ b/ratpack-core/src/main/java/ratpack/exec/internal/DefaultPromise.java
@@ -41,7 +41,7 @@ public class DefaultPromise<T> implements Promise<T> {
       public void success(T value) {
         try {
           then.execute(value);
-        } catch (Exception e) {
+        } catch (Throwable e) {
           throwError(e);
         }
       }

--- a/ratpack-core/src/test/groovy/ratpack/exec/PromiseOperationsSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/exec/PromiseOperationsSpec.groovy
@@ -420,4 +420,61 @@ class PromiseOperationsSpec extends Specification {
     events == ["one", "foo", "two", "three", "oof", "four", "five", "complete"]
   }
 
+  def "exception thrown in promise consumer is routed to execution error handler"() {
+    given:
+    def ex = new Exception("!")
+
+    when:
+    exec ({
+      Promise.value("foo").onError {
+        events << "unexpected"
+      }.then {
+        throw ex
+      }
+    }, {
+      events << it
+    }
+    )
+
+    then:
+    events == [ex, "complete"]
+  }
+
+  def "unchecked exception thrown in promise consumer is routed to execution error handler"() {
+    given:
+    def ex = new RuntimeException("!")
+
+    when:
+    exec ({
+      Promise.value("foo").onError {
+        events << "unexpected"
+      }.then {
+        throw ex
+      }
+    }, {
+      events << it
+    })
+
+    then:
+    events == [ex, "complete"]
+  }
+
+  def "error thrown in promise consumer is routed to execution error handler"() {
+    given:
+    def ex = new Error("!")
+
+    when:
+    exec ({
+      Promise.value("foo").onError {
+        events << "unexpected"
+      }.then {
+        throw ex
+      }
+    }, {
+      events << it
+    })
+
+    then:
+    events == [ex, "complete"]
+  }
 }


### PR DESCRIPTION
Fixes #973 (errors in Promise.then action are routed to the promise's error handler instead of the execution's error handler) by catching Throwable instead of Exception in the implementation of Downstream.success.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/974)
<!-- Reviewable:end -->
