### PR TITLE
Keep alive header not set

### DIFF
--- a/ratpack-core/src/main/java/ratpack/server/internal/DefaultResponseTransmitter.java
+++ b/ratpack-core/src/main/java/ratpack/server/internal/DefaultResponseTransmitter.java
@@ -94,6 +94,8 @@ public class DefaultResponseTransmitter implements ResponseTransmitter {
         isKeepAlive = false;
       } else if (!isKeepAlive) {
         responseHeaders.set(HttpHeaderNames.CONNECTION, HttpHeaderValues.CLOSE);
+      } else {
+        responseHeaders.set(HttpHeaderNames.CONNECTION, HttpHeaderValues.KEEP_ALIVE);
       }
 
       HttpResponse headersResponse = new CustomHttpResponse(responseStatus, responseHeaders);

--- a/ratpack-core/src/test/groovy/ratpack/http/KeepAliveSupportSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/http/KeepAliveSupportSpec.groovy
@@ -63,7 +63,7 @@ class KeepAliveSupportSpec extends RatpackGroovyDslSpec {
     }
     latch.await()
     connections.size() == threads * requests
-    connections.every { it == 'keep-alive' }
+    connections.every { it == "keep-alive" }
 
     where:
     dev << [true, false, true, false]

--- a/ratpack-core/src/test/groovy/ratpack/http/KeepAliveSupportSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/http/KeepAliveSupportSpec.groovy
@@ -18,6 +18,7 @@ package ratpack.http
 
 import ratpack.test.internal.RatpackGroovyDslSpec
 
+import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.CountDownLatch
 
 class KeepAliveSupportSpec extends RatpackGroovyDslSpec {
@@ -42,6 +43,7 @@ class KeepAliveSupportSpec extends RatpackGroovyDslSpec {
     then:
     def url = applicationUnderTest.address.toURL()
     def latch = new CountDownLatch(threads * requests)
+    def connections = new ConcurrentLinkedQueue<String>()
     threads.times { i ->
       Thread.start {
         requests.times {
@@ -51,12 +53,17 @@ class KeepAliveSupportSpec extends RatpackGroovyDslSpec {
             connection.requestMethod = "POST"
             connection.outputStream << "a" * (1024 * 6)
           }
-          connection.getHeaderField("Connection") == "keep-alive"
+          def connectionHeader = connection.getHeaderField("Connection")
+          if (connectionHeader) {
+            connections.add(connectionHeader)
+          }
           latch.countDown()
         }
       }
     }
     latch.await()
+    connections.size() == threads * requests
+    connections.every { it == 'keep-alive' }
 
     where:
     dev << [true, false, true, false]

--- a/ratpack-core/src/test/groovy/ratpack/http/RequestBodyReadingSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/http/RequestBodyReadingSpec.groovy
@@ -345,7 +345,7 @@ class RequestBodyReadingSpec extends RatpackGroovyDslSpec {
     def channelId1 = connection.inputStream.text
 
     then:
-    connection.getHeaderField("Connection") == null
+    connection.getHeaderField("Connection") == "keep-alive"
 
     when:
     connection = applicationUnderTest.address.toURL().openConnection()
@@ -355,7 +355,7 @@ class RequestBodyReadingSpec extends RatpackGroovyDslSpec {
     def channelId2 = connection.inputStream.text
 
     then:
-    connection.getHeaderField("Connection") == null
+    connection.getHeaderField("Connection") == "keep-alive"
 
     and:
     channelId1 == channelId2

--- a/ratpack-core/src/test/groovy/ratpack/http/RequestBodyStreamReadingSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/http/RequestBodyStreamReadingSpec.groovy
@@ -275,7 +275,7 @@ class RequestBodyStreamReadingSpec extends RatpackGroovyDslSpec {
     def channelId1 = connection.inputStream.text
 
     then:
-    connection.getHeaderField("Connection") == null
+    connection.getHeaderField("Connection") == "keep-alive"
 
     when:
     connection = applicationUnderTest.address.toURL().openConnection()
@@ -285,7 +285,7 @@ class RequestBodyStreamReadingSpec extends RatpackGroovyDslSpec {
     def channelId2 = connection.inputStream.text
 
     then:
-    connection.getHeaderField("Connection") == null
+    connection.getHeaderField("Connection") == "keep-alive"
 
     and:
     channelId1 == channelId2

--- a/ratpack-core/src/test/groovy/ratpack/http/client/HttpReverseProxySpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/http/client/HttpReverseProxySpec.groovy
@@ -154,7 +154,7 @@ class HttpReverseProxySpec extends BaseHttpClientSpec {
 
     expect:
     def response = get()
-    response.headers.asMultiValueMap() == ["x-foo-header": "foo", "content-type": "text/plain;charset=UTF-8", "content-length": "3"]
+    response.headers.asMultiValueMap() == ["x-foo-header": "foo", "content-type": "text/plain;charset=UTF-8", "content-length": "3", "connection": "keep-alive"]
     response.body.text == "bar"
 
     where:

--- a/ratpack-core/src/test/groovy/ratpack/http/internal/DefaultResponseSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/http/internal/DefaultResponseSpec.groovy
@@ -322,7 +322,7 @@ class DefaultResponseSpec extends RatpackGroovyDslSpec {
     def connection1 = applicationUnderTest.getAddress().toURL().openConnection()
 
     then:
-    connection1.getHeaderField("Connection") == null
+    connection1.getHeaderField("Connection") == "keep-alive"
     channel.get().open
 
     when:


### PR DESCRIPTION
A change between 1.3 and 1.4.0 resulted in the keep-alive header never being set. The change was made here: https://github.com/ratpack/ratpack/commit/184d8804becb4d41641c8817a6e06f05f21ed5c2#diff-d70a1c937265cad0083814db2236676e

Also KeepAliveSupportSpec did not actually assert anything. This change adds some checks for keep alive headers.

I'm a little wary of this change as it changes the behaviour for all responses, but it does appear to be the intended behaviour. AFAIK any HTTP 1.1 requests that don't explicitly close the connection should expect to handle a connection: 'keep-alive' header

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1169)
<!-- Reviewable:end -->
