### PR TITLE
Remove extranous @Nullable annotation

### DIFF
--- a/ratpack-test/src/main/java/ratpack/test/handling/HandlingResult.java
+++ b/ratpack-test/src/main/java/ratpack/test/handling/HandlingResult.java
@@ -92,7 +92,6 @@ public interface HandlingResult {
    * @param <T> The expected type of the exception captured.
    * @return the “unhandled” throwable that occurred, or raise {@link ratpack.test.handling.HandlerExceptionNotThrownException}
    */
-  @Nullable
   <T extends Throwable> T exception(Class<T> type);
 
   /**


### PR DESCRIPTION
Kotlin forces the programmer to do null checks on methods annotated with `@Nullable`. I was surprised when I needed to do a null check after using `HandlingResult.exception(Class)` in my tests.

So, this PR removes it from the method, as the method throws an exception instead of returning null.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1094)

<!-- Reviewable:end -->
