### PR TITLE
Ability to provide listener for unhandled execution errors

### DIFF
--- a/ratpack-core/src/main/java/ratpack/exec/ExecutionErrorListener.java
+++ b/ratpack-core/src/main/java/ratpack/exec/ExecutionErrorListener.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.exec;
+
+import com.google.common.reflect.TypeToken;
+import ratpack.registry.Registry;
+
+/**
+ * A handler for capturing unhandled errors in an {@link Execution}.
+ * This must be added to the {@link Registry} for the execution.
+ *
+ * <pre class="java">{@code
+ * import ratpack.exec.Execution;
+ * import ratpack.exec.ExecutionErrorListener;
+ *
+ * import static org.junit.Assert.assertTrue;
+ *
+ * public class Example {
+ *   public static class RecordingExecutionErrorListener implements ExecutionErrorListener {
+ *     private String message;
+ *
+ *     public String getMessage() {
+ *       return this.message;
+ *     }
+ *
+ *     public void onError(Execution execution, Throwable error) {
+ *       this.message = error.getMessage();
+ *     }
+ *   }
+ *
+ *   public static void main(String[] args) throws Exception {
+ *     ExecutionErrorListener listener = new RecordingExecutionErrorListener();
+ *     try (ExecHarness harness = ExecHarness.harness()) {
+ *       harness.run(
+ *         // add our custom ExecutionErrorListener to the execution registry
+ *         registrySpec ->
+ *           registrySpec.add(ExecutionErrorListener.class, listener),
+ *         // throw an unhandled exception
+ *         execution ->
+ *           throw new RuntimeException("!!")
+ *       );
+ *     }
+ *     assertTrue(listener.getMessage(), "!!");
+ *   }
+ * }
+ *
+ * }</pre>
+ *
+ * @since 1.5
+ */
+@FunctionalInterface
+public interface ExecutionErrorListener {
+
+  /**
+   * A type token for this type.
+   */
+  TypeToken<ExecutionErrorListener> TYPE = TypeToken.of(ExecutionErrorListener.class);
+
+  /**
+   * This method is invoked when an unhandled error is thrown in an {@link Execution}.
+   *
+   * @param execution the {@link Execution} from which the error was thrown
+   * @param error the error that was thrown
+     */
+  void onError(Execution execution, Throwable error) throws Exception;
+}

--- a/ratpack-core/src/main/java/ratpack/exec/internal/DefaultExecController.java
+++ b/ratpack-core/src/main/java/ratpack/exec/internal/DefaultExecController.java
@@ -17,6 +17,7 @@
 package ratpack.exec.internal;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import io.netty.util.concurrent.DefaultThreadFactory;
@@ -28,6 +29,7 @@ import ratpack.func.Block;
 import ratpack.registry.RegistrySpec;
 import ratpack.util.internal.ChannelImplDetector;
 
+import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -35,8 +37,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static ratpack.func.Action.noop;
 
 public class DefaultExecController implements ExecControllerInternal {
-
-  private static final Action<Throwable> LOG_UNCAUGHT = t -> DefaultExecution.LOGGER.error("Uncaught execution exception", t);
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ExecController.class);
 
