### PR TITLE
Re-enable failOnVersionConflict().

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -35,6 +35,10 @@ ext {
     springBoot: "1.3.0.RELEASE",
     caffeine: "2.2.6",
     retrofit: "2.0.2",
+    commonsLogging: "1.2",
+    commonsCodec: "1.10",
+    xmlApis: "1.4.01",
+    snakeyaml: "1.15",
   ]
 
   if (System.getenv('CI_GROOVY_VERSION')) {
@@ -66,11 +70,20 @@ ext {
     }),
     groovy: "org.codehaus.groovy:groovy-all:${commonVersions.groovy}",
     guava: "com.google.guava:guava:$commonVersions.guava",
-    remote: "io.remotecontrol:remote-core:${commonVersions.remote}",
-    "remote-http": "io.remotecontrol:remote-transport-http:${commonVersions.remote}",
+    rxjava: "io.reactivex:rxjava:$commonVersions.rxjava",
+    remote: dependencies.create("io.remotecontrol:remote-core:${commonVersions.remote}", {
+      exclude group: "org.codehaus.groovy", module: "groovy-all"
+    }),
+    remoteHttp: dependencies.create("io.remotecontrol:remote-transport-http:${commonVersions.remote}", {
+      exclude group: "org.codehaus.groovy", module: "groovy-all"
+    }),
     jackson: "com.fasterxml.jackson.core:jackson-databind:${commonVersions.jackson}",
     slf4j: "org.slf4j:slf4j-api:${commonVersions.slf4j}",
     h2: "com.h2database:h2:1.4.186",
