### PR TITLE
Remove <op>IfOrElse in favor of Function.applyIfOrElse.

### DIFF
--- a/ratpack-core/src/main/java/ratpack/exec/Promise.java
+++ b/ratpack-core/src/main/java/ratpack/exec/Promise.java
@@ -539,40 +539,7 @@ public interface Promise<T> {
    * @since 1.4
    */
   default Promise<T> mapIf(Predicate<? super T> predicate, Function<? super T, ? extends T> transformer) {
-    return mapIfOrElse(predicate, transformer, Function.identity());
-  }
-
-  /**
-   * Transforms the promised value by applying one of the given functions to it, depending if it satisfies the predicate.
-   *
-   * <pre class="java">{@code
-   * import ratpack.test.exec.ExecHarness;
-   * import ratpack.exec.ExecResult;
-   * import ratpack.exec.Promise;
-   *
-   * import static org.junit.Assert.assertEquals;
-   *
-   * public class Example {
-   *   public static void main(String... args) throws Exception {
-   *     ExecResult<String> result = ExecHarness.yieldSingle(c ->
-   *         Promise.value("foo")
-   *           .mapIfOrElse(s -> s.contains("f"), String::toUpperCase, s -> s)
-   *           .mapIfOrElse(s -> s.contains("f"), s -> s, s -> s + "-BAR")
-   *     );
-   *
-   *     assertEquals("FOO-BAR", result.getValue());
-   *   }
-   * }
-   * }</pre>
-   *
-   * @param predicate the condition to decide which transformation to apply
-   * @param ifTransformer the transformation to apply when the predicate is true
-   * @param elseTransformer the transformation to apply when the predicate is false
-   * @return a promise
-   * @since 1.5
-   */
-  default Promise<T> mapIfOrElse(Predicate<? super T> predicate, Function<? super T, ? extends T> ifTransformer, Function<? super T, ? extends T> elseTransformer) {
-    return map(t -> predicate.apply(t) ? ifTransformer.apply(t) : elseTransformer.apply(t));
+    return map(Function.applyIfOrElse(predicate, transformer, Function.identity()));
   }
 
   /**
@@ -1228,40 +1195,7 @@ public interface Promise<T> {
    * @since 1.4
    */
   default Promise<T> flatMapIf(Predicate<? super T> predicate, Function<? super T, ? extends Promise<T>> transformer) {
-    return flatMapIfOrElse(predicate, transformer, Promise::value);
-  }
-
-  /**
-   * Transforms the promised value by applying one of the given functions to it that returns a promise for the transformed value, depending if it satisfies the predicate.
-   *
-   * <pre class="java">{@code
-   * import ratpack.test.exec.ExecHarness;
-   * import ratpack.exec.ExecResult;
-   * import ratpack.exec.Promise;
-   *
-   * import static org.junit.Assert.assertEquals;
-   *
-   * public class Example {
-   *   public static void main(String... args) throws Exception {
-   *     ExecResult<String> result = ExecHarness.yieldSingle(c ->
-   *         Promise.value("foo")
-   *           .flatMapIfOrElse(s -> s.contains("f"), s -> Promise.value(s.toUpperCase()), s -> Promise.value(s))
-   *           .flatMapIfOrElse(s -> s.contains("f"), s -> Promise.value(s), s -> Promise.value(s + "-BAR"))
-   *     );
-   *
-   *     assertEquals("FOO-BAR", result.getValue());
-   *   }
-   * }
-   * }</pre>
-   *
-   * @param predicate the condition to decide which transformation to apply
-   * @param ifTransformer the transformation to apply to the promised value when the predicate is true
-   * @param elseTransformer the transformation to apply to the promised value when the predicate is false
-   * @return a promise
-   * @since 1.5
-   */
-  default Promise<T> flatMapIfOrElse(Predicate<? super T> predicate, Function<? super T, ? extends Promise<T>> ifTransformer, Function<? super T, ? extends Promise<T>> elseTransformer) {
-    return flatMap(t -> predicate.apply(t) ? ifTransformer.apply(t) : elseTransformer.apply(t));
+    return flatMap(Function.applyIfOrElse(predicate, transformer, Promise::value));
   }
 
   /**

--- a/ratpack-core/src/main/java/ratpack/func/Function.java
+++ b/ratpack-core/src/main/java/ratpack/func/Function.java
@@ -170,7 +170,29 @@ public interface Function<I, O> {
     return t -> t;
   }
 
+  /**
+   * Returns a constant function (return values always the same regardless of input).
+   *
+   * @param t the value to return
+   * @param <T> The type of the output object from the function
+   * @return a function that always returns the same value regardless of the input
+   */
   static <T> Function<Object, T> constant(T t) {
     return i -> t;
+  }
+
+  /**
+   * Creates a function that returns one of the provided functions depending on the results of the supplied predicate
+   *
+   * @param predicate the condition which selects the applied function
+   * @param ifFunction the function applied if the predicate is satisfied
+   * @param elseFunction the function applied if teh predicate is not satisfied
+   * @param <I> the type of the input to the functions and the predicate
+   * @param <O> the type of the output of the functions
+   *
+   * @return a function based on the condition of the predicate
+   */
+  static <I, O> Function<? super I, ? extends O> applyIfOrElse(Predicate<? super I> predicate, Function<? super I, ? extends O> ifFunction, Function<? super I, ? extends O> elseFunction) {
+    return i -> predicate.apply(i) ? ifFunction.apply(i) : elseFunction.apply(i);
   }
 }

