### PR TITLE
Extends 'by method handler' builder with handler class/instance arguments

### DIFF
--- a/ratpack-core/src/main/java/ratpack/handling/ByMethodSpec.java
+++ b/ratpack-core/src/main/java/ratpack/handling/ByMethodSpec.java
@@ -34,12 +34,44 @@ public interface ByMethodSpec {
   ByMethodSpec get(Block block);
 
   /**
+   * Inserts the handler to chain if the request has a HTTP method of GET.
+   *
+   * @param clazz a handler class
+   * @return this
+   */
+  ByMethodSpec get(Class<? extends Handler> clazz);
+
+  /**
+   * Inserts the handler to chain if the request has a HTTP method of GET.
+   *
+   * @param handler the handler to delegate to
+   * @return this
+   */
+  ByMethodSpec get(Handler handler);
+
+  /**
    * Defines the action to to take if the request has a HTTP method of POST.
    *
    * @param block the code to invoke if the request method matches
    * @return this
    */
   ByMethodSpec post(Block block);
+
+  /**
+   * Inserts the handler to chain if the request has a HTTP method of POST.
+   *
+   * @param clazz a handler class
+   * @return this
+   */
+  ByMethodSpec post(Class<? extends Handler> clazz);
+
+  /**
+   * Inserts the handler to chain if the request has a HTTP method of POST.
+   *
+   * @param handler the handler to delegate to
+   * @return this
+   */
+  ByMethodSpec post(Handler handler);
 
   /**
    * Defines the action to to take if the request has a HTTP method of PUT.
@@ -50,12 +82,44 @@ public interface ByMethodSpec {
   ByMethodSpec put(Block block);
 
   /**
+   * Inserts the handler to chain if the request has a HTTP method of PUT.
+   *
+   * @param clazz a handler class
+   * @return this
+   */
+  ByMethodSpec put(Class<? extends Handler> clazz);
+
+  /**
+   * Inserts the handler to chain if the request has a HTTP method of PUT.
+   *
+   * @param handler the handler to delegate to
+   * @return this
+   */
+  ByMethodSpec put(Handler handler);
+
+  /**
    * Defines the action to to take if the request has a HTTP method of PATCH.
    *
    * @param block the code to invoke if the request method matches
    * @return this
    */
   ByMethodSpec patch(Block block);
+
+  /**
+   * Inserts the handler to chain if the request has a HTTP method of PATCH.
+   *
+   * @param clazz a handler class
+   * @return this
+   */
+  ByMethodSpec patch(Class<? extends Handler> clazz);
+
+  /**
+   * Inserts the handler to chain if the request has a HTTP method of PATCH.
+   *
+   * @param handler the handler to delegate to
+   * @return this
+   */
+  ByMethodSpec patch(Handler handler);
 
   /**
    * Defines the action to to take if the request has a HTTP method of OPTIONS.
@@ -67,12 +131,46 @@ public interface ByMethodSpec {
   ByMethodSpec options(Block block);
 
   /**
+   * Inserts the handler to chain if the request has a HTTP method of OPTIONS.
+   *
+   * @param clazz a handler class
+   * @return this
+   * @since 1.1
+   */
+  ByMethodSpec options(Class<? extends Handler> clazz);
+
+  /**
+   * Inserts the handler to chain if the request has a HTTP method of OPTIONS.
+   *
+   * @param handler the handler to delegate to
+   * @return this
+   * @since 1.1
+   */
+  ByMethodSpec options(Handler handler);
+
+  /**
    * Defines the action to to take if the request has a HTTP method of DELETE.
    *
    * @param block the code to invoke if the request method matches
    * @return this
    */
   ByMethodSpec delete(Block block);
+
+  /**
+   * Inserts the handler to chain if the request has a HTTP method of DELETE.
+   *
+   * @param clazz a handler class
+   * @return this
+   */
+  ByMethodSpec delete(Class<? extends Handler> clazz);
+
+  /**
+   * Inserts the handler to chain if the request has a HTTP method of DELETE.
+   *
+   * @param handler the handler to delegate to
+   * @return this
+   */
+  ByMethodSpec delete(Handler handler);
 
   /**
    * Defines the action to to take if the request has a HTTP method of {@code methodName}.
@@ -84,5 +182,27 @@ public interface ByMethodSpec {
    * @return this
    */
   ByMethodSpec named(String methodName, Block block);
+
+  /**
+   * Inserts the handler to chain if the request has a HTTP method of {@code methodName}.
+   * <p>
+   * The method name is case insensitive.
+   *
+   * @param methodName The HTTP method to map the given action to
+   * @param clazz a handler class
+   * @return this
+   */
+  ByMethodSpec named(String methodName, Class<? extends Handler> clazz);
+
+  /**
+   * Inserts the handler to chain if the request has a HTTP method of {@code methodName}.
+   * <p>
+   * The method name is case insensitive.
+   *
+   * @param methodName The HTTP method to map the given action to
+   * @param handler the handler to delegate to
+   * @return this
+   */
+  ByMethodSpec named(String methodName, Handler handler);
 
 }

