### PR TITLE
Add HttpClientReadTimeoutException

### DIFF
--- a/ratpack-core/src/main/java/ratpack/http/client/HttpClientReadTimeoutException.java
+++ b/ratpack-core/src/main/java/ratpack/http/client/HttpClientReadTimeoutException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.http.client;
+
+/**
+ * Thrown when when no data was read within a certain period of time for a http client. 
+ */
+public class HttpClientReadTimeoutException extends RuntimeException  {
+
+  /**
+   * Constructor
+   *
+   * @param message the exception message.
+   */
+  public HttpClientReadTimeoutException(String message){
+    super(message);
+  }
+}

--- a/ratpack-core/src/main/java/ratpack/http/client/internal/RequestActionSupport.java
+++ b/ratpack-core/src/main/java/ratpack/http/client/internal/RequestActionSupport.java
@@ -33,6 +33,7 @@ import ratpack.func.Action;
 import ratpack.func.Function;
 import ratpack.http.Headers;
 import ratpack.http.Status;
+import ratpack.http.client.HttpClientReadTimeoutException;
 import ratpack.http.client.ReceivedResponse;
 import ratpack.http.client.RequestSpec;
 import ratpack.http.internal.*;
@@ -175,7 +176,7 @@ abstract class RequestActionSupport<T> implements Upstream<T> {
           e.setStackTrace(cause.getStackTrace());
           cause = e;
         } else if (cause instanceof ReadTimeoutException) {
-          cause = new RuntimeException("Read timeout (" + requestConfig.readTimeout + ") waiting on HTTP server at " + requestConfig.uri);
+          cause = new HttpClientReadTimeoutException("Read timeout (" + requestConfig.readTimeout + ") waiting on HTTP server at " + requestConfig.uri);
         }
 
         error(downstream, cause);

--- a/ratpack-core/src/test/groovy/ratpack/http/client/HttpClientSmokeSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/http/client/HttpClientSmokeSpec.groovy
@@ -407,7 +407,7 @@ class HttpClientSmokeSpec extends BaseHttpClientSpec {
     }
 
     then:
-    text == "java.lang.RuntimeException: Read timeout (PT1S) waiting on HTTP server at $otherApp.address".toString()
+    text == "ratpack.http.client.HttpClientReadTimeoutException: Read timeout (PT1S) waiting on HTTP server at $otherApp.address".toString()
 
     where:
     pooled << [true, false]
@@ -443,7 +443,7 @@ class HttpClientSmokeSpec extends BaseHttpClientSpec {
     }
 
     then:
-    text == "java.lang.RuntimeException: Read timeout (PT1S) waiting on HTTP server at $otherApp.address".toString()
+    text == "ratpack.http.client.HttpClientReadTimeoutException: Read timeout (PT1S) waiting on HTTP server at $otherApp.address".toString()
 
     where:
     pooled << [true, false]


### PR DESCRIPTION
HttpClientReadTimeoutException replaces the RuntimeException in the case
of a read timeout in the HttpClient.

This fixes #1046

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1047)
<!-- Reviewable:end -->
