### PR TITLE
Include URL query string in NCSA request log

### DIFF
--- a/ratpack-core/src/main/java/ratpack/handling/internal/NcsaRequestLogger.java
+++ b/ratpack-core/src/main/java/ratpack/handling/internal/NcsaRequestLogger.java
@@ -70,7 +70,7 @@ public class NcsaRequestLogger implements RequestLogger {
           request.maybeGet(UserId.class).map(Types::cast),
           request.getTimestamp(),
           request.getMethod(),
-          "/" + request.getPath(),
+          request.getRawUri(),
           request.getProtocol(),
           outcome.getResponse().getStatus(),
           responseSize));

--- a/ratpack-core/src/test/groovy/ratpack/handling/internal/NcsaRequestLoggerSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/handling/internal/NcsaRequestLoggerSpec.groovy
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.handling.internal
+
+import org.slf4j.Logger
+import ratpack.handling.RequestLogger
+import ratpack.test.internal.RatpackGroovyDslSpec
+
+import java.util.concurrent.ArrayBlockingQueue
+import java.util.concurrent.TimeUnit
+
+class NcsaRequestLoggerSpec extends RatpackGroovyDslSpec {
+
+  def "request log includes query string"() {
+    given:
+    def msgQueue = new ArrayBlockingQueue<String>(1)
+    def logger = Mock(Logger) {
+      isInfoEnabled() >> true
+      info(_ as String) >> { String msg -> msgQueue << msg }
+    }
+
+    handlers {
+      all RequestLogger.ncsa(logger)
+      path("foo") {
+        render "hello"
+      }
+    }
+
+    when:
+    getText("foo?bar=baz")
+
+    then:
+    msgQueue.poll(2, TimeUnit.SECONDS).contains("\"GET /foo?bar=baz HTTP/1.1\"")
+  }
+}


### PR DESCRIPTION
For our use case the query string is often very important in understanding what requests were made but it's not currently included by the NCSA-style request logger (which includes only the path portion of the request URI). My understanding is that by convention the URL logged in NCSA-style access logs is the literal URL from the first line of the HTTP request (including any query string), so that's what I've changed it to do.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1083)

<!-- Reviewable:end -->
