### PR TITLE
Exposing max initial line length and max header size.

### DIFF
--- a/ratpack-core/src/main/java/ratpack/config/internal/module/ServerConfigDataDeserializer.java
+++ b/ratpack-core/src/main/java/ratpack/config/internal/module/ServerConfigDataDeserializer.java
@@ -79,6 +79,12 @@ public class ServerConfigDataDeserializer extends JsonDeserializer<ServerConfigD
     if (serverNode.hasNonNull("maxChunkSize")) {
       data.setMaxChunkSize(serverNode.get("maxChunkSize").asInt(ServerConfig.DEFAULT_MAX_CHUNK_SIZE));
     }
+    if (serverNode.hasNonNull("maxInitialLineLength")) {
+      data.setMaxInitialLineLength(serverNode.get("maxInitialLineLength").asInt(ServerConfig.DEFAULT_MAX_INITIAL_LINE_LENGTH));
+    }
+    if (serverNode.hasNonNull("maxHeaderSize")) {
+      data.setMaxHeaderSize(serverNode.get("maxHeaderSize").asInt(ServerConfig.DEFAULT_MAX_HEADER_SIZE));
+    }
     if (serverNode.hasNonNull("ssl")) {
       data.setSslContext(toValue(codec, serverNode.get("ssl"), SSLContext.class));
     }

