### PR TITLE
Update DefaultRequestFixture.java

### DIFF
--- a/ratpack-groovy-test/src/main/java/ratpack/groovy/test/handling/GroovyRequestFixture.java
+++ b/ratpack-groovy-test/src/main/java/ratpack/groovy/test/handling/GroovyRequestFixture.java
@@ -213,6 +213,12 @@ public interface GroovyRequestFixture extends RequestFixture {
    * {@inheritDoc}
    */
   @Override
+  GroovyRequestFixture pathBinding(String boundTo, String pastBinding, Map<String, String> pathTokens, String description);
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
   GroovyRequestFixture serverConfig(Action<? super ServerConfigBuilder> action) throws Exception;
 
   /**

--- a/ratpack-groovy-test/src/main/java/ratpack/groovy/test/handling/internal/DefaultGroovyRequestFixture.java
+++ b/ratpack-groovy-test/src/main/java/ratpack/groovy/test/handling/internal/DefaultGroovyRequestFixture.java
@@ -122,6 +122,12 @@ public class DefaultGroovyRequestFixture implements GroovyRequestFixture {
   }
 
   @Override
+  public GroovyRequestFixture pathBinding(String boundTo, String pastBinding, Map<String, String> pathTokens, String description) {
+    delegate.pathBinding(boundTo, pastBinding, pathTokens, description);
+    return this;
+  }
+
+  @Override
   public GroovyRequestFixture serverConfig(Action<? super ServerConfigBuilder> action) throws Exception {
     delegate.serverConfig(action);
     return this;

--- a/ratpack-test/src/main/java/ratpack/test/handling/RequestFixture.java
+++ b/ratpack-test/src/main/java/ratpack/test/handling/RequestFixture.java
@@ -276,6 +276,19 @@ public interface RequestFixture {
   RequestFixture pathBinding(String boundTo, String pastBinding, Map<String, String> pathTokens);
 
   /**
+   * Adds a path binding, with the given path tokens and parts.
+   * <p>
+   * By default, there are no path tokens and no path binding.
+   *
+   * @param boundTo the part of the request path that the binding bound to
+   * @param pastBinding the part of the request path past {@code boundTo}
+   * @param pathTokens the path tokens and binding to make available to the handler(s) under test
+   * @param description the description of the request path binding
+   * @return this
+   */
+  RequestFixture pathBinding(String boundTo, String pastBinding, Map<String, String> pathTokens, String description);
+
+  /**
    * Configures the context registry.
    *
    * @param action a registry specification action

--- a/ratpack-test/src/main/java/ratpack/test/handling/internal/DefaultRequestFixture.java
+++ b/ratpack-test/src/main/java/ratpack/test/handling/internal/DefaultRequestFixture.java
@@ -227,7 +227,12 @@ public class DefaultRequestFixture implements RequestFixture {
 
   @Override
   public RequestFixture pathBinding(String boundTo, String pastBinding, Map<String, String> pathTokens) {
-    pathBinding = new DefaultPathBinding(pastBinding, ImmutableMap.copyOf(pathTokens), new RootPathBinding(pastBinding), "");
+    return pathBinding(boundTo, pastBinding, pathTokens, "");
+  }
+
+  @Override
+  public RequestFixture pathBinding(String boundTo, String pastBinding, Map<String, String> pathTokens, String description) {
+    pathBinding = new DefaultPathBinding(pastBinding, ImmutableMap.copyOf(pathTokens), new RootPathBinding(pastBinding), description);
     return this;
   }
 


### PR DESCRIPTION
Added `pathBinding` overload that allows caller to set the `PathBinding`'s description.

My team is currently stuck using reflection to set the `description` because there's no other way we can find to set it, and we need it to be a certain value for our unit tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1228)
<!-- Reviewable:end -->
