### PR TITLE
Surface error when request bodyStream is closed unexpectedly

### DIFF
--- a/ratpack-core/src/main/java/ratpack/http/ConnectionClosedException.java
+++ b/ratpack-core/src/main/java/ratpack/http/ConnectionClosedException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.http;
+
+/**
+ * Thrown when an operation is attempted against a connection that is closed.
+ */
+public class ConnectionClosedException extends RuntimeException {
+
+  public ConnectionClosedException(String message) {
+    super(message);
+  }
+}

--- a/ratpack-core/src/test/groovy/ratpack/http/RequestBodyStreamReadingSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/http/RequestBodyStreamReadingSpec.groovy
@@ -19,7 +19,6 @@ package ratpack.http
 import io.netty.buffer.ByteBuf
 import io.netty.buffer.ByteBufUtil
 import io.netty.buffer.Unpooled
-import io.netty.util.CharsetUtil
 import org.apache.commons.lang3.RandomStringUtils
 import org.reactivestreams.Subscriber
 import org.reactivestreams.Subscription


### PR DESCRIPTION
This PR surfaces an error to a request bodyStream `Subscriber` when the client closes the connection before the content-length is reached.

* Fixes #1112

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1117)
<!-- Reviewable:end -->
