### PR TITLE
Default .gitignore for lazybones template

### DIFF
--- a/ratpack-lazybones/src/templates/ratpack/.gitignore
+++ b/ratpack-lazybones/src/templates/ratpack/.gitignore
@@ -1,0 +1,2 @@
+.gradle/
+build/


### PR DESCRIPTION
The current lazybones template doesn't include a `.gitignore` file.
Doing a `git init && git add .` in a new project will results in many binaries added to the repository.
Include this `.gitignore` file to avoid this.

```
    new file:   .gradle/3.0/taskArtifacts/cache.properties
    new file:   .gradle/3.0/taskArtifacts/cache.properties.lock
    new file:   .gradle/3.0/taskArtifacts/fileHashes.bin
    new file:   .gradle/3.0/taskArtifacts/fileSnapshots.bin
    new file:   .gradle/3.0/taskArtifacts/fileSnapshotsToTreeSnapshotsIndex.bin
    new file:   .gradle/3.0/taskArtifacts/taskArtifacts.bin
    new file:   README.md
    new file:   build.gradle
    new file:   build/libs/my-app-all.jar
    new file:   build/resources/main/Ratpack.groovy
    new file:   build/resources/main/public/images/favicon.ico
    new file:   build/resources/main/templates/index.gtpl
    new file:   build/tmp/shadowJar/MANIFEST.MF
    new file:   gradle/wrapper/gradle-wrapper.jar
    new file:   gradle/wrapper/gradle-wrapper.properties
    new file:   gradlew
    new file:   gradlew.bat
    new file:   src/ratpack/Ratpack.groovy
    new file:   src/ratpack/public/images/favicon.ico
    new file:   src/ratpack/templates/index.gtpl
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1071)

<!-- Reviewable:end -->
