### PR TITLE
Change dependency example in gradle section

### DIFF
--- a/ratpack-manual/src/content/chapters/60-gradle.md
+++ b/ratpack-manual/src/content/chapters/60-gradle.md
@@ -72,11 +72,11 @@ repositories {
 }
 
 dependencies {
-  compile ratpack.dependency("jackson")
+  compile ratpack.dependency("dopwizard-metrics")
 }
 ```
 
-Using `ratpack.dependency("jackson")` is equivalent to `"io.ratpack:ratpack-jackson:«version of ratpack-gradle dependency»"`.
+Using `ratpack.dependency("dropwizard-metrics")` is equivalent to `"io.ratpack:ratpack-dropwizard-metrics:«version of ratpack-gradle dependency»"`.
 This is the recommended way to add dependencies that are part of the core distribution.
 
 The `'io.ratpack.ratpack-java'` plugin adds the following implicit dependencies:


### PR DESCRIPTION
Removed refrences to the old ratpack.dependency("jackson") and used the
metrics lib instead.

This fixes #1101

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1115)
<!-- Reviewable:end -->
