### PR TITLE
Fix issue with metrics truncating seconds from request time measurement

### DIFF
--- a/ratpack-dropwizard-metrics/src/main/java/ratpack/dropwizard/metrics/internal/DefaultRequestTimingHandler.java
+++ b/ratpack-dropwizard-metrics/src/main/java/ratpack/dropwizard/metrics/internal/DefaultRequestTimingHandler.java
@@ -43,7 +43,7 @@ public class DefaultRequestTimingHandler implements RequestTimingHandler {
     context.onClose(outcome -> {
       String timerName = buildRequestTimerTag(outcome.getRequest().getPath(), outcome.getRequest().getMethod().getName());
       String responseCodeCounter = String.valueOf(outcome.getResponse().getStatus().getCode()).substring(0, 1) + "xx-responses";
-      metricRegistry.timer(timerName).update(outcome.getDuration().getNano(), TimeUnit.NANOSECONDS);
+      metricRegistry.timer(timerName).update(outcome.getDuration().toNanos(), TimeUnit.NANOSECONDS);
       metricRegistry.counter(responseCodeCounter).inc();
     });
     context.next();


### PR DESCRIPTION
During a load test on one of Ratpack apps prior to going to production we noticed our Datadog dashboard response times never exceeding 1 second.  Checked out some of our other Ratpack projects and noticed similar behavior.

During debugging it seems Ratpack's metrics module is truncating the seconds and only using the durations nanos for reporting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1151)
<!-- Reviewable:end -->