--- a/ratpack-core/src/main/java/ratpack/handling/internal/DefaultByMethodSpec.java
+++ b/ratpack-core/src/main/java/ratpack/handling/internal/DefaultByMethodSpec.java
@@ -18,6 +18,8 @@ package ratpack.handling.internal;
 
 import ratpack.func.Block;
 import ratpack.handling.ByMethodSpec;
+import ratpack.handling.Context;
+import ratpack.handling.Handler;
 
 import java.util.Map;
 
@@ -31,9 +33,11 @@ public class DefaultByMethodSpec implements ByMethodSpec {
   public static final String METHOD_DELETE = "DELETE";
 
   private final Map<String, Block> blocks;
+  private final Context context;
 
-  public DefaultByMethodSpec(Map<String, Block> blocks) {
+  public DefaultByMethodSpec(Map<String, Block> blocks, Context context) {
     this.blocks = blocks;
+    this.context = context;
   }
 
   @Override
@@ -42,8 +46,28 @@ public class DefaultByMethodSpec implements ByMethodSpec {
   }
 
   @Override
+  public ByMethodSpec get(Class<? extends Handler> clazz) {
+    return get(block(clazz));
+  }
+
+  @Override
+  public ByMethodSpec get(Handler handler) {
+    return get(block(handler));
+  }
+
+  @Override
   public ByMethodSpec post(Block block) {
     return named(METHOD_POST, block);
+  }
+
+  @Override
+  public ByMethodSpec post(Class<? extends Handler> clazz) {
+    return post(block(clazz));
+  }
+
+  @Override
+  public ByMethodSpec post(Handler handler) {
+    return post(block(handler));
   }
 
   @Override
@@ -52,8 +76,28 @@ public class DefaultByMethodSpec implements ByMethodSpec {
   }
 
   @Override
+  public ByMethodSpec put(Class<? extends Handler> clazz) {
+    return put(block(clazz));
+  }
+
+  @Override
+  public ByMethodSpec put(Handler handler) {
+    return put(block(handler));
+  }
+
+  @Override
   public ByMethodSpec patch(Block block) {
     return named(METHOD_PATCH, block);
+  }
+
+  @Override
+  public ByMethodSpec patch(Class<? extends Handler> clazz) {
+    return patch(block(clazz));
+  }
+
+  @Override
+  public ByMethodSpec patch(Handler handler) {
+    return patch(block(handler));
   }
 
   @Override
@@ -62,8 +106,28 @@ public class DefaultByMethodSpec implements ByMethodSpec {
   }
 
   @Override
+  public ByMethodSpec options(Class<? extends Handler> clazz) {
+    return options(block(clazz));
+  }
+
+  @Override
+  public ByMethodSpec options(Handler handler) {
+    return options(block(handler));
+  }
+
+  @Override
   public ByMethodSpec delete(Block block) {
     return named(METHOD_DELETE, block);
+  }
+
+  @Override
+  public ByMethodSpec delete(Class<? extends Handler> clazz) {
+    return delete(block(clazz));
+  }
+
+  @Override
+  public ByMethodSpec delete(Handler handler) {
+    return delete(block(handler));
   }
 
   @Override
@@ -72,4 +136,21 @@ public class DefaultByMethodSpec implements ByMethodSpec {
     return this;
   }
 
+  @Override
+  public ByMethodSpec named(String methodName, Class<? extends Handler> clazz) {
+    return named(methodName, block(clazz));
+  }
+
+  @Override
+  public ByMethodSpec named(String methodName, Handler handler) {
+    return named(methodName, block(handler));
+  }
+
+  private Block block(Class<? extends Handler> clazz) {
+    return block(context.get(clazz));
+  }
+
+  private Block block(Handler handler) {
+    return () -> context.insert(handler);
+  }
 }

--- a/ratpack-core/src/main/java/ratpack/handling/internal/DefaultContext.java
+++ b/ratpack-core/src/main/java/ratpack/handling/internal/DefaultContext.java
@@ -448,7 +448,7 @@ public class DefaultContext implements Context {
 
   public void byMethod(Action<? super ByMethodSpec> action) throws Exception {
     Map<String, Block> blocks = Maps.newLinkedHashMap();
-    DefaultByMethodSpec spec = new DefaultByMethodSpec(blocks);
+    DefaultByMethodSpec spec = new DefaultByMethodSpec(blocks, this);
     action.execute(spec);
     new MultiMethodHandler(blocks).handle(this);
   }

--- a/ratpack-core/src/test/groovy/ratpack/handling/internal/DefaultByMethodSpecSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/handling/internal/DefaultByMethodSpecSpec.groovy
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.handling.internal
+
+import com.google.common.collect.Maps
+import ratpack.func.Block
+import ratpack.handling.ByMethodSpec
+import ratpack.handling.Context
+import ratpack.handling.Handler
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class DefaultByMethodSpecSpec extends Specification {
+
+  static final METHODS = ["GET", "POST", "PUT", "PATCH", "OPTIONS", "DELETE"]
+
+  TestHandler handler = new TestHandler()
+  Context context = Mock(Context)
+  Map<String, Block> blocks = Maps.newLinkedHashMap()
+  ByMethodSpec byMethodSpec = new DefaultByMethodSpec(blocks, context)
+
+  @Unroll
+  def "handle #method with named block"() {
+    given:
+    def block = Mock(Block)
+
+    when:
+    byMethodSpec.named(method, block)
+
+    then:
+    blocks.get(method) == block
+
+    where:
+    method << METHODS
+  }
+
+  @Unroll
+  def "handle #method with block"() {
+    setup:
+    def block = Mock(Block)
+
+    when:
+    byMethodSpec."${method.toLowerCase()}"(block)
+
+    then:
+    blocks.get(method) == block
+
+    where:
+    method << METHODS
+  }
+
+  @Unroll
+  def "handle #method with Handler instance"() {
+    when:
+    byMethodSpec."${method.toLowerCase()}"(handler)
+
+    then:
+    blocks.get(method) != null
+
+    when:
+    blocks.get(method).execute()
+
+    then:
+    1 * context.insert(handler)
+
+    where:
+    method << METHODS
+  }
+
+  @Unroll
+  def "handle #method with clazz"() {
+    setup:
+    context = Mock(Context) {
+      1 * get(TestHandler) >> handler
+    }
+    byMethodSpec = new DefaultByMethodSpec(blocks, context)
+
+    when:
+    byMethodSpec."${method.toLowerCase()}"(TestHandler)
+
+    then:
+    blocks.get(method) != null
+
+    when:
+    blocks.get(method).execute()
+
+    then:
+    1 * context.insert(handler)
+
+    where:
+    method << METHODS
+  }
+
+  private static class TestHandler implements Handler {
+    @Override
+    void handle(Context ctx) throws Exception {
+    }
+  }
+
+}

--- a/ratpack-groovy/src/main/java/ratpack/groovy/handling/GroovyByMethodSpec.java
+++ b/ratpack-groovy/src/main/java/ratpack/groovy/handling/GroovyByMethodSpec.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.groovy.handling;
+
+import groovy.lang.Closure;
+import groovy.lang.DelegatesTo;
+import ratpack.handling.ByMethodSpec;
+
+/**
+ * A Groovy oriented multi-method handler builder.
+ */
+public interface GroovyByMethodSpec extends ByMethodSpec {
+
+  /**
+   * Inserts the handler to chain if the request has a HTTP method of GET.
+   *
+   * @param closure a handler closure
+   * @return this {@code ByMethodSpec}
+   */
+  ByMethodSpec get(@DelegatesTo(value = GroovyContext.class, strategy = Closure.DELEGATE_FIRST) Closure<?> closure);
+
+  /**
+   * Inserts the handler to chain if the request has a HTTP method of POST.
+   *
+   * @param closure a handler closure
+   * @return this {@code ByMethodSpec}
+   */
+  ByMethodSpec post(@DelegatesTo(value = GroovyContext.class, strategy = Closure.DELEGATE_FIRST) Closure<?> closure);
+
+  /**
+   * Inserts the handler to chain if the request has a HTTP method of PUT.
+   *
+   * @param closure a handler closure
+   * @return this {@code ByMethodSpec}
+   */
+  ByMethodSpec put(@DelegatesTo(value = GroovyContext.class, strategy = Closure.DELEGATE_FIRST) Closure<?> closure);
+
+  /**
+   * Inserts the handler to chain if the request has a HTTP method of PATCH.
+   *
+   * @param closure a handler closure
+   * @return this {@code ByMethodSpec}
+   */
+  ByMethodSpec patch(@DelegatesTo(value = GroovyContext.class, strategy = Closure.DELEGATE_FIRST) Closure<?> closure);
+
+
+  /**
+   * Inserts the handler to chain if the request has a HTTP method of OPTIONS.
+   *
+   * @param closure a handler closure
+   * @return this {@code ByMethodSpec}
+   */
+  ByMethodSpec options(@DelegatesTo(value = GroovyContext.class, strategy = Closure.DELEGATE_FIRST) Closure<?> closure);
+
+
+  /**
+   * Inserts the handler to chain if the request has a HTTP method of DELETE.
+   *
+   * @param closure a handler closure
+   * @return this {@code ByMethodSpec}
+   */
+  ByMethodSpec delete(@DelegatesTo(value = GroovyContext.class, strategy = Closure.DELEGATE_FIRST) Closure<?> closure);
+
+  /**
+   * Inserts the handler to chain if the request has a HTTP method of {@code methodName}.
+   * @param closure a handler closure
+   * @return this {@code ByMethodSpec}
+   */
+  ByMethodSpec named(@DelegatesTo(value = GroovyContext.class, strategy = Closure.DELEGATE_FIRST) String methodName, Closure<?> closure);
+
+}

--- a/ratpack-groovy/src/main/java/ratpack/groovy/handling/GroovyContext.java
+++ b/ratpack-groovy/src/main/java/ratpack/groovy/handling/GroovyContext.java
@@ -21,7 +21,6 @@ import groovy.lang.DelegatesTo;
 import ratpack.func.Action;
 import ratpack.groovy.handling.internal.DefaultGroovyContext;
 import ratpack.handling.ByContentSpec;
-import ratpack.handling.ByMethodSpec;
 import ratpack.handling.Context;
 import ratpack.handling.RequestOutcome;
 
@@ -85,7 +84,7 @@ public interface GroovyContext extends Context {
    * @param closure defines the action to take for different HTTP methods
    * @throws Exception any thrown by the closure
    */
-  void byMethod(@DelegatesTo(value = ByMethodSpec.class, strategy = Closure.DELEGATE_FIRST) Closure<?> closure) throws Exception;
+  void byMethod(@DelegatesTo(value = GroovyByMethodSpec.class, strategy = Closure.DELEGATE_FIRST) Closure<?> closure) throws Exception;
 
   /**
    * Groovy friendly overload of {@link #byContent(Action)}.

--- a/ratpack-groovy/src/main/java/ratpack/groovy/handling/internal/DefaultGroovyByMethodSpec.java
+++ b/ratpack-groovy/src/main/java/ratpack/groovy/handling/internal/DefaultGroovyByMethodSpec.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.groovy.handling.internal;
+
+import groovy.lang.Closure;
+import io.netty.handler.codec.http.HttpMethod;
+import ratpack.func.Block;
+import ratpack.groovy.handling.GroovyByMethodSpec;
+import ratpack.handling.ByMethodSpec;
+import ratpack.handling.Context;
+import ratpack.handling.Handler;
+
+public class DefaultGroovyByMethodSpec implements GroovyByMethodSpec {
+
+  private final ByMethodSpec delegate;
+  private final Context context;
+
+  public DefaultGroovyByMethodSpec(ByMethodSpec delegate, Context context) {
+    this.delegate = delegate;
+    this.context = context;
+  }
+
+  @Override
+  public ByMethodSpec get(Block block) {
+    return delegate.get(block);
+  }
+
+  @Override
+  public ByMethodSpec get(Class<? extends Handler> clazz) {
+    return delegate.get(clazz);
+  }
+
+  @Override
+  public ByMethodSpec get(Handler handler) {
+    return delegate.get(handler);
+  }
+
+  @Override
+  public ByMethodSpec get(Closure<?> closure) {
+   return named(HttpMethod.GET.name(), closure);
+  }
+
+  @Override
+  public ByMethodSpec post(Block block) {
+    return delegate.post(block);
+  }
+
+  @Override
+  public ByMethodSpec post(Class<? extends Handler> clazz) {
+    return delegate.post(clazz);
+  }
+
+  @Override
+  public ByMethodSpec post(Handler handler) {
+    return delegate.post(handler);
+  }
+
+  @Override
+  public ByMethodSpec post(Closure<?> closure) {
+    return named(HttpMethod.POST.name(), closure);
+  }
+
+  @Override
+  public ByMethodSpec put(Block block) {
+    return delegate.put(block);
+  }
+
+  @Override
+  public ByMethodSpec put(Class<? extends Handler> clazz) {
+    return delegate.put(clazz);
+  }
+
+  @Override
+  public ByMethodSpec put(Handler handler) {
+    return delegate.put(handler);
+  }
+
+  @Override
+  public ByMethodSpec put(Closure<?> closure) {
+    return named(HttpMethod.PUT.name(), closure);
+  }
+
+  @Override
+  public ByMethodSpec patch(Block block) {
+    return delegate.patch(block);
+  }
+
+  @Override
+  public ByMethodSpec patch(Class<? extends Handler> clazz) {
+    return delegate.patch(clazz);
+  }
+
+  @Override
+  public ByMethodSpec patch(Handler handler) {
+    return delegate.patch(handler);
+  }
+
+  @Override
+  public ByMethodSpec patch(Closure<?> closure) {
+    return named(HttpMethod.PATCH.name(), closure);
+  }
+
+  @Override
+  public ByMethodSpec options(Block block) {
+    return delegate.options(block);
+  }
+
+  @Override
+  public ByMethodSpec options(Class<? extends Handler> clazz) {
+    return delegate.options(clazz);
+  }
+
+  @Override
+  public ByMethodSpec options(Handler handler) {
+    return delegate.options(handler);
+  }
+
+  @Override
+  public ByMethodSpec options(Closure<?> closure) {
+    return named(HttpMethod.OPTIONS.name(), closure);
+  }
+
+  @Override
+  public ByMethodSpec delete(Block block) {
+    return delegate.delete(block);
+  }
+
+  @Override
+  public ByMethodSpec delete(Class<? extends Handler> clazz) {
+    return delegate.delete(clazz);
+  }
+
+  @Override
+  public ByMethodSpec delete(Handler handler) {
+    return delegate.delete(handler);
+  }
+
+  @Override
+  public ByMethodSpec delete(Closure<?> closure) {
+    return named(HttpMethod.DELETE.name(), closure);
+  }
+
+  @Override
+  public ByMethodSpec named(String methodName, Block block) {
+    return delegate.named(methodName, block);
+  }
+
+  @Override
+  public ByMethodSpec named(String methodName, Class<? extends Handler> clazz) {
+    return delegate.named(methodName, clazz);
+  }
+
+  @Override
+  public ByMethodSpec named(String methodName, Handler handler) {
+    return delegate.named(methodName, handler);
+  }
+
+  @Override
+  public ByMethodSpec named(String methodName, Closure<?> closure) {
+    closure.setDelegate(context);
+    closure.setResolveStrategy(Closure.DELEGATE_FIRST);
+    if (closure.getMaximumNumberOfParameters() == 0) {
+      delegate.named(methodName, (Block) closure::call);
+    } else {
+      delegate.named(methodName, (Handler) closure::call);
+    }
+    return this;
+  }
+
+}

--- a/ratpack-groovy/src/test/groovy/ratpack/groovy/handling/internal/DefaultGroovyByMethodSpecSpec.groovy
+++ b/ratpack-groovy/src/test/groovy/ratpack/groovy/handling/internal/DefaultGroovyByMethodSpecSpec.groovy
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.groovy.handling.internal
+
+import ratpack.func.Block
+import ratpack.groovy.handling.GroovyByMethodSpec
+import ratpack.handling.ByMethodSpec
+import ratpack.handling.Context
+import ratpack.handling.Handler
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class DefaultGroovyByMethodSpecSpec extends Specification {
+
+  static final METHODS = ["GET", "POST", "PUT", "PATCH", "OPTIONS", "DELETE"]
+
+  Context context = Mock(Context)
+  ByMethodSpec delegate = Mock(ByMethodSpec)
+  GroovyByMethodSpec byMethodSpec = new DefaultGroovyByMethodSpec(delegate, context)
+
+  @Unroll
+  def "handle #method with closure"() {
+    when:
+    byMethodSpec."${method.toLowerCase()}" {
+      render("Test $method with closure")
+    }
+
+    then:
+    0 * context.render(_)
+    1 * delegate.named(method, { it instanceof Handler })
+
+    where:
+    method << METHODS
+  }
+
+  @Unroll
+  def "handle #method with named closure"() {
+    when:
+    byMethodSpec.named(method) {
+      render("Test $method with closure")
+    }
+
+    then:
+    0 * context.render(_)
+    1 * delegate.named(method, { it instanceof Handler })
+
+    where:
+    method << METHODS
+  }
+
+  @Unroll
+  def "handle #method with named block"() {
+    given:
+    def block = Mock(Block)
+
+    when:
+    byMethodSpec.named(method, block)
+
+    then:
+    1 * delegate.named(method, block)
+
+    where:
+    method << METHODS
+  }
+
+  @Unroll
+  def "handle #method with block"() {
+    setup:
+    def block = Mock(Block)
+
+    when:
+    byMethodSpec."${method.toLowerCase()}"(block)
+
+    then:
+    1 * delegate."${method.toLowerCase()}"(block)
+
+    where:
+    method << METHODS
+  }
+
+  @Unroll
+  def "handle #method with Handler instance"() {
+    setup:
+    def handler = Mock(Handler)
+
+    when:
+    byMethodSpec."${method.toLowerCase()}"(handler)
+
+    then:
+    1 * delegate."${method.toLowerCase()}"(handler)
+
+    where:
+    method << METHODS
+  }
+
+  @Unroll
+  def "handle #method with clazz"() {
+    setup:
+    byMethodSpec = new DefaultGroovyByMethodSpec(delegate, context)
+
+    when:
+    byMethodSpec."${method.toLowerCase()}"(TestHandler)
+
+    then:
+    1 * delegate."${method.toLowerCase()}"(TestHandler)
+
+    where:
+    method << METHODS
+  }
+
+  private static class TestHandler implements Handler {
+    @Override
+    void handle(Context ctx) throws Exception {
+    }
+  }
+
+}


### PR DESCRIPTION
In my use case I have many handler classes. This PR allows me to map them directly to http method like this:

```
handlers {
  prefix "users/:id" {
    byMethod {
      get GetUserHandler
      put PutUserHandler
      delete DeleteUserHandler
    }
  }
}
```

Without these changes I have to write code like this:

```
handlers {
  prefix "users/:id" {
    byMethod {
      get {
        context.insert(context.get(GetUserHandler))
      }
      put {
        // or like this
        context.get(PutUserHandler).handle(context)
      }
      ...
    }
  }
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1172)
<!-- Reviewable:end -->
