### PR TITLE
#1012 RxRatpack#fork for parallel observables

### DIFF
--- a/ratpack-rx/src/main/java/ratpack/rx/RxRatpack.java
+++ b/ratpack-rx/src/main/java/ratpack/rx/RxRatpack.java
@@ -19,6 +19,7 @@ package ratpack.rx;
 import org.reactivestreams.Publisher;
 import ratpack.exec.*;
 import ratpack.func.Action;
+import ratpack.registry.RegistrySpec;
 import ratpack.rx.internal.DefaultSchedulers;
 import ratpack.rx.internal.ExecControllerBackedScheduler;
 import ratpack.stream.Streams;
@@ -672,11 +673,67 @@ public abstract class RxRatpack {
    * @param observable the observable sequence to execute on a different compute thread
    * @param <T> the element type
    * @return an observable on the compute thread that <code>fork</code> was called from
+   * @since 1.4
    * @see #forkEach(Observable)
    */
   public static <T> Observable<T> fork(Observable<T> observable) {
     return observeEach(promise(observable).fork());
   }
+
+  /**
+   *
+   * A variant of {@link #fork} that allows access to the registry of the forked execution inside an {@link Action}.
+   * <p>
+   * This allows the insertion of objects via {@link RegistrySpec#add} that will be available to the forked observable.
+   * <p>
+   * You do not have access to the original execution inside the {@link Action}.
+   *
+   * <pre class="java">{@code
+   * import ratpack.exec.Execution;
+   * import ratpack.registry.RegistrySpec;
+   * import ratpack.rx.RxRatpack;
+   * import ratpack.test.exec.ExecHarness;
+   *
+   * import rx.Observable;
+   *
+   * import static org.junit.Assert.assertEquals;
+   *
+   * public class Example {
+   *   public static void main(String[] args) throws Exception {
+   *     RxRatpack.initialize();
+   *
+   *     try (ExecHarness execHarness = ExecHarness.harness(6)) {
+   *       String concatenatedResult = execHarness.yield(execution -> {
+   *
+   *         Observable<String> notYetForked = Observable.just("foo")
+   *             .map((value) -> value + Execution.current().get(String.class));
+   *
+   *         Observable<String> forkedObservable = RxRatpack.fork(
+   *             notYetForked,
+   *             (RegistrySpec registrySpec) -> registrySpec.add("bar")
+   *         );
+   *
+   *         return RxRatpack.promiseSingle(forkedObservable);
+   *       }).getValueOrThrow();
+   *
+   *       assertEquals(concatenatedResult, "foobar");
+   *     }
+   *   }
+   * }
+   * }</pre>
+   *
+   * @param observable the observable sequence to execute on a different compute thread
+   * @param doWithRegistrySpec an Action where objects can be inserted into the registry of the forked execution
+   * @param <T> the element type
+   * @return an observable on the compute thread that <code>fork</code> was called from
+   * @throws Exception
+   * @since 1.4
+   * @see #fork(Observable)
+     */
+  public static <T> Observable<T> fork(Observable<T> observable, Action<? super RegistrySpec> doWithRegistrySpec) throws Exception {
+    return observeEach(promise(observable).fork(execSpec -> execSpec.register(doWithRegistrySpec)));
+  }
+
 
   /**
    * Parallelize an observable by creating a new Ratpack execution for each element.

--- a/ratpack-rx/src/test/groovy/ratpack/rx/RxParallelSpec.groovy
+++ b/ratpack-rx/src/test/groovy/ratpack/rx/RxParallelSpec.groovy
@@ -132,6 +132,27 @@ class RxParallelSpec extends Specification {
     received.sort() == [1, 2, 3, 4, 5]
   }
 
+  def "can add to registry of each fork"() {
+    given:
+    def sequence = rx.Observable.from(0, 1, 2, 3, 4)
+    def barrier = new CyclicBarrier(6)
+    def received = [].asSynchronized()
+    Integer addMe = 1
+
+    when:
+    harness.run {
+
+      sequence.forkEach({ RegistrySpec registrySpec -> registrySpec.add(addMe)}).subscribe {
+        received << it + Execution.current().get(Integer)
+        barrier.await()
+      }
+      barrier.await()
+    }
+
+    then:
+    received.sort() == [1, 2, 3, 4, 5]
+  }
+
   def "can use fork on next on observable"() {
     given:
     def sequence = rx.Observable.from("a", "b", "c", "d", "e")


### PR DESCRIPTION
Implements `RxRatpack#fork` by leveraging the work by @alkemist that was just added.

I used the same name as was used for the `Promise#fork`, but there could be some discussion as to how it could be a little confusing how it differs from `forkEach`.  

I tried to highlight in the documentation and tests how `fork` modifies the execution that the upstream observable is run on and gets bound back to the original execution after the `fork`, whereas `forkEach` modifies where downstream gets executed on.  It's quite a bit similar to the RxJava `subscribeOn` vs `observeOn`.

I also modified the existing tests for `forkEach` to demonstrate that you don't need to use `compose` within groovy code.  That wasn't obvious to me when I was looking through the tests originally trying to understand how it worked.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1014)
<!-- Reviewable:end -->
