### PR TITLE
Docs Fix: change reference to deprecated module

### DIFF
--- a/ratpack-manual/src/content/chapters/60-gradle.md
+++ b/ratpack-manual/src/content/chapters/60-gradle.md
@@ -72,11 +72,11 @@ repositories {
 }
 
 dependencies {
-  compile ratpack.dependency("jackson")
+  compile ratpack.dependency("handlebars")
 }
 ```
 
-Using `ratpack.dependency("jackson")` is equivalent to `"io.ratpack:ratpack-jackson:«version of ratpack-gradle dependency»"`.
+Using `ratpack.dependency("handlebars")` is equivalent to `"io.ratpack:ratpack-handlebars:«version of ratpack-gradle dependency»"`.
 This is the recommended way to add dependencies that are part of the core distribution.
 
 The `'io.ratpack.ratpack-java'` plugin adds the following implicit dependencies:


### PR DESCRIPTION
Since `jackson` has been moved to core, changed this confusing example to reference something that still works.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1036)

<!-- Reviewable:end -->
