### PR TITLE
Point to non-deprecated method `Promise#async` instead of `Promise#of`

### DIFF
--- a/ratpack-manual/src/content/chapters/14-async.md
+++ b/ratpack-manual/src/content/chapters/14-async.md
@@ -113,7 +113,7 @@ See the [Blocking#get()](api/ratpack/exec/Blocking.html#get-ratpack.func.Factory
 
 ## Performing async operations
 
-The [Promise#of(Upstream<T>>)](api/ratpack/exec/Promise.html#of-ratpack.exec.Upstream-) for integrating with async APIs.
+The [Promise#async(Upstream<T>>)](api/ratpack/exec/Promise.html#async-ratpack.exec.Upstream-) for integrating with async APIs.
 It is essentially a mechanism for adapting 3rd party APIs to Ratpack's promise type.
 
 ```language-java


### PR DESCRIPTION

----

I'm having trouble building Ratpack so can't entirely verify that this is correct (but appears to be).

```
$ java -version
java version "1.8.0_101"
Java(TM) SE Runtime Environment (build 1.8.0_101-b13)
Java HotSpot(TM) 64-Bit Server VM (build 25.101-b13, mixed mode)

$ ./gradlew :ratpack-manual:build
...
...
...
javadoc: error - invalid flag: --allow-script-in-comments

:ratpack-manual:api FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':ratpack-manual:api'.
> Javadoc generation failed. Generated Javadoc options file (useful for troubleshooting): '/Users/mkobit/Workspace/personal/ratpack/ratpack/ratpack-manual/build/tmp/api/javadoc.options'
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1174)
<!-- Reviewable:end -->
