### PR TITLE
ByContentSpec should accept CharSequence for Types

### DIFF
--- a/ratpack-core/src/main/java/ratpack/handling/ByContentSpec.java
+++ b/ratpack-core/src/main/java/ratpack/handling/ByContentSpec.java
@@ -78,7 +78,7 @@ public interface ByContentSpec {
    * @param block the code to invoke if the content type matches
    * @return this
    */
-  default ByContentSpec type(String mimeType, Block block) {
+  default ByContentSpec type(CharSequence mimeType, Block block) {
     return type(mimeType, Handlers.of(block));
   }
 
@@ -91,7 +91,7 @@ public interface ByContentSpec {
    * @return this
    * @since 1.5
    */
-  ByContentSpec type(String mimeType, Handler handler);
+  ByContentSpec type(CharSequence mimeType, Handler handler);
 
   /**
    * Specifies that the given handler should be used if the client wants content of the given MIME type.
@@ -102,7 +102,7 @@ public interface ByContentSpec {
    * @return this
    * @since 1.5
    */
-  ByContentSpec type(String mimeType, Class<? extends Handler> handlerType);
+  ByContentSpec type(CharSequence mimeType, Class<? extends Handler> handlerType);
 
   /**
    * Specifies that the given handler should be used if the client wants content of type "text/plain".

--- a/ratpack-core/src/main/java/ratpack/handling/internal/ContentNegotiationHandler.java
+++ b/ratpack-core/src/main/java/ratpack/handling/internal/ContentNegotiationHandler.java
@@ -19,6 +19,7 @@ package ratpack.handling.internal;
 import com.google.common.base.Strings;
 import com.google.common.collect.Iterables;
 import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
 import ratpack.func.Action;
 import ratpack.handling.ByContentSpec;
 import ratpack.handling.Context;
@@ -69,9 +70,7 @@ public class ContentNegotiationHandler implements Handler {
 
   public static class DefaultByContentSpec implements ByContentSpec {
 
-    private static final String TYPE_PLAIN_TEXT = "text/plain";
     private static final String TYPE_HTML = "text/html";
-    private static final String TYPE_JSON = "application/json";
     private static final String TYPE_XML = "application/xml";
 
     private final Map<String, Handler> handlers;
@@ -95,12 +94,12 @@ public class ContentNegotiationHandler implements Handler {
     }
 
     @Override
-    public ByContentSpec type(String mimeType, Handler handler) {
+    public ByContentSpec type(CharSequence mimeType, Handler handler) {
       if (mimeType == null) {
         throw new IllegalArgumentException("mimeType cannot be null");
       }
 
-      String trimmed = mimeType.trim();
+      String trimmed = mimeType.toString().trim();
       if (trimmed.isEmpty()) {
         throw new IllegalArgumentException("mimeType cannot be a blank string");
       }
@@ -109,13 +108,13 @@ public class ContentNegotiationHandler implements Handler {
         throw new IllegalArgumentException("mimeType cannot include wildcards");
       }
 
-      handlers.put(mimeType, handler);
+      handlers.put(trimmed, handler);
       return this;
     }
 
     @Override
     public ByContentSpec plainText(Handler handler) {
-      return type(TYPE_PLAIN_TEXT, handler);
+      return type(HttpHeaderValues.TEXT_PLAIN, handler);
     }
 
     @Override
@@ -125,7 +124,7 @@ public class ContentNegotiationHandler implements Handler {
 
     @Override
     public ByContentSpec json(Handler handler) {
-      return type(TYPE_JSON, handler);
+      return type(HttpHeaderValues.APPLICATION_JSON, handler);
     }
 
     @Override
@@ -170,7 +169,7 @@ public class ContentNegotiationHandler implements Handler {
     }
 
     @Override
-    public ByContentSpec type(String mimeType, Class<? extends Handler> handlerType) {
+    public ByContentSpec type(CharSequence mimeType, Class<? extends Handler> handlerType) {
       return type(mimeType, registry.get(handlerType));
     }
 

--- a/ratpack-core/src/test/groovy/ratpack/http/ContentNegotiationSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/http/ContentNegotiationSpec.groovy
@@ -16,6 +16,7 @@
 
 package ratpack.http
 
+import io.netty.handler.codec.http.HttpHeaderValues
 import ratpack.error.ServerErrorHandler
 import ratpack.http.client.RequestSpec
 import ratpack.test.internal.RatpackGroovyDslSpec
@@ -100,6 +101,33 @@ class ContentNegotiationSpec extends RatpackGroovyDslSpec {
     withAcceptHeader("text/html")
     then:
     text == "html"
+  }
+
+  def "Accepts valid custom mime types (#mimeType"(CharSequence mimeType, String expectedOutput) {
+    given:
+    handlers {
+      get {
+        byContent {
+          type(HttpHeaderValues.APPLICATION_OCTET_STREAM) {
+            render "octect-stream"
+          }
+          type("application/x-protobuf") {
+            render "x-protobuf"
+          }
+        }
+      }
+    }
+
+    when:
+    withAcceptHeader(mimeType.toString())
+
+    then:
+    text == expectedOutput
+
+    where:
+    mimeType                                  || expectedOutput
+    HttpHeaderValues.APPLICATION_OCTET_STREAM || "octect-stream"
+    "application/x-protobuf"                  || "x-protobuf"
   }
 
   def "refuses invalid custom mime types (#mimeType)"(String mimeType, String message) {

--- a/ratpack-groovy/src/main/java/ratpack/groovy/handling/DefaultGroovyByContentSpec.java
+++ b/ratpack-groovy/src/main/java/ratpack/groovy/handling/DefaultGroovyByContentSpec.java
@@ -33,17 +33,17 @@ public class DefaultGroovyByContentSpec implements GroovyByContentSpec {
   }
 
   @Override
-  public GroovyByContentSpec type(String mimeType, Block block) {
+  public GroovyByContentSpec type(CharSequence mimeType, Block block) {
     return r(delegate.type(mimeType, block));
   }
 
   @Override
-  public GroovyByContentSpec type(String mimeType, Handler handler) {
+  public GroovyByContentSpec type(CharSequence mimeType, Handler handler) {
     return r(delegate.type(mimeType, handler));
   }
 
   @Override
-  public GroovyByContentSpec type(String mimeType, Class<? extends Handler> handlerType) {
+  public GroovyByContentSpec type(CharSequence mimeType, Class<? extends Handler> handlerType) {
     return r(delegate.type(mimeType, handlerType));
   }
 

--- a/ratpack-groovy/src/main/java/ratpack/groovy/handling/GroovyByContentSpec.java
+++ b/ratpack-groovy/src/main/java/ratpack/groovy/handling/GroovyByContentSpec.java
@@ -41,7 +41,7 @@ public interface GroovyByContentSpec extends ByContentSpec {
    * @param handler the handler to invoke if the content type matches
    * @return this
    */
-  default GroovyByContentSpec type(String mimeType, @DelegatesTo(value = GroovyContext.class, strategy = Closure.DELEGATE_FIRST) Closure<?> handler) {
+  default GroovyByContentSpec type(CharSequence mimeType, @DelegatesTo(value = GroovyContext.class, strategy = Closure.DELEGATE_FIRST) Closure<?> handler) {
     return type(mimeType, Groovy.groovyHandler(handler));
   }
 
@@ -109,19 +109,19 @@ public interface GroovyByContentSpec extends ByContentSpec {
    * {@inheritDoc}
    */
   @Override
-  GroovyByContentSpec type(String mimeType, Block block);
+  GroovyByContentSpec type(CharSequence mimeType, Block block);
 
   /**
    * {@inheritDoc}
    */
   @Override
-  GroovyByContentSpec type(String mimeType, Handler handler);
+  GroovyByContentSpec type(CharSequence mimeType, Handler handler);
 
   /**
    * {@inheritDoc}
    */
   @Override
-  GroovyByContentSpec type(String mimeType, Class<? extends Handler> handlerType);
+  GroovyByContentSpec type(CharSequence mimeType, Class<? extends Handler> handlerType);
 
   /**
    * {@inheritDoc}


### PR DESCRIPTION
Instead of taking String we want to accept CharSequence for the `type` methods so we can use the Netty Constants

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1224)
<!-- Reviewable:end -->
