### PR TITLE
Allow for 3rd party reporter extension

### DIFF
--- a/ratpack-dropwizard-metrics/src/main/java/ratpack/dropwizard/metrics/ReporterConfigSupport.java
+++ b/ratpack-dropwizard-metrics/src/main/java/ratpack/dropwizard/metrics/ReporterConfigSupport.java
@@ -15,7 +15,7 @@
  */
 package ratpack.dropwizard.metrics;
 
-abstract class ReporterConfigSupport<T extends ReporterConfigSupport<T>> {
+public abstract class ReporterConfigSupport<T extends ReporterConfigSupport<T>> {
   private String includeFilter;
   private String excludeFilter;
 

--- a/ratpack-dropwizard-metrics/src/main/java/ratpack/dropwizard/metrics/ScheduledReporterConfigSupport.java
+++ b/ratpack-dropwizard-metrics/src/main/java/ratpack/dropwizard/metrics/ScheduledReporterConfigSupport.java
@@ -18,7 +18,7 @@ package ratpack.dropwizard.metrics;
 
 import java.time.Duration;
 
-abstract class ScheduledReporterConfigSupport<T extends ReporterConfigSupport<T>> extends ReporterConfigSupport<T> {
+public abstract class ScheduledReporterConfigSupport<T extends ReporterConfigSupport<T>> extends ReporterConfigSupport<T> {
   private Duration reporterInterval = Duration.ofSeconds(30);
 
   /**


### PR DESCRIPTION
Change from the default protected to public so users can utilize these classes when they want to implement a 3rd party reporter (for example statsd). This makes it a lot easier to extend the existing module and follow the same patterns.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1018)
<!-- Reviewable:end -->
