### PR TITLE
Signal subscription cancellation when channel is abruptly closed.

### DIFF
--- a/ratpack-core/src/main/java/ratpack/server/internal/DefaultResponseTransmitter.java
+++ b/ratpack-core/src/main/java/ratpack/server/internal/DefaultResponseTransmitter.java
@@ -171,6 +171,10 @@ public class DefaultResponseTransmitter implements ResponseTransmitter {
         }
       };
 
+      private final ChannelFutureListener onCloseListener = future -> {
+        cancel();
+      };
+
       private void cancel() {
         if (done.compareAndSet(false, true)) {
           subscription.cancel();
@@ -202,6 +206,7 @@ public class DefaultResponseTransmitter implements ResponseTransmitter {
           notifyListeners(responseStatus, channel.close());
         } else {
           channelFuture.addListener(cancelOnFailure);
+          channel.closeFuture().addListener(onCloseListener);
           if (channel.isWritable()) {
             this.subscription.request(1);
           }


### PR DESCRIPTION
I have experimented in some situations when the publisher subscription is not properly closed. It happens as example when SSE connection is established but no data is transferred, then the connection is abruptly closed. In this case, the cancel is never called causing subscriptions leaking.

This PR solves it adding an additional listener to closeFuture.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1111)
<!-- Reviewable:end -->