--- a/ratpack-core/src/main/java/ratpack/server/ServerConfig.java
+++ b/ratpack-core/src/main/java/ratpack/server/ServerConfig.java
@@ -84,6 +84,7 @@ public interface ServerConfig extends ConfigData {
    * Defaults to {@value}
    *
    * @see #getMaxInitialLineLength()
+   * @since 1.4
    */
   int DEFAULT_MAX_INITIAL_LINE_LENGTH = 4096;
 
@@ -93,6 +94,7 @@ public interface ServerConfig extends ConfigData {
    * Defaults to {@value}
    *
    * @see #getMaxHeaderSize()
+   * @since 1.4
    */
   int DEFAULT_MAX_HEADER_SIZE = 8192;
 
@@ -260,13 +262,13 @@ public interface ServerConfig extends ConfigData {
    * The maximum initial line length allowed for reading http requests.
    * <p>
    * This value is used to determine the maximum allowed length for the initial line of an http request.
-   * A lower value will reduce memory pressure by requiring less memory at one time,
    * <p>
    * Defaults to {@link #DEFAULT_MAX_INITIAL_LINE_LENGTH}.
    * This value is suitable for most applications.
    * If your application deals with very large request URIs, you may want to increase it.
    *
    * @return the maximum initial line length allowed for http requests.
+   * @since 1.4
    */
   int getMaxInitialLineLength();
 
@@ -274,13 +276,13 @@ public interface ServerConfig extends ConfigData {
    * The maximum size of all headers allowed for reading http requests.
    * <p>
    * This value is used to determine the maximum allowed size for the sum of the length all headers of an http request.
-   * A lower value will reduce memory pressure by requiring less memory at one time,
    * <p>
    * Defaults to {@link #DEFAULT_MAX_HEADER_SIZE}.
    * This value is suitable for most applications.
    * If your application deals with very large http headers, you may want to increase it.
    *
    * @return the maximum size of http headers allowed for an incoming http requests.
+   * @since 1.4
    */
   int getMaxHeaderSize();
 

--- a/ratpack-core/src/main/java/ratpack/server/ServerConfig.java
+++ b/ratpack-core/src/main/java/ratpack/server/ServerConfig.java
@@ -79,6 +79,24 @@ public interface ServerConfig extends ConfigData {
   int DEFAULT_MAX_CHUNK_SIZE = 8192;
 
   /**
+   * The default maximum initial line length to use when reading requests.
+   * <p>
+   * Defaults to {@value}
+   *
+   * @see #getMaxInitialLineLength()
+   */
+  int DEFAULT_MAX_INITIAL_LINE_LENGTH = 4096;
+
+  /**
+   * The default maximum header size to use when reading requests.
+   * <p>
+   * Defaults to {@value}
+   *
+   * @see #getMaxHeaderSize()
+   */
+  int DEFAULT_MAX_HEADER_SIZE = 8192;
+
+  /**
    * Creates a builder configured for development mode and an ephemeral port.
    *
    * @return a server config builder
@@ -237,6 +255,34 @@ public interface ServerConfig extends ConfigData {
    * @return the maximum chunk size
    */
   int getMaxChunkSize();
+
+  /**
+   * The maximum initial line length allowed for reading http requests.
+   * <p>
+   * This value is used to determine the maximum allowed length for the initial line of an http request.
+   * A lower value will reduce memory pressure by requiring less memory at one time,
+   * <p>
+   * Defaults to {@link #DEFAULT_MAX_INITIAL_LINE_LENGTH}.
+   * This value is suitable for most applications.
+   * If your application deals with very large request URIs, you may want to increase it.
+   *
+   * @return the maximum initial line length allowed for http requests.
+   */
+  int getMaxInitialLineLength();
+
+  /**
+   * The maximum size of all headers allowed for reading http requests.
+   * <p>
+   * This value is used to determine the maximum allowed size for the sum of the length all headers of an http request.
+   * A lower value will reduce memory pressure by requiring less memory at one time,
+   * <p>
+   * Defaults to {@link #DEFAULT_MAX_HEADER_SIZE}.
+   * This value is suitable for most applications.
+   * If your application deals with very large http headers, you may want to increase it.
+   *
+   * @return the maximum size of http headers allowed for an incoming http requests.
+   */
+  int getMaxHeaderSize();
 
   /**
    * The base dir of the application, which is also the initial {@link ratpack.file.FileSystemBinding}.

--- a/ratpack-core/src/main/java/ratpack/server/ServerConfigBuilder.java
+++ b/ratpack-core/src/main/java/ratpack/server/ServerConfigBuilder.java
@@ -148,6 +148,28 @@ public interface ServerConfigBuilder extends ConfigDataBuilder {
   ServerConfigBuilder maxChunkSize(int maxChunkSize);
 
   /**
+   * The maximum initial line length allowed for reading http requests.
+   *
+   * Default value is {@link ServerConfig#DEFAULT_MAX_INITIAL_LINE_LENGTH}.
+   *
+   * @param maxInitialLineLength the maximum length of the initial line of the request.
+   * @return {@code this}
+   * @see ServerConfig#getMaxInitialLineLength()
+   */
+  ServerConfigBuilder maxInitialLineLength(int maxInitialLineLength);
+
+  /**
+   * The maximum size of all headers allowed for reading http requests.
+   *
+   * Default value is {@link ServerConfig#DEFAULT_MAX_HEADER_SIZE}.
+   *
+   * @param maxHeaderSize the maximum size of the sum of the length of all headers.
+   * @return {@code this}
+   * @see ServerConfig#getMaxHeaderSize()
+   */
+  ServerConfigBuilder maxHeaderSize(int maxHeaderSize);
+
+  /**
    * The connect timeout of the channel.
    *
    * @param connectTimeoutMillis the connect timeout in milliseconds

--- a/ratpack-core/src/main/java/ratpack/server/ServerConfigBuilder.java
+++ b/ratpack-core/src/main/java/ratpack/server/ServerConfigBuilder.java
@@ -155,6 +155,7 @@ public interface ServerConfigBuilder extends ConfigDataBuilder {
    * @param maxInitialLineLength the maximum length of the initial line of the request.
    * @return {@code this}
    * @see ServerConfig#getMaxInitialLineLength()
+   * @since 1.4
    */
   ServerConfigBuilder maxInitialLineLength(int maxInitialLineLength);
 
@@ -166,6 +167,7 @@ public interface ServerConfigBuilder extends ConfigDataBuilder {
    * @param maxHeaderSize the maximum size of the sum of the length of all headers.
    * @return {@code this}
    * @see ServerConfig#getMaxHeaderSize()
+   * @since 1.4
    */
   ServerConfigBuilder maxHeaderSize(int maxHeaderSize);
 

--- a/ratpack-core/src/main/java/ratpack/server/internal/DefaultRatpackServer.java
+++ b/ratpack-core/src/main/java/ratpack/server/internal/DefaultRatpackServer.java
@@ -247,7 +247,8 @@ public class DefaultRatpackServer implements RatpackServer {
             serverConfig.getMaxInitialLineLength(),
             serverConfig.getMaxHeaderSize(),
             serverConfig.getMaxChunkSize(),
-            false));
+            false)
+          );
           pipeline.addLast("encoder", new HttpResponseEncoder());
           pipeline.addLast("deflater", new IgnorableHttpContentCompressor());
           pipeline.addLast("chunkedWriter", new ChunkedWriteHandler());

--- a/ratpack-core/src/main/java/ratpack/server/internal/DefaultRatpackServer.java
+++ b/ratpack-core/src/main/java/ratpack/server/internal/DefaultRatpackServer.java
@@ -243,7 +243,11 @@ public class DefaultRatpackServer implements RatpackServer {
             pipeline.addLast("ssl", new SslHandler(sslEngine));
           }
 
-          pipeline.addLast("decoder", new HttpRequestDecoder(4096, 8192, serverConfig.getMaxChunkSize(), false));
+          pipeline.addLast("decoder", new HttpRequestDecoder(
+            serverConfig.getMaxInitialLineLength(),
+            serverConfig.getMaxHeaderSize(),
+            serverConfig.getMaxChunkSize(),
+            false));
           pipeline.addLast("encoder", new HttpResponseEncoder());
           pipeline.addLast("deflater", new IgnorableHttpContentCompressor());
           pipeline.addLast("chunkedWriter", new ChunkedWriteHandler());

--- a/ratpack-core/src/main/java/ratpack/server/internal/DefaultServerConfig.java
+++ b/ratpack-core/src/main/java/ratpack/server/internal/DefaultServerConfig.java
@@ -101,6 +101,16 @@ public class DefaultServerConfig extends DelegatingConfigData implements ServerC
   }
 
   @Override
+  public int getMaxInitialLineLength() {
+    return serverConfigData.getMaxInitialLineLength();
+  }
+
+  @Override
+  public int getMaxHeaderSize() {
+    return serverConfigData.getMaxHeaderSize();
+  }
+
+  @Override
   public FileSystemBinding getBaseDir() throws NoBaseDirException {
     return baseDir.orElseThrow(() -> new NoBaseDirException("No base dir has been set"));
   }

--- a/ratpack-core/src/main/java/ratpack/server/internal/DefaultServerConfigBuilder.java
+++ b/ratpack-core/src/main/java/ratpack/server/internal/DefaultServerConfigBuilder.java
@@ -139,6 +139,16 @@ public class DefaultServerConfigBuilder implements ServerConfigBuilder {
   }
 
   @Override
+  public ServerConfigBuilder maxInitialLineLength(int maxInitialLineLength) {
+    return addToServer(n -> n.put("maxInitialLineLength", maxInitialLineLength));
+  }
+
+  @Override
+  public ServerConfigBuilder maxHeaderSize(int maxHeaderSize) {
+    return addToServer(n -> n.put("maxHeaderSize", maxHeaderSize));
+  }
+
+  @Override
   public ServerConfigBuilder connectTimeoutMillis(int connectTimeoutMillis) {
     return addToServer(n -> n.put("connectTimeoutMillis", connectTimeoutMillis));
   }

--- a/ratpack-core/src/main/java/ratpack/server/internal/ServerConfigData.java
+++ b/ratpack-core/src/main/java/ratpack/server/internal/ServerConfigData.java
@@ -42,6 +42,8 @@ public class ServerConfigData {
   private Optional<Integer> receiveBufferSize = Optional.empty();
   private Optional<Integer> writeSpinCount = Optional.empty();
   private int maxChunkSize = ServerConfig.DEFAULT_MAX_CHUNK_SIZE;
+  private int maxInitialLineLength = ServerConfig.DEFAULT_MAX_INITIAL_LINE_LENGTH;
+  private int maxHeaderSize = ServerConfig.DEFAULT_MAX_HEADER_SIZE;
 
   public ServerConfigData(FileSystemBinding baseDir, int port, boolean development, URI publicAddress) {
     this.baseDir = baseDir;
@@ -154,6 +156,22 @@ public class ServerConfigData {
     this.writeSpinCount = Optional.of(writeSpinCount);
   }
 
+  public int getMaxInitialLineLength() {
+    return maxInitialLineLength;
+  }
+
+  public void setMaxInitialLineLength(final int maxInitialLineLength) {
+    this.maxInitialLineLength = maxInitialLineLength;
+  }
+
+  public int getMaxHeaderSize() {
+    return maxHeaderSize;
+  }
+
+  public void setMaxHeaderSize(final int maxHeaderSize) {
+    this.maxHeaderSize = maxHeaderSize;
+  }
+
   public int getMaxChunkSize() {
     return maxChunkSize;
   }
@@ -165,4 +183,5 @@ public class ServerConfigData {
   public FileSystemBinding getBaseDir() {
     return baseDir;
   }
+
 }

--- a/ratpack-core/src/test/groovy/ratpack/server/ServerConfigBuilderSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/server/ServerConfigBuilderSpec.groovy
@@ -133,6 +133,36 @@ class ServerConfigBuilderSpec extends Specification {
     builder.maxContentLength(256).build().maxContentLength == 256
   }
 
+  def "new builder has default max chunk size"() {
+    expect:
+    builder.build().maxChunkSize == ServerConfig.DEFAULT_MAX_CHUNK_SIZE
+  }
+
+  def "set max chunk size"() {
+    expect:
+    builder.maxChunkSize(256).build().maxChunkSize == 256
+  }
+
+  def "new builder has default max initial line length"() {
+    expect:
+    builder.build().maxInitialLineLength == ServerConfig.DEFAULT_MAX_INITIAL_LINE_LENGTH
+  }
+
+  def "set max initial line length"() {
+    expect:
+    builder.maxInitialLineLength(256).build().maxInitialLineLength == 256
+  }
+
+  def "new builder has default max header size"() {
+    expect:
+    builder.build().maxHeaderSize == ServerConfig.DEFAULT_MAX_HEADER_SIZE
+  }
+
+  def "set max header size"() {
+    expect:
+    builder.maxHeaderSize(256).build().maxHeaderSize == 256
+  }
+
   def "set ssl context"() {
     given:
     SSLContext context = SSLContexts.sslContext(ServerConfigBuilderSpec.classLoader.getResourceAsStream('ratpack/launch/internal/keystore.jks'), 'password')


### PR DESCRIPTION
Exposing additional constructor parameters of Netty's HttpRequestDecoder as configuration options through the ServerConfig and ServerConfigBuilder.

The default values for `maxInitialLineLength` and `maxHeaderSize` are 4096 and 8192, respectively. These were the initial values hard coded in `DefaultRatpackServer` as well as the defaults for Netty itself.

I tried to follow how this was done for `maxChunkSize`, which was already exposed. It was, however, untested, so I added tests for configuring `maxChunkSize` as well as for `maxInitialLineLength` and `maxHeaderSize`.

This pull request is to resolve issue #1004.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1009)
<!-- Reviewable:end -->