@@ -146,7 +146,7 @@ public class DefaultExecController implements ExecControllerInternal {
   @Override
   public ExecStarter fork() {
     return new ExecStarter() {
-      private Action<? super Throwable> onError = LOG_UNCAUGHT;
+      private List<ExecutionErrorListener> errorListeners = Lists.newArrayList();
       private Action<? super Execution> onComplete = noop();
       private Action<? super Execution> onStart = noop();
       private Action<? super RegistrySpec> registry = noop();
@@ -160,7 +160,7 @@ public class DefaultExecController implements ExecControllerInternal {
 
       @Override
       public ExecStarter onError(Action<? super Throwable> onError) {
-        this.onError = onError;
+        this.errorListeners.add((e, t) -> onError.execute(t));
         return this;
       }
 
@@ -186,13 +186,13 @@ public class DefaultExecController implements ExecControllerInternal {
       public void start(Action<? super Execution> initialExecutionSegment) {
         if (eventLoop.inEventLoop() && DefaultExecution.get() == null) {
           try {
-            new DefaultExecution(DefaultExecController.this, eventLoop, registry, initialExecutionSegment, onError, onStart, onComplete);
+            new DefaultExecution(DefaultExecController.this, eventLoop, registry, initialExecutionSegment, onStart, onComplete, errorListeners);
           } catch (Throwable e) {
             throw new InternalError("could not start execution", e);
           }
         } else {
           eventLoop.submit(() ->
-            new DefaultExecution(DefaultExecController.this, eventLoop, registry, initialExecutionSegment, onError, onStart, onComplete)
+            new DefaultExecution(DefaultExecController.this, eventLoop, registry, initialExecutionSegment, onStart, onComplete, errorListeners)
           );
         }
       }

--- a/ratpack-core/src/main/java/ratpack/exec/internal/DefaultExecution.java
+++ b/ratpack-core/src/main/java/ratpack/exec/internal/DefaultExecution.java
@@ -46,13 +46,15 @@ public class DefaultExecution implements Execution {
 
   public final static Logger LOGGER = LoggerFactory.getLogger(Execution.class);
 
+  private static final ExecutionErrorListener LOG_UNCAUGHT = (e, t) ->
+    DefaultExecution.LOGGER.error("Uncaught execution exception in execution " + e + " :", t);
+
   public final static FastThreadLocal<DefaultExecution> THREAD_BINDING = new FastThreadLocal<>();
 
   private ExecStream execStream;
 
   private final ExecControllerInternal controller;
   private final EventLoop eventLoop;
-  private final Action<? super Throwable> onError;
   private final Action<? super Execution> onComplete;
 
   private List<AutoCloseable> closeables;
@@ -67,16 +69,16 @@ public class DefaultExecution implements Execution {
     EventLoop eventLoop,
     Action<? super RegistrySpec> registryInit,
     Action<? super Execution> action,
-    Action<? super Throwable> onError,
     Action<? super Execution> onStart,
-    Action<? super Execution> onComplete
-  ) throws Exception {
+    Action<? super Execution> onComplete,
+    Iterable<ExecutionErrorListener> errorListeners
+    ) throws Exception {
     this.controller = controller;
     this.eventLoop = eventLoop;
-    this.onError = onError;
     this.onComplete = onComplete;
 
     registryInit.execute(registry);
+    errorListeners.forEach(el -> registry.add(ExecutionErrorListener.class, el));
     onStart.execute(this);
 
     this.execStream = new InitialExecStream(action);
@@ -177,7 +179,7 @@ public class DefaultExecution implements Execution {
   }
 
   private void drain() {
-    if (execStream == TerminalExecStream.INSTANCE) {
+    if (execStream == TerminalExecStream.INSTANCE || execStream == InErrorHandlerExecStream.INSTANCE) {
       return;
     }
 
@@ -297,6 +299,25 @@ public class DefaultExecution implements Execution {
     abstract void enqueue(Block block);
 
     abstract void error(Throwable throwable);
+  }
+
+  private static class InErrorHandlerExecStream extends ExecStream {
+    static final ExecStream INSTANCE = new InErrorHandlerExecStream();
+
+    @Override
+    boolean exec() {
+      return false;
+    }
+
+    @Override
+    void enqueue(Block segment) {
+      throw new ExecutionException("this execution has completed (you may be trying to use a promise in a cleanup method)");
+    }
+
+    @Override
+    void error(Throwable throwable) {
+      throw new ExecutionException("this execution has completed (you may be trying to use a promise in a cleanup method)");
+    }
   }
 
   private static class TerminalExecStream extends ExecStream {
@@ -441,16 +462,34 @@ public class DefaultExecution implements Execution {
 
     @Override
     void error(Throwable throwable) {
+      execStream = InErrorHandlerExecStream.INSTANCE;
+
       initial = null;
       if (segments != null) {
         segments.clear();
       }
-      try {
-        onError.execute(throwable);
-      } catch (Throwable errorHandlerError) {
-        LOGGER.error("error handler " + onError + " threw error (this execution will terminate):", errorHandlerError);
-        execStream = TerminalExecStream.INSTANCE;
-      }
+
+      final Execution currentExecution = DefaultExecution.this;
+      List<ExecutionErrorListener> errorListeners =
+        Lists.newArrayList(registry.getAll(ExecutionErrorListener.class));
+
+      controller.fork()
+        .onComplete(e -> {
+          execStream = TerminalExecStream.INSTANCE;
+          DefaultExecution.this.exec();
+        })
+        .start(e -> {
+          if (errorListeners.size() == 0) {
+            errorListeners.add(LOG_UNCAUGHT);
+          }
+          errorListeners.forEach(errorListener -> {
+            try {
+              errorListener.onError(currentExecution, throwable);
+            } catch (Throwable errorListenerError) {
+              LOGGER.error("error listener " + errorListener + " threw error: ", errorListenerError);
+            }
+          });
+        });
     }
   }
 

--- a/ratpack-core/src/test/groovy/ratpack/exec/ExecutionErrorHandlingSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/exec/ExecutionErrorHandlingSpec.groovy
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.exec
+
+import ratpack.test.exec.ExecHarness
+import spock.lang.AutoCleanup
+import spock.lang.Specification
+import spock.lang.Timeout
+
+import java.util.concurrent.CountDownLatch
+
+class ExecutionErrorHandlingSpec extends Specification {
+
+  @AutoCleanup
+  ExecHarness harness = ExecHarness.harness()
+
+  @Timeout(10)
+  def "can add error handlers using onError"() {
+    setup:
+    def latch = new CountDownLatch(1)
+
+    when:
+    harness.controller.fork().onError { t ->
+      latch.countDown()
+    }.start {
+      throw new RuntimeException("!")
+    }
+
+    and:
+    latch.await()
+
+    then:
+    notThrown(Throwable)
+  }
+
+  void exec(ExecutionErrorListener... errorListeners) {
+    harness.controller.fork().onStart { e ->
+      errorListeners.each { errorListener ->
+        e.add(ExecutionErrorListener, errorListener)
+      }
+    }.start {
+      throw new RuntimeException("!")
+    }
+  }
+
+  @Timeout(10)
+  def "error listeners are pulled from registry"() {
+    setup:
+    def latch = new CountDownLatch(1)
+    def result = ""
+    def errorListener = { e, t ->
+      latch.countDown()
+      result = t.message
+    } as ExecutionErrorListener
+
+    when:
+    exec(errorListener)
+
+    and:
+    latch.await()
+
+    then:
+    result == "!"
+  }
+
+  @Timeout(10)
+  def "multiple error listeners will be invoked and in registry order"() {
+    setup:
+    def latch = new CountDownLatch(2)
+    def results = []
+    def errorListener1 = { e, t ->
+      latch.countDown()
+      results << 1
+    } as ExecutionErrorListener
+    def errorListener2 = { e, t ->
+      latch.countDown()
+      results << 2
+    } as ExecutionErrorListener
+
+    when:
+    exec(errorListener1, errorListener2)
+
+    and:
+    latch.await()
+
+    then:
+    results == [2, 1]
+  }
+
+  def "can use promise inside of error listener"() {
+    setup:
+    def latch = new CountDownLatch(1)
+    def result
+    def errorListener = { e, t ->
+      Operation.of {
+        result = 1
+        latch.countDown()
+      }.then()
+    } as ExecutionErrorListener
+
+    when:
+    exec(errorListener)
+
+    and:
+    latch.await()
+
+    then:
+    result == 1
+  }
+}


### PR DESCRIPTION
* Fixes #1037 

This commit provides the means by which users can add one or many `ExecutionErrorListener` instances to an execution registry. Furthermore it extends the capabilities of `ExecStarter#onError` to allow multiple error handlers to be specified in a forked execution.

Users will be able to use this feature to provide a handler that will capture any uncaught exceptions in an execution, and do further processing in a new execution.