### PR TITLE
Enable SSL SNI support in default http client

### DIFF
--- a/ratpack-core/src/main/java/ratpack/http/client/internal/RequestActionSupport.java
+++ b/ratpack-core/src/main/java/ratpack/http/client/internal/RequestActionSupport.java
@@ -275,9 +275,9 @@ abstract class RequestActionSupport<T> implements Upstream<T> {
   private SslHandler createSslHandler() throws NoSuchAlgorithmException {
     SSLEngine sslEngine;
     if (requestConfig.sslContext != null) {
-      sslEngine = requestConfig.sslContext.createSSLEngine();
+      sslEngine = requestConfig.sslContext.createSSLEngine(requestConfig.uri.getHost(), requestConfig.uri.getPort());
     } else {
-      sslEngine = SSLContext.getDefault().createSSLEngine();
+      sslEngine = SSLContext.getDefault().createSSLEngine(requestConfig.uri.getHost(), requestConfig.uri.getPort());
     }
     sslEngine.setUseClientMode(true);
     return new SslHandler(sslEngine);


### PR DESCRIPTION
By creating an SSL engine with peer host and port the http client can support SSL SNI out of the box. Some apis, for instance when provided via AWS API Gateway, may require SNI in order to access them.

Fixes #1077.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1142)
<!-- Reviewable:end -->