--- a/ratpack-core/src/test/groovy/ratpack/exec/PromiseFlatMapSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/exec/PromiseFlatMapSpec.groovy
@@ -16,6 +16,7 @@
 
 package ratpack.exec
 
+import ratpack.func.Function
 import spock.lang.Unroll
 
 class PromiseFlatMapSpec extends BaseExecutionSpec {
@@ -52,11 +53,11 @@ class PromiseFlatMapSpec extends BaseExecutionSpec {
   }
 
   @Unroll
-  def "can flatMapIfOrElse promise when the predicate is #predicate"() {
+  def "can flatMap If Or Else promise when the predicate is #predicate"() {
     when:
     exec {
       Blocking.get { originalValue }
-        .flatMapIfOrElse( { s -> s == "foo" }, { s -> Blocking.get { s + "-true" } } , { s -> Blocking.get { s + "-false" } } )
+        .flatMap(Function.applyIfOrElse( { s -> s == "foo"}, { s -> Blocking.get { s + "-true" } }, { s -> Blocking.get { s + "-false" } } ))
         .then { events << it }
     }
 

--- a/ratpack-core/src/test/groovy/ratpack/exec/PromiseMapSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/exec/PromiseMapSpec.groovy
@@ -16,6 +16,7 @@
 
 package ratpack.exec
 
+import ratpack.func.Function
 import spock.lang.Unroll
 
 class PromiseMapSpec extends BaseExecutionSpec {
@@ -52,11 +53,11 @@ class PromiseMapSpec extends BaseExecutionSpec {
   }
 
   @Unroll
-  def "can mapIfOrElse promise when the predicate is #predicate"() {
+  def "can map If Or Else promise when the predicate is #predicate"() {
     when:
     exec {
       Blocking.get { originalValue }
-        .mapIfOrElse( { it == "foo" }, { it + "-true" }, { it + "-false" })
+        .map(Function.applyIfOrElse( { it == "foo" }, { it + "-true" }, { it + "-false" } ))
         .then { events << it }
     }
 


### PR DESCRIPTION
This is a proof of a new paradigm for the API such that we don't have method explosion for various flow control. Instead we could use a nested function to provide the logic were applicable.
This removes some methods that have been added but not yet released thus there isn't a breaking change. 

Methods that previously existed and provide only a single branch of flow control (e.g. `Promise.mapIf(Predicate, Function)` would remain un-deprecated as it would be difficult to abstract the desired behavior into a single static method on `Function`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1138)
<!-- Reviewable:end -->
