### PR TITLE
Add interceptors for HttpClient (#975)

### DIFF
--- a/ratpack-core/src/main/java/ratpack/http/client/HttpClientBuilder.java
+++ b/ratpack-core/src/main/java/ratpack/http/client/HttpClientBuilder.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ratpack.http.client;
+
+/**
+ * Interface for {@link HttpClient} builders.
+ */
+public interface HttpClientBuilder {
+
+  /**
+   * Configure a {@link HttpClientRequestInterceptor} for the {@link HttpClient}.
+   *
+   * @param requestInterceptor the request interceptor
+   *
+   * @return the builder.
+   */
+  HttpClientBuilder requestInterceptor(HttpClientRequestInterceptor requestInterceptor);
+
+  /**
+   * Configure a {@link HttpClientResponseInterceptor} for the {@link HttpClient}.
+   *
+   * @param responseInterceptor the response interceptor
+   *
+   * @return the builder.
+   */
+  HttpClientBuilder responseInterceptor(HttpClientResponseInterceptor responseInterceptor);
+
+  /**
+   * Configure a {@link RequestSpecConfigurer} for the {@link HttpClient}.
+   *
+   * @param requestSpecConfigurer the request configurer
+   *
+   * @return the builder.
+   */
+  HttpClientBuilder requestSpecConfigurer(RequestSpecConfigurer requestSpecConfigurer);
+
+  /**
+   * Build the {@link HttpClient} instance.
+   *
+   * @return the http client.
+   */
+  HttpClient build();
+}

--- a/ratpack-core/src/main/java/ratpack/http/client/HttpClientRequestInterceptor.java
+++ b/ratpack-core/src/main/java/ratpack/http/client/HttpClientRequestInterceptor.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ratpack.http.client;
+
+/**
+ * Functional interface for http client request interceptors.
+ */
+@FunctionalInterface
+public interface HttpClientRequestInterceptor {
+  void intercept(SentRequest request);
+}

--- a/ratpack-core/src/main/java/ratpack/http/client/HttpClientResponseInterceptor.java
+++ b/ratpack-core/src/main/java/ratpack/http/client/HttpClientResponseInterceptor.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ratpack.http.client;
+
+/**
+ * Functional interface for http client response interceptors.
+ */
+@FunctionalInterface
+public interface HttpClientResponseInterceptor {
+  void intercept(ReceivedResponse receivedResponse);
+}

--- a/ratpack-core/src/main/java/ratpack/http/client/RequestSpecConfigurer.java
+++ b/ratpack-core/src/main/java/ratpack/http/client/RequestSpecConfigurer.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ratpack.http.client;
+
+/**
+ * Functional interface for request configurer functions.
+ */
+@FunctionalInterface
+public interface RequestSpecConfigurer {
+  /**
+   * Configure the request.
+   *
+   * @param requestSpec the request spec.
+   */
+  void configure(RequestSpec requestSpec);
+}

--- a/ratpack-core/src/main/java/ratpack/http/client/SentRequest.java
+++ b/ratpack-core/src/main/java/ratpack/http/client/SentRequest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ratpack.http.client;
+
+import io.netty.handler.codec.http.HttpHeaders;
+
+/**
+ * Interface representing the HTTP request sent by {@link HttpClient}.
+ *
+ */
+public interface SentRequest {
+  /**
+   * The HTTP method.
+   * @return the method
+   */
+  String method();
+
+  /**
+   * The request uri.
+   * @return the uri.
+   */
+  String uri();
+
+  /**
+   * The request headers.
+   *
+   * @return the headers
+   */
+  HttpHeaders requestHeaders();
+
+}

--- a/ratpack-core/src/main/java/ratpack/http/client/internal/DefaultHttpClientBuilder.java
+++ b/ratpack-core/src/main/java/ratpack/http/client/internal/DefaultHttpClientBuilder.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ratpack.http.client.internal;
+
+import io.netty.buffer.ByteBufAllocator;
+import ratpack.http.client.*;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Optional;
+
+/**
+ * {@link HttpClientBuilder} implementation that creates instances of {@link DefaultHttpClient}.
+ */
+public class DefaultHttpClientBuilder implements HttpClientBuilder {
+  private final ByteBufAllocator byteBufAllocator;
+  private final int maxContentLengthBytes;
+  private final int poolSize;
+  private final Duration readTimeout;
+  /**
+   * Constructor.
+   *
+   * @param byteBufAllocator the byte buf allocator
+   * @param maxContentLengthBytes the max content length
+   * @param poolSize the pool size
+   * @param readTimeout the read timeout
+   */
+  public DefaultHttpClientBuilder(final ByteBufAllocator byteBufAllocator,
+                                  final int maxContentLengthBytes,
+                                  final int poolSize,
+                                  final Duration readTimeout) {
+    this.byteBufAllocator = byteBufAllocator;
+    this.maxContentLengthBytes = maxContentLengthBytes;
+    this.poolSize = poolSize;
+    this.readTimeout = readTimeout;
+  }
+
+  private Iterable<? extends HttpClientRequestInterceptor> requestInterceptor = Collections.emptyList();
+  private Iterable<? extends HttpClientResponseInterceptor> responseInterceptor = Collections.emptyList();
+  private Optional<RequestSpecConfigurer> requestConfigurer = Optional.empty();
+
+  @Override
+  public HttpClientBuilder requestInterceptor(final HttpClientRequestInterceptor
+                                                  requestInterceptor) {
+    this.requestInterceptor = Collections.singleton(requestInterceptor);
+    return this;
+  }
+
+  @Override
+  public HttpClientBuilder responseInterceptor(final HttpClientResponseInterceptor responseInterceptor) {
+    this.responseInterceptor = Collections.singleton(responseInterceptor);
+    return this;
+  }
+
+  @Override
+  public HttpClientBuilder requestSpecConfigurer(final RequestSpecConfigurer
+                                                     requestSpecConfigurer) {
+    this.requestConfigurer = Optional.of(requestSpecConfigurer);
+    return this;
+  }
+
+  @Override
+  public HttpClient build() {
+    return new DefaultHttpClient(
+      byteBufAllocator,
+      maxContentLengthBytes,
+      poolSize,
+      readTimeout,
+      () -> requestInterceptor,
+      () -> responseInterceptor,
+      () -> requestConfigurer);
+  }
+}

--- a/ratpack-core/src/main/java/ratpack/http/client/internal/HttpClientRequestInterceptorChain.java
+++ b/ratpack-core/src/main/java/ratpack/http/client/internal/HttpClientRequestInterceptorChain.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ratpack.http.client.internal;
+
+import ratpack.http.client.HttpClientRequestInterceptor;
+import ratpack.http.client.SentRequest;
+
+class HttpClientRequestInterceptorChain {
+  private Iterable<? extends HttpClientRequestInterceptor> interceptors;
+
+  /**
+   * Constructor.
+   *
+   * @param interceptors request interceptors
+   */
+  HttpClientRequestInterceptorChain(final Iterable<? extends HttpClientRequestInterceptor>
+                                             interceptors) {
+    this.interceptors = interceptors;
+  }
+
+  void intercept(final SentRequest request) {
+    interceptors.forEach(c -> c.intercept(new ImmutableSentRequest(request.method(),
+      request.uri(),
+      request.requestHeaders())));
+  }
+}

--- a/ratpack-core/src/main/java/ratpack/http/client/internal/HttpClientResponseInterceptorChain.java
+++ b/ratpack-core/src/main/java/ratpack/http/client/internal/HttpClientResponseInterceptorChain.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ratpack.http.client.internal;
+
+import ratpack.http.client.HttpClientResponseInterceptor;
+import ratpack.http.client.ReceivedResponse;
+
+class HttpClientResponseInterceptorChain {
+  private Iterable<? extends HttpClientResponseInterceptor> interceptors;
+
+  /**
+   * Constructor.
+   *
+   * @param interceptors response interceptors
+   */
+  HttpClientResponseInterceptorChain(final Iterable<? extends
+    HttpClientResponseInterceptor> interceptors) {
+    this.interceptors = interceptors;
+  }
+
+  void intercept(final ReceivedResponse response) {
+    interceptors.forEach(c -> c.intercept(response));
+  }
+}

--- a/ratpack-core/src/main/java/ratpack/http/client/internal/ImmutableSentRequest.java
+++ b/ratpack-core/src/main/java/ratpack/http/client/internal/ImmutableSentRequest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ratpack.http.client.internal;
+
+
+import io.netty.handler.codec.http.HttpHeaders;
+import ratpack.http.client.SentRequest;
+
+class ImmutableSentRequest implements SentRequest {
+  private final String method;
+  private final String uri;
+  private final HttpHeaders headers;
+
+  /**
+   * Constructor.
+   *
+   * @param method the method
+   * @param uri the uri
+   * @param headers the headers
+   */
+  ImmutableSentRequest(final String method, final String uri, final HttpHeaders headers) {
+    this.method = method;
+    this.uri = uri;
+    this.headers = headers;
+  }
+
+  @Override
+  public String method() {
+    return null;
+  }
+
+  @Override
+  public String uri() {
+    return null;
+  }
+
+  @Override
+  public HttpHeaders requestHeaders() {
+    return null;
+  }
+}

--- a/ratpack-core/src/main/java/ratpack/http/client/internal/RequestActionSupport.java
+++ b/ratpack-core/src/main/java/ratpack/http/client/internal/RequestActionSupport.java
@@ -42,6 +42,7 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import java.net.URI;
 import java.security.NoSuchAlgorithmException;
+import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
@@ -64,11 +65,16 @@ abstract class RequestActionSupport<T> implements Upstream<T> {
   private ChannelPool channelPool;
   private final int redirectCount;
   private final Action<? super RequestSpec> requestConfigurer;
+  private final HttpClientRequestInterceptorChain requestInterceptorChain;
 
   private boolean fired;
   private boolean disposed;
 
   RequestActionSupport(URI uri, HttpClientInternal client, int redirectCount, Execution execution, Action<? super RequestSpec> requestConfigurer) {
+    this(uri, client, redirectCount, execution, requestConfigurer, new HttpClientRequestInterceptorChain(Collections.emptyList()));
+  }
+
+  RequestActionSupport(URI uri, HttpClientInternal client, int redirectCount, Execution execution, Action<? super RequestSpec> requestConfigurer, HttpClientRequestInterceptorChain requestInterceptorChain) {
     this.requestConfigurer = requestConfigurer;
     this.requestConfig = uncheck(() -> RequestConfig.of(uri, client, requestConfigurer));
     this.client = client;
@@ -76,7 +82,7 @@ abstract class RequestActionSupport<T> implements Upstream<T> {
     this.redirectCount = redirectCount;
     this.channelKey = new HttpChannelKey(requestConfig.uri, requestConfig.connectTimeout, execution);
     this.channelPool = client.getChannelPoolMap().get(channelKey);
-
+    this.requestInterceptorChain = requestInterceptorChain;
     finalizeHeaders();
   }
 
@@ -110,7 +116,7 @@ abstract class RequestActionSupport<T> implements Upstream<T> {
 
   private void send(Downstream<? super T> downstream, Channel channel) throws Exception {
     channel.config().setAutoRead(true);
-
+    
     FullHttpRequest request = new DefaultFullHttpRequest(
       HttpVersion.HTTP_1_1,
       requestConfig.method.getNettyMethod(),
@@ -123,6 +129,9 @@ abstract class RequestActionSupport<T> implements Upstream<T> {
     addCommonResponseHandlers(channel.pipeline(), downstream);
 
     channel.writeAndFlush(request).addListener(writeFuture -> {
+      //invoke the request interceptor
+      requestInterceptorChain.intercept(new ImmutableSentRequest(request.method().name(),
+        request.uri(), request.headers()));
       if (!writeFuture.isSuccess()) {
         error(downstream, writeFuture.cause());
       }

--- a/ratpack-core/src/main/java/ratpack/server/internal/ServerRegistry.java
+++ b/ratpack-core/src/main/java/ratpack/server/internal/ServerRegistry.java
@@ -42,6 +42,8 @@ import ratpack.handling.RequestId;
 import ratpack.handling.internal.UuidBasedRequestIdGenerator;
 import ratpack.health.internal.HealthCheckResultsRenderer;
 import ratpack.http.client.HttpClient;
+import ratpack.http.client.HttpClientBuilder;
+import ratpack.http.client.internal.DefaultHttpClientBuilder;
 import ratpack.impose.Impositions;
 import ratpack.jackson.internal.JsonParser;
 import ratpack.jackson.internal.JsonRenderer;
@@ -52,6 +54,7 @@ import ratpack.server.*;
 import ratpack.sse.ServerSentEventStreamClient;
 
 import java.time.Clock;
+import java.time.Duration;
 import java.util.Optional;
 
 import static ratpack.util.Exceptions.uncheck;
@@ -123,6 +126,7 @@ public abstract class ServerRegistry {
           return null;
         }))
         .add(HttpClient.class, httpClient)
+        .add(HttpClientBuilder.class, new DefaultHttpClientBuilder(PooledByteBufAllocator.DEFAULT, serverConfig.getMaxContentLength(), 0, Duration.ofSeconds(30)))
         .add(ServerSentEventStreamClient.class, ServerSentEventStreamClient.of(httpClient))
         .add(HealthCheckResultsRenderer.TYPE, new HealthCheckResultsRenderer(PooledByteBufAllocator.DEFAULT))
         .add(RequestId.Generator.class, UuidBasedRequestIdGenerator.INSTANCE);

--- a/ratpack-core/src/test/groovy/ratpack/http/client/HttpClientInterceptorSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/http/client/HttpClientInterceptorSpec.groovy
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ratpack.http.client
+import spock.lang.Unroll
+
+/**
+ * Test suite for request/response interceptors for {@link HttpClient}
+ */
+class HttpClientInterceptorSpec extends BaseHttpClientSpec {
+
+  @Unroll
+  def "can intercept #method request and response with single binding"() {
+    given:
+    otherApp {
+      get("foo") { ctx ->
+        render "bar"
+      }
+    }
+    def requestInterceptor = Mock(HttpClientRequestInterceptor)
+    def responseInterceptor = Mock(HttpClientResponseInterceptor)
+    when:
+
+    handlers {
+      get { ctx ->
+        ctx.execution.add(HttpClientRequestInterceptor, requestInterceptor)
+        ctx.execution.add(HttpClientResponseInterceptor, responseInterceptor)
+        def httpClient = ctx.get(HttpClient)
+        httpClient.get(otherAppUrl("foo")) {
+        } then { ReceivedResponse response ->
+          render response.body.text
+        }
+      }
+    }
+    text
+    then:
+    1 * requestInterceptor.intercept(_ as SentRequest)
+    1 * responseInterceptor.intercept(_ as ReceivedResponse)
+    where:
+    method << ["GET", "PUT", "POST", "DELETE", "PATCH"]
+  }
+
+  @Unroll
+  def "can intercept #method request and response with multiple bindings"() {
+    given:
+    otherApp {
+      get("foo") { ctx ->
+        render "bar"
+      }
+    }
+    def requestInterceptorA = Mock(HttpClientRequestInterceptor)
+    def requestInterceptorB = Mock(HttpClientRequestInterceptor)
+    def responseInterceptorA = Mock(HttpClientResponseInterceptor)
+    def responseInterceptorB = Mock(HttpClientResponseInterceptor)
+    when:
+
+    handlers {
+      get { ctx ->
+        ctx.execution.add(HttpClientRequestInterceptor, requestInterceptorA)
+        ctx.execution.add(HttpClientResponseInterceptor, responseInterceptorA)
+        ctx.execution.add(HttpClientRequestInterceptor, requestInterceptorB)
+        ctx.execution.add(HttpClientResponseInterceptor, responseInterceptorB)
+        def httpClient = ctx.get(HttpClient)
+        httpClient.get(otherAppUrl("foo")) {
+        } then { ReceivedResponse response ->
+          render response.body.text
+        }
+      }
+    }
+    text
+    then:
+    1 * requestInterceptorA.intercept(_ as SentRequest)
+    1 * responseInterceptorA.intercept(_ as ReceivedResponse)
+    1 * requestInterceptorB.intercept(_ as SentRequest)
+    1 * responseInterceptorB.intercept(_ as ReceivedResponse)
+    where:
+    method << ["GET", "PUT", "POST", "DELETE", "PATCH"]
+  }
+
+  @Unroll
+  def "can intercept #method request and response with client builder"() {
+    given:
+    otherApp {
+      get("foo") { ctx ->
+        render "bar"
+      }
+    }
+    def requestInterceptor = Mock(HttpClientRequestInterceptor)
+    def responseInterceptor = Mock(HttpClientResponseInterceptor)
+    when:
+
+    handlers {
+      get { ctx ->
+        def factory = ctx.get(HttpClientBuilder)
+        def httpClient = factory
+          .requestInterceptor(requestInterceptor)
+          .responseInterceptor(responseInterceptor)
+          .build()
+        httpClient.get(otherAppUrl("foo")) {
+        } then { ReceivedResponse response ->
+          render response.body.text
+        }
+      }
+    }
+    text
+    then:
+    1 * requestInterceptor.intercept(_ as SentRequest)
+    1 * responseInterceptor.intercept(_ as ReceivedResponse)
+    where:
+    method << ["GET", "PUT", "POST", "DELETE", "PATCH"]
+  }
+  @Unroll
+  def "can confgure #method"() {
+    given:
+    otherApp {
+      get("foo") { ctx ->
+        render "bar"
+      }
+    }
+    def requestConfigurer = Mock(RequestSpecConfigurer)
+    when:
+
+    handlers {
+      get { ctx ->
+        ctx.execution.add(RequestSpecConfigurer, requestConfigurer)
+        def httpClient = ctx.get(HttpClient)
+        httpClient.get(otherAppUrl("foo")) {
+        } then { ReceivedResponse response ->
+          render response.body.text
+        }
+      }
+    }
+    text
+    then:
+    1 * requestConfigurer.configure(_ as RequestSpec)
+    where:
+    method << ["GET", "PUT", "POST", "DELETE", "PATCH"]
+  }
+  @Unroll
+  def "can configure #method request via builder"() {
+    given:
+    otherApp {
+      get("foo") { ctx ->
+        render "bar"
+      }
+    }
+    def requestConfigurer = Mock(RequestSpecConfigurer)
+    when:
+
+    handlers {
+      get { ctx ->
+        def factory = ctx.get(HttpClientBuilder)
+        def httpClient = factory
+          .requestSpecConfigurer(requestConfigurer)
+          .build()
+        httpClient.get(otherAppUrl("foo")) {
+        } then { ReceivedResponse response ->
+          render response.body.text
+        }
+      }
+    }
+    text
+    then:
+    1 * requestConfigurer.configure(_ as RequestSpec)
+    where:
+    method << ["GET", "PUT", "POST", "DELETE", "PATCH"]
+  }
+}

--- a/ratpack-core/src/test/groovy/ratpack/http/client/HttpClientSmokeSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/http/client/HttpClientSmokeSpec.groovy
@@ -831,5 +831,4 @@ BAR
     and:
     pathResponse.status.code == 404
   }
-
 }

--- a/ratpack-core/src/test/groovy/ratpack/http/client/internal/HttpClientRequestInterceptorChainSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/http/client/internal/HttpClientRequestInterceptorChainSpec.groovy
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ratpack.http.client.internal
+
+import com.google.common.collect.Lists
+import ratpack.http.client.HttpClientRequestInterceptor
+import ratpack.http.client.SentRequest
+import spock.lang.Specification
+
+
+class HttpClientRequestInterceptorChainSpec extends Specification {
+  def 'Should invoke all interceptors'() {
+    given:
+    def interceptorA = Mock(HttpClientRequestInterceptor)
+    def interceptorB = Mock(HttpClientRequestInterceptor)
+    def chain = new HttpClientRequestInterceptorChain(Lists
+      .newArrayList(interceptorA, interceptorB))
+    when:
+    chain.intercept(Stub(SentRequest))
+    then:
+    1 * interceptorA.intercept(_ as SentRequest)
+    1 * interceptorB.intercept(_ as SentRequest)
+  }
+}

--- a/ratpack-core/src/test/groovy/ratpack/http/client/internal/HttpClientResponseInterceptorChainSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/http/client/internal/HttpClientResponseInterceptorChainSpec.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ratpack.http.client.internal
+
+import com.google.common.collect.Lists
+import ratpack.http.client.HttpClientResponseInterceptor
+import ratpack.http.client.ReceivedResponse
+import spock.lang.Specification
+
+class HttpClientResponseInterceptorChainSpec extends Specification {
+  def 'Should invoke all interceptors'() {
+    given:
+    def interceptorA = Mock(HttpClientResponseInterceptor)
+    def interceptorB = Mock(HttpClientResponseInterceptor)
+    def chain = new HttpClientResponseInterceptorChain(Lists
+      .newArrayList(interceptorA, interceptorB))
+    when:
+    chain.intercept(Stub(ReceivedResponse))
+    then:
+    1 * interceptorA.intercept(_ as ReceivedResponse)
+    1 * interceptorB.intercept(_ as ReceivedResponse)
+  }
+}


### PR DESCRIPTION
Ref: https://github.com/ratpack/ratpack/issues/975

Probably still needs some work, but I wanted to get some feedback on this before taking it much further.

I've added a couple of "hooks" that allow intercepting the sent request and received response. These hooks (currently) don't permit modification of either the request or the response - they're intended as "wiretaps" (which would be fine for my original use case).

Re. this (https://github.com/ratpack/ratpack/issues/975#issuecomment-216666556) bit of feedback, I've also added a hook that allows you to customize the `RequestSpec` all requests (e.g. add a header on all requests).

These interceptors can bound in the registry, in which case they'll apply "globally" for all `HttpClient` instance. I've also added a builder class for `HttpClient` instances so that you can apply interceptors for a specific instance of `HttpClient`.

I had some trouble with the unit tests in that I wasn't able to use `bindings { ... }` to bind my interceptors.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/979)

<!-- Reviewable:end -->
