### PR TITLE
Fixes broken javadoc links for Guava

### DIFF
--- a/ratpack-manual/src/content/chapters/35-config.md
+++ b/ratpack-manual/src/content/chapters/35-config.md
@@ -20,7 +20,7 @@ To get started:
 [`ConfigDataBuilder`](api/ratpack/config/ConfigDataBuilder.html) provides methods to easily load data from the most common sources.
 
 Commonly used file formats can be used via the [`yaml`](api/ratpack/config/ConfigDataBuilder.html#yaml-java.lang.String-), [`json`](api/ratpack/config/ConfigDataBuilder.html#json-java.lang.String-) and [`props`](api/ratpack/config/ConfigDataBuilder.html#props-java.lang.String-) methods.
-The provided signatures can be used to load data from local files (`String` or `Path`), over the network (`URL`), from the classpath (use [`Resources.getResource(String)`](http://docs.guava-libraries.googlecode.com/git/javadoc/com/google/common/io/Resources.html) to get a `URL`), or anywhere else you can treat as a [`ByteSource`](http://docs.guava-libraries.googlecode.com/git/javadoc/com/google/common/io/ByteSource.html).
+The provided signatures can be used to load data from local files (`String` or `Path`), over the network (`URL`), from the classpath (use [`Resources.getResource(String)`](http://google.github.io/guava/releases/18.0/api/docs/com/google/common/io/Resources.html) to get a `URL`), or anywhere else you can treat as a [`ByteSource`](http://google.github.io/guava/releases/18.0/api/docs/com/google/common/io/ByteSource.html).
 Additionally, you can load data from non-file sources such as `Map`s/`Properties` objects (particularly useful for default values; see [example](api/ratpack/config/ConfigDataBuilder.html#props-java.util.Map-)), system properties, and environment variables.
 If additional flexibility is needed, you can provide your own [`ConfigSource`](api/ratpack/config/ConfigSource.html) implementation.
 


### PR DESCRIPTION
Looks like the Guava javadocs have moved to Github(?), so a couple of the links in the docs (https://ratpack.io/manual/current/config.html) broke...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/980)
<!-- Reviewable:end -->