+    toolingApi: dependencies.create("org.gradle:gradle-tooling-api:${gradle.gradleVersion}", {
+      exclude group: "org.slf4j", module: "slf4j-api"
+    }),
+    snakeyaml: "org.yaml:snakeyaml:${commonVersions.snakeyaml}",
     compass: [
       dependencies.create("rubygems:compass:1.0.3"),
       dependencies.create("rubygems:chunky_png:1.2.9", {

--- a/gradle/dependencyRules.gradle
+++ b/gradle/dependencyRules.gradle
@@ -1,12 +1,28 @@
 configurations.all { configuration ->
   resolutionStrategy {
-    // failOnVersionConflict()
+    gradle.taskGraph.whenReady { taskGraph ->
+      if (taskGraph.allTasks.every { it.name != "dependencies" } ) {
+        failOnVersionConflict()
+      }
+    }
 
     eachDependency {
       // Spock brings in both 1.1 and 1.3 of this guy, so force 1.1 to 1.3.
       // Excludes aren't ideal because it's spock bringing in both of these
       if (requested.name == "hamcrest-core" && requested.version == "1.1") {
         useVersion "1.3"
+      }
+      // JRuby (used by the manual) pulls in multiple versions of a few modules
+      if (configuration.name == "jrubyExec") {
+        if (requested.name == "jcodings" && requested.group == "org.jruby.jcodings") {
+          useVersion "1.0.10"
+        }
+        if (requested.name == "jnr-ffi" && requested.group == "com.github.jnr") {
+          useVersion "1.0.10"
+        }
+        if (requested.name == "jnr-constants" && requested.group == "com.github.jnr") {
+          useVersion "0.8.5"
+        }
       }
       if (configuration.name == "codenarc") {
         if (requested.group == "org.codehaus.groovy") {

--- a/perf/perf.gradle
+++ b/perf/perf.gradle
@@ -24,7 +24,7 @@ configurations {
 
 dependencies {
   compile commonDependencies.groovy
-  compile "org.gradle:gradle-tooling-api:${gradle.gradleVersion}"
+  compile commonDependencies.toolingApi
   compile "org.slf4j:slf4j-simple:${commonVersions.slf4j}"
   testCompile commonDependencies.spock
 }

--- a/ratpack-core/ratpack-core.gradle
+++ b/ratpack-core/ratpack-core.gradle
@@ -44,15 +44,29 @@ dependencies {
 
   compile commonDependencies.jackson
   compile "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${commonVersions.jackson}"
-  compile "com.fasterxml.jackson.datatype:jackson-datatype-guava:${commonVersions.jackson}"
+  compile("com.fasterxml.jackson.datatype:jackson-datatype-guava:${commonVersions.jackson}") {
+    exclude group: "com.google.guava", module: "guava"
+    exclude group: "org.yaml", module: "snakeyaml"
+  }
+  compile commonDependencies.snakeyaml
   compile "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${commonVersions.jackson}"
   compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${commonVersions.jackson}"
 
   testCompile 'org.apache.commons:commons-lang3:3.3.2'
-  testCompile "org.reactivestreams:reactive-streams-tck:${commonVersions.reactiveStreams}"
-  testCompile 'org.mockito:mockito-core:1.10.19'
+  testCompile("org.reactivestreams:reactive-streams-tck:${commonVersions.reactiveStreams}") {
+    exclude group: "junit", module: "junit"
+    exclude group: "org.yaml", module: "snakeyaml"
+  }
+  testCompile('org.mockito:mockito-core:1.10.19') {
+    exclude group: "org.hamcrest", module: "hamcrest-core"
+  }
   testCompile 'com.opencsv:opencsv:3.3'
-  testCompile 'com.github.tomakehurst:wiremock:1.56'
+  testCompile('com.github.tomakehurst:wiremock:1.56') {
+    exclude group: "org.slf4j", module: "slf4j-api"
+    exclude group: "com.fasterxml.jackson.core", module: "jackson-annotations"
+    exclude group: "com.fasterxml.jackson.core", module: "jackson-core"
+    exclude group: "com.fasterxml.jackson.core", module: "jackson-databind"
+  }
 }
 
 test {

--- a/ratpack-dropwizard-metrics/ratpack-dropwizard-metrics.gradle
+++ b/ratpack-dropwizard-metrics/ratpack-dropwizard-metrics.gradle
@@ -22,11 +22,23 @@ dependencies {
   compile project(":ratpack-core")
   compile project(":ratpack-guice")
 
-  compile "io.dropwizard.metrics:metrics-core:${commonVersions.dropwizardMetrics}"
-  compile "io.dropwizard.metrics:metrics-json:${commonVersions.dropwizardMetrics}"
-  compile "io.dropwizard.metrics:metrics-healthchecks:${commonVersions.dropwizardMetrics}"
-  compile "io.dropwizard.metrics:metrics-jvm:${commonVersions.dropwizardMetrics}"
-  compile "io.dropwizard.metrics:metrics-annotation:${commonVersions.dropwizardMetrics}"
-  compile "io.dropwizard.metrics:metrics-graphite:${commonVersions.dropwizardMetrics}"
+  compile("io.dropwizard.metrics:metrics-core:${commonVersions.dropwizardMetrics}") {
+    exclude group: "org.slf4j", module: "slf4j-api"
+  }
+  compile("io.dropwizard.metrics:metrics-json:${commonVersions.dropwizardMetrics}") {
+    exclude group: "org.slf4j", module: "slf4j-api"
+    exclude group: "com.fasterxml.jackson.core", module: "jackson-databind"
+  }
+  compile("io.dropwizard.metrics:metrics-healthchecks:${commonVersions.dropwizardMetrics}") {
+    exclude group: "org.slf4j", module: "slf4j-api"
+  }
+  compile("io.dropwizard.metrics:metrics-jvm:${commonVersions.dropwizardMetrics}") {
+    exclude group: "org.slf4j", module: "slf4j-api"
+  }
+  compile("io.dropwizard.metrics:metrics-annotation:${commonVersions.dropwizardMetrics}") {
+    exclude group: "org.slf4j", module: "slf4j-api"
+  }
+  compile("io.dropwizard.metrics:metrics-graphite:${commonVersions.dropwizardMetrics}") {
+    exclude group: "org.slf4j", module: "slf4j-api"
+  }
 }
-

--- a/ratpack-handlebars/ratpack-handlebars.gradle
+++ b/ratpack-handlebars/ratpack-handlebars.gradle
@@ -20,6 +20,8 @@ description = "Support for Handlebars server side template rendering in Ratpack 
 
 dependencies {
   compile project(":ratpack-guice")
-  compile 'com.github.jknack:handlebars:2.3.0'
+  compile('com.github.jknack:handlebars:2.3.0') {
+    exclude group: "org.slf4j", module: "slf4j-api"
+  }
   runtime commonDependencies.slf4j
 }

--- a/ratpack-hikari/ratpack-hikari.gradle
+++ b/ratpack-hikari/ratpack-hikari.gradle
@@ -4,7 +4,9 @@ apply from: "$rootDir/gradle/javaModule.gradle"
 
 dependencies {
   compile project(":ratpack-guice")
-  compile "com.zaxxer:HikariCP:2.3.5"
+  compile("com.zaxxer:HikariCP:2.3.5") {
+    exclude group: "org.slf4j", module: "slf4j-api"
+  }
   testCompile commonDependencies.h2
 }
 

--- a/ratpack-hystrix/ratpack-hystrix.gradle
+++ b/ratpack-hystrix/ratpack-hystrix.gradle
@@ -25,7 +25,13 @@ ext.apiLinks = [
 dependencies {
   compile project(":ratpack-core")
   compile project(":ratpack-guice")
-  compile "com.netflix.hystrix:hystrix-core:$commonVersions.hystrix"
+  compile("com.netflix.hystrix:hystrix-core:$commonVersions.hystrix") {
+    exclude group: "org.slf4j", module: "slf4j-api"
+    exclude group: "io.reactivex", module: "rxjava"
+    exclude group: "commons-logging", module: "commons-logging"
+  }
+  compile "commons-logging:commons-logging:${commonVersions.commonsLogging}"
+  compile commonDependencies.rxjava
   compile commonDependencies.jackson
 
   testCompile project(":ratpack-rx")

--- a/ratpack-lazybones/ratpack-lazybones.gradle
+++ b/ratpack-lazybones/ratpack-lazybones.gradle
@@ -33,7 +33,7 @@ apply from: "$rootDir/gradle/projectLocalRepo.gradle"
 apply plugin: "uk.co.cacoethes.lazybones-templates"
 
 dependencies {
-  compile "org.gradle:gradle-tooling-api:${gradle.gradleVersion}"
+  compile commonDependencies.toolingApi
 
   testCompile "commons-io:commons-io:2.4"
   testCompile "org.apache.commons:commons-lang3:3.3.2"

--- a/ratpack-manual/ratpack-manual.gradle
+++ b/ratpack-manual/ratpack-manual.gradle
@@ -43,8 +43,9 @@ dependencies {
     exclude group: "org.slf4j", module: "slf4j-api"
     exclude group: "com.google.inject", module: "guice"
     exclude group: "org.apache.httpcomponents", module: "httpclient"
+    exclude group: "com.fasterxml.jackson.core", module: "jackson-databind"
   }
-  testRuntime "org.gradle:gradle-tooling-api:${gradle.gradleVersion}" // used by gradle snippet fixture
+  testRuntime commonDependencies.toolingApi // used by gradle snippet fixture
   testRuntime "org.apache.ant:ant-nodeps:1.8.1"
   testRuntime "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${commonVersions.jackson}"
 

--- a/ratpack-pac4j/ratpack-pac4j.gradle
+++ b/ratpack-pac4j/ratpack-pac4j.gradle
@@ -46,7 +46,11 @@ dependencies {
   testCompile("org.pac4j:pac4j-openid:${commonVersions.pac4j}") {
     exclude group: "org.slf4j", module: "slf4j-api"
     exclude group: "com.google.inject", module: "guice"
+    exclude group: "commons-codec", module: "commons-codec"
+    exclude group: "xml-apis", module: "xml-apis"
   }
+  testCompile "commons-codec:commons-codec:${commonVersions.commonsCodec}"
+  testCompile "xml-apis:xml-apis:${commonVersions.xmlApis}"
 
   testCompile("org.pac4j:pac4j-http:${commonVersions.pac4j}") {
     exclude group: "org.slf4j", module: "slf4j-api"

--- a/ratpack-remote-test/ratpack-remote-test.gradle
+++ b/ratpack-remote-test/ratpack-remote-test.gradle
@@ -20,5 +20,5 @@ apply from: "$rootDir/gradle/groovyModule.gradle"
 
 dependencies {
   compile project(":ratpack-test"), project(":ratpack-remote")
-  compile commonDependencies."remote-http"
+  compile commonDependencies.remoteHttp
 }

--- a/ratpack-remote/ratpack-remote.gradle
+++ b/ratpack-remote/ratpack-remote.gradle
@@ -22,6 +22,5 @@ dependencies {
   compile project(":ratpack-guice")
   compile commonDependencies.remote
 
-  testCompile commonDependencies."remote-http"
+  testCompile commonDependencies.remoteHttp
 }
-

--- a/ratpack-retrofit2/ratpack-retrofit2.gradle
+++ b/ratpack-retrofit2/ratpack-retrofit2.gradle
@@ -22,7 +22,9 @@ dependencies {
   compile project(':ratpack-core')
   compile "com.squareup.retrofit2:retrofit:${commonVersions.retrofit}"
   compile "com.squareup.retrofit2:converter-scalars:${commonVersions.retrofit}"
-  compile "com.squareup.retrofit2:converter-jackson:${commonVersions.retrofit}"
+  compile("com.squareup.retrofit2:converter-jackson:${commonVersions.retrofit}") {
+    exclude group: "com.fasterxml.jackson.core", module: "jackson-databind"
+  }
 }
 
 ext.apiLinks = [

--- a/ratpack-rx/ratpack-rx.gradle
+++ b/ratpack-rx/ratpack-rx.gradle
@@ -24,6 +24,8 @@ ext.apiLinks = [
 
 dependencies {
   compile project(":ratpack-core")
-  compile "io.reactivex:rxjava:$commonVersions.rxjava"
-  compile "io.reactivex:rxjava-reactive-streams:1.0.1"
+  compile commonDependencies.rxjava
+  compile("io.reactivex:rxjava-reactive-streams:1.0.1") {
+    exclude group: "io.reactivex", module: "rxjava"
+  }
 }

--- a/ratpack-session-redis/ratpack-session-redis.gradle
+++ b/ratpack-session-redis/ratpack-session-redis.gradle
@@ -22,6 +22,12 @@ dependencies {
   compile project(":ratpack-guice")
   compile project(":ratpack-session")
 
-  compile 'biz.paluch.redis:lettuce:4.0.2.Final'
+  compile('biz.paluch.redis:lettuce:4.0.2.Final') {
+    exclude group: "io.netty", module: "netty-common"
+    exclude group: "io.netty", module: "netty-handler"
+    exclude group: "io.netty", module: "netty-transport"
+    exclude group: "io.reactivex", module: "rxjava"
+  }
+  compile commonDependencies.rxjava
   testCompile "com.github.kstyrc:embedded-redis:0.6"
 }

--- a/ratpack-site/ratpack-site.gradle
+++ b/ratpack-site/ratpack-site.gradle
@@ -98,8 +98,18 @@ dependencies {
   compile project(":ratpack-newrelic")
   compile "org.pegdown:pegdown:${commonVersions.pegdown}"
 
-  compile 'com.bertramlabs.plugins:ratpack-asset-pipeline:2.6.1'
-  providedRuntime 'com.bertramlabs.plugins:sass-asset-pipeline:2.6.1'
+  compile('com.bertramlabs.plugins:ratpack-asset-pipeline:2.6.1') {
+    exclude group: "org.slf4j", module: "slf4j-api"
+    exclude group: "io.ratpack", module: "ratpack-guice"
+    exclude group: "commons-logging", module: "commons-logging"
+    exclude group: "com.google.code.gson", module: "gson"
+  }
+  providedRuntime('com.bertramlabs.plugins:sass-asset-pipeline:2.6.1') {
+    exclude group: "org.jruby", module: "jruby-complete"
+    exclude group: "commons-logging", module: "commons-logging"
+    exclude group: "com.google.code.gson", module: "gson"
+  }
+  providedRuntime "org.jruby:jruby-complete:1.7.18"
 
   runtime "org.apache.logging.log4j:log4j-slf4j-impl:${commonVersions.log4j}"
   runtime "org.apache.logging.log4j:log4j-api:${commonVersions.log4j}"
@@ -113,9 +123,12 @@ dependencies {
   testCompile 'org.jsoup:jsoup:1.8.1'
   latestManual isHeroku ? "io.ratpack:ratpack-manual:$version" : project(":ratpack-manual")
 
-  browserTestCompile "org.gebish:geb-spock:0.10.0"
+  browserTestCompile("org.gebish:geb-spock:0.10.0") {
+    exclude group: "org.codehaus.groovy", module: "groovy-all"
+  }
   browserTestCompile "org.seleniumhq.selenium:selenium-chrome-driver:2.45.0", {
     exclude module: 'guava'
+    exclude group: "cglib", module: "cglib-nodep"
   }
 
   manualVersions.each {

--- a/ratpack-spring-boot-starter/ratpack-spring-boot-starter.gradle
+++ b/ratpack-spring-boot-starter/ratpack-spring-boot-starter.gradle
@@ -24,7 +24,12 @@ configurations {
 
 dependencies {
   compile project(":ratpack-spring-boot")
-  compile "org.springframework.boot:spring-boot-starter:$commonVersions.springBoot"
+  compile("org.springframework.boot:spring-boot-starter:$commonVersions.springBoot") {
+    exclude group: "org.yaml", module: "snakeyaml"
+    exclude group: "org.slf4j", module: "slf4j-api"
+  }
+  compile commonDependencies.snakeyaml
+  compile commonDependencies.slf4j
 }
 
 conf2ScopeMappings.addMapping(100, configurations.compile, "compile")


### PR DESCRIPTION
This required resolving a number of conflicts that have arisen since it was last enabled.
Note that failOnVersionConflict() is now automatically disabled if you are running a "dependencies" task, allowing its use for getting more information about conflicts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1011)
<!-- Reviewable:end -->
