### PR TITLE
CharSequence for Body Type

### DIFF
--- a/ratpack-core/src/main/java/ratpack/http/client/RequestSpec.java
+++ b/ratpack-core/src/main/java/ratpack/http/client/RequestSpec.java
@@ -309,7 +309,7 @@ public interface RequestSpec {
      * @param contentType the value of the Content-Type header
      * @return this
      */
-    Body type(String contentType);
+    Body type(CharSequence contentType);
 
     /**
      * Specifies the request body by writing to an output stream.

--- a/ratpack-core/src/main/java/ratpack/http/client/internal/RequestConfig.java
+++ b/ratpack-core/src/main/java/ratpack/http/client/internal/RequestConfig.java
@@ -194,7 +194,7 @@ class RequestConfig {
 
     private class BodyImpl implements Body {
       @Override
-      public Body type(String contentType) {
+      public Body type(CharSequence contentType) {
         getHeaders().set(HttpHeaderConstants.CONTENT_TYPE, contentType);
         return this;
       }


### PR DESCRIPTION
Allow RequestSpec.Body to take CharSequence for the type method this
allows using Netty HttpHeaderValues

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1131)
<!-- Reviewable:end -->
