### PR TITLE
Introduce InvalidPathEncodingErrorHandler

### DIFF
--- a/ratpack-core/src/main/java/ratpack/error/InvalidPathEncodingErrorHandler.java
+++ b/ratpack-core/src/main/java/ratpack/error/InvalidPathEncodingErrorHandler.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.error;
+
+import com.google.common.reflect.TypeToken;
+import ratpack.api.NonBlocking;
+import ratpack.handling.Context;
+import ratpack.path.InvalidPathEncodingException;
+import ratpack.util.Types;
+
+/**
+ * An object that can deal with request path encoding errors.
+ *
+ * @since 1.5
+ */
+public interface InvalidPathEncodingErrorHandler {
+
+  /**
+   * A type token for this type.
+   */
+  TypeToken<InvalidPathEncodingErrorHandler> TYPE = Types.token(InvalidPathEncodingErrorHandler.class);
+
+  /**
+   * Processes the given request path encoding error that occurred processing the given context.
+   * <p>
+   * Implementations should strive to avoid throwing exceptions.
+   * If exceptions are thrown, they will just be logged at a warning level and the response will be finalised with a 500 error code and empty body.
+   *
+   * @param context The context being processed
+   * @param exception The path encoding error that occurred
+   * @throws Exception if something goes wrong handling the error
+   */
+  @NonBlocking
+  void error(Context context, InvalidPathEncodingException exception) throws Exception;
+
+}

--- a/ratpack-core/src/main/java/ratpack/error/internal/DefaultInvalidPathEncodingErrorHandler.java
+++ b/ratpack-core/src/main/java/ratpack/error/internal/DefaultInvalidPathEncodingErrorHandler.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.error.internal;
+
+import ratpack.error.InvalidPathEncodingErrorHandler;
+import ratpack.handling.Context;
+import ratpack.path.InvalidPathEncodingException;
+
+public class DefaultInvalidPathEncodingErrorHandler implements InvalidPathEncodingErrorHandler {
+
+  public static final InvalidPathEncodingErrorHandler INSTANCE = new DefaultInvalidPathEncodingErrorHandler();
+
+  @Override
+  public void error(Context context, InvalidPathEncodingException exception) throws Exception {
+    context.clientError(400);
+  }
+
+}

--- a/ratpack-core/src/main/java/ratpack/handling/internal/DefaultContext.java
+++ b/ratpack-core/src/main/java/ratpack/handling/internal/DefaultContext.java
@@ -24,6 +24,7 @@ import io.netty.channel.EventLoop;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ratpack.error.ClientErrorHandler;
+import ratpack.error.InvalidPathEncodingErrorHandler;
 import ratpack.error.ServerErrorHandler;
 import ratpack.exec.ExecController;
 import ratpack.exec.Execution;
@@ -44,6 +45,7 @@ import ratpack.http.internal.HttpHeaderConstants;
 import ratpack.parse.NoSuchParserException;
 import ratpack.parse.Parse;
 import ratpack.parse.Parser;
+import ratpack.path.InvalidPathEncodingException;
 import ratpack.path.PathBinding;
 import ratpack.path.internal.PathBindingStorage;
 import ratpack.path.internal.RootPathBinding;
@@ -401,7 +403,11 @@ public class DefaultContext implements Context {
       getRequest().add(ThrowableHolder.TYPE, new ThrowableHolder(throwable));
 
       try {
-        serverErrorHandler.error(this, throwable);
+        if (throwable instanceof InvalidPathEncodingException) {
+          get(InvalidPathEncodingErrorHandler.TYPE).error(this, (InvalidPathEncodingException) throwable);
+        } else {
+          serverErrorHandler.error(this, throwable);
+        }
       } catch (Throwable errorHandlerThrowable) {
         onErrorHandlerError(serverErrorHandler, throwable, errorHandlerThrowable);
       }

--- a/ratpack-core/src/main/java/ratpack/path/InvalidPathEncodingException.java
+++ b/ratpack-core/src/main/java/ratpack/path/InvalidPathEncodingException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.path;
+
+/**
+ * Thrown when a request is made for a path that is not correctly encoded.
+ *
+ * @since 1.5
+ */
+public class InvalidPathEncodingException extends RuntimeException {
+
+  /**
+   * Constructs the exception.
+   *
+   * @param cause The underlying exception cause
+   */
+  public InvalidPathEncodingException(Throwable cause) {
+    super(cause);
+  }
+
+}

--- a/ratpack-core/src/main/java/ratpack/path/internal/TokenPathBinder.java
+++ b/ratpack-core/src/main/java/ratpack/path/internal/TokenPathBinder.java
@@ -19,6 +19,7 @@ package ratpack.path.internal;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.netty.handler.codec.http.QueryStringDecoder;
+import ratpack.path.InvalidPathEncodingException;
 import ratpack.path.PathBinder;
 import ratpack.path.PathBinding;
 
@@ -60,7 +61,11 @@ public class TokenPathBinder implements PathBinder {
   }
 
   private String decodeURIComponent(String s) {
-    return QueryStringDecoder.decodeComponent(s.replace("+", "%2B"));
+    try {
+      return QueryStringDecoder.decodeComponent(s.replace("+", "%2B"));
+    } catch (IllegalArgumentException cause) {
+      throw new InvalidPathEncodingException(cause);
+    }
   }
 
   @Override

--- a/ratpack-core/src/main/java/ratpack/server/internal/ServerRegistry.java
+++ b/ratpack-core/src/main/java/ratpack/server/internal/ServerRegistry.java
@@ -23,8 +23,10 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.PooledByteBufAllocator;
 import ratpack.config.ConfigObject;
 import ratpack.error.ClientErrorHandler;
+import ratpack.error.InvalidPathEncodingErrorHandler;
 import ratpack.error.ServerErrorHandler;
 import ratpack.error.internal.DefaultDevelopmentErrorHandler;
+import ratpack.error.internal.DefaultInvalidPathEncodingErrorHandler;
 import ratpack.error.internal.DefaultProductionErrorHandler;
 import ratpack.error.internal.ErrorHandler;
 import ratpack.exec.ExecController;
@@ -125,7 +127,8 @@ public abstract class ServerRegistry {
         .add(HttpClient.class, httpClient)
         .add(ServerSentEventStreamClient.class, ServerSentEventStreamClient.of(httpClient))
         .add(HealthCheckResultsRenderer.TYPE, new HealthCheckResultsRenderer(PooledByteBufAllocator.DEFAULT))
-        .add(RequestId.Generator.class, UuidBasedRequestIdGenerator.INSTANCE);
+        .add(RequestId.Generator.class, UuidBasedRequestIdGenerator.INSTANCE)
+        .add(InvalidPathEncodingErrorHandler.class, DefaultInvalidPathEncodingErrorHandler.INSTANCE);
 
       addConfigObjects(serverConfig, baseRegistryBuilder);
     } catch (Exception e) {

--- a/ratpack-core/src/test/groovy/ratpack/path/InvalidPathEncodingSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/path/InvalidPathEncodingSpec.groovy
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.path
+
+import ratpack.error.InvalidPathEncodingErrorHandler
+import ratpack.handling.Context
+import ratpack.test.ApplicationUnderTest
+import ratpack.test.internal.RatpackGroovyDslSpec
+
+class InvalidPathEncodingSpec extends RatpackGroovyDslSpec {
+
+  def "requesting incorrectly formatted paths results in a 400 response by default"() {
+    when:
+    handlers {
+      get(":token") {
+        response.send()
+      }
+    }
+
+    then:
+    statusCode(applicationUnderTest, "/networking%party") == 400
+  }
+
+  def "responses to requests with incorrectly formatted paths can be customised"() {
+    when:
+    bindings {
+      add(InvalidPathEncodingErrorHandler, { Context context, InvalidPathEncodingException exception ->
+        context.clientError(404)
+      } as InvalidPathEncodingErrorHandler)
+    }
+    handlers {
+      get(":token") {
+        response.send()
+      }
+    }
+
+    then:
+    statusCode(applicationUnderTest, "/networking%party") == 404
+  }
+
+  private int statusCode(ApplicationUnderTest applicationUnderTest, String path) {
+    def port = applicationUnderTest.address.port
+    Socket s = new Socket("localhost", port)
+    def statusLine = s.withCloseable { socket ->
+      def pw = new PrintWriter(socket.outputStream)
+      pw.println("GET $path HTTP/1.1")
+      pw.println("Host: localhost:$port")
+      pw.println("")
+      pw.flush()
+      def reader = new InputStreamReader(socket.inputStream)
+      reader.readLine()
+    }
+    statusLine.tokenize()[1].toInteger()
+  }
+
+}

--- a/ratpack-manual/src/content/chapters/99-about-the-project.md
+++ b/ratpack-manual/src/content/chapters/99-about-the-project.md
@@ -84,6 +84,7 @@ The following people have provided significant contributions.
 * [Sebastien Bonnet] (https://github.com/sebbonnet)
 * [Alex Edwards](https://github.com/set321go)
 * [Ho Yan Leung](https://github.com/hyleung)
+* [Nick Pocock](https://github.com/pocockn)
 
 ### Past project members
 


### PR DESCRIPTION
InvalidPathEncodingErrorHandler allows to deal with requests to incorrectly encoded paths. The default implementation responds with a 400 status code.

This PR provides a fix for #1079.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1097)
<!-- Reviewable:end -->
