### PR TITLE
Fix path binding in request fixture

### DIFF
--- a/ratpack-test/src/main/java/ratpack/test/handling/internal/DefaultRequestFixture.java
+++ b/ratpack-test/src/main/java/ratpack/test/handling/internal/DefaultRequestFixture.java
@@ -232,7 +232,7 @@ public class DefaultRequestFixture implements RequestFixture {
 
   @Override
   public RequestFixture pathBinding(String boundTo, String pastBinding, Map<String, String> pathTokens, String description) {
-    pathBinding = new DefaultPathBinding(pastBinding, ImmutableMap.copyOf(pathTokens), new RootPathBinding(pastBinding), description);
+    pathBinding = new DefaultPathBinding(boundTo, ImmutableMap.copyOf(pathTokens), new RootPathBinding(boundTo + "/" + pastBinding), description);
     return this;
   }
 

--- a/ratpack-test/src/test/groovy/ratpack/test/handling/HandlerUnitTestingSpec.groovy
+++ b/ratpack-test/src/test/groovy/ratpack/test/handling/HandlerUnitTestingSpec.groovy
@@ -378,6 +378,21 @@ class HandlerUnitTestingSpec extends Specification {
     rendered(String) == [a: "1", b: "2"].toString()
   }
 
+  def "can add path past binding for unit tests"() {
+    given:
+    fixture {
+      pathBinding "bound/to", "past/binding", [:]
+    }
+
+    when:
+    handle {
+      render([boundTo: pathBinding.boundTo, pastBinding: pathBinding.pastBinding].toString())
+    }
+
+    then:
+    rendered(String) == [boundTo: "bound/to", pastBinding: "past/binding"].toString()
+  }
+
   def "can access things inserted into registry"() {
     when:
     handle {


### PR DESCRIPTION
Unless I'm badly misunderstanding the expected behaviour here, we seem to be doing the wrong thing in the request fixture with the path binding bound-to and past-binding parameters. This fixes it to give what a user of the fixture would expect.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1237)
<!-- Reviewable:end -->
