### PR TITLE
Fixes #960 - typo in steams chapter

### DIFF
--- a/ratpack-manual/src/content/chapters/15-streams.md
+++ b/ratpack-manual/src/content/chapters/15-streams.md
@@ -18,7 +18,7 @@ Ratpack provides some useful utilities for dealing with streams via its [`Stream
 
 ### Back pressure
 
-A key tenant of the Reactive Streams API is support for flow control via back pressure.
+A key tenet of the Reactive Streams API is support for flow control via back pressure.
 This allows stream subscribers, which in the case of a HTTP server app is usually the HTTP client, to communicate to the publisher how much data they can handle.
 In extreme cases, without back pressure a slowly consuming client can exhaust resources on the server as the data producer produces data faster than it is being consumed, potentially filling up in memory buffers.
 Back pressure allows the data producer to match its rate of production with what the client can handle.


### PR DESCRIPTION
This fixes #960

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/985)
<!-- Reviewable:end -->
