### PR TITLE
ISSUE-1244: Expose some metrics on HttpClient

### DIFF
--- a/ratpack-core/src/main/java/ratpack/http/client/internal/ChannelPoolStats.java
+++ b/ratpack-core/src/main/java/ratpack/http/client/internal/ChannelPoolStats.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.http.client.internal;
+
+public interface ChannelPoolStats {
+
+  String getHost();
+
+  int getActiveConnectionCount();
+
+  int getIdleConnectionCount();
+
+  default HostStats getHostStats() {
+    return new HostStats(getActiveConnectionCount(), getIdleConnectionCount());
+  }
+
+}

--- a/ratpack-core/src/main/java/ratpack/http/client/internal/DefaultHttpClient.java
+++ b/ratpack-core/src/main/java/ratpack/http/client/internal/DefaultHttpClient.java
@@ -19,7 +19,6 @@ package ratpack.http.client.internal;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.PooledByteBufAllocator;
-import io.netty.channel.Channel;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.pool.*;
 import ratpack.exec.ExecController;
@@ -34,40 +33,16 @@ import ratpack.util.internal.ChannelImplDetector;
 
 import java.net.URI;
 import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 public class DefaultHttpClient implements HttpClientInternal {
 
   private static final ChannelHealthChecker ALWAYS_UNHEALTHY = channel ->
     channel.eventLoop().newSucceededFuture(Boolean.FALSE);
 
-  private static final ChannelPoolHandler NOOP_HANDLER = new AbstractChannelPoolHandler() {
-    @Override
-    public void channelCreated(Channel ch) throws Exception {}
-
-    @Override
-    public void channelReleased(Channel ch) throws Exception {
-    }
-  };
-
-  private static final ChannelPoolHandler POOLING_HANDLER = new AbstractChannelPoolHandler() {
-    @Override
-    public void channelCreated(Channel ch) throws Exception {
-
-    }
-
-    @Override
-    public void channelReleased(Channel ch) throws Exception {
-      if (ch.isOpen()) {
-        ch.config().setAutoRead(true);
-        ch.pipeline().addLast(IdlingConnectionHandler.INSTANCE);
-      }
-    }
-
-    @Override
-    public void channelAcquired(Channel ch) throws Exception {
-      ch.pipeline().remove(IdlingConnectionHandler.INSTANCE);
-    }
-  };
+  private final Map<String, ChannelPoolStats> hostStats = new ConcurrentHashMap<>();
 
   private final HttpChannelPoolMap channelPoolMap = new HttpChannelPoolMap() {
     @Override
@@ -82,14 +57,18 @@ public class DefaultHttpClient implements HttpClientInternal {
         .option(ChannelOption.SO_KEEPALIVE, isPooling());
 
       if (isPooling()) {
-        ChannelPool channelPool = new FixedChannelPool(bootstrap, POOLING_HANDLER, getPoolSize(), getPoolQueueSize());
+        InstrumentedChannelPoolHandler channelPoolHandler = getPoolingHandler(key);
+        hostStats.put(key.host, channelPoolHandler);
+        ChannelPool channelPool = new FixedChannelPool(bootstrap, channelPoolHandler, getPoolSize(), getPoolQueueSize());
         ((ExecControllerInternal) key.execution.getController()).onClose(() -> {
           remove(key);
           channelPool.close();
         });
         return channelPool;
       } else {
-        return new SimpleChannelPool(bootstrap, NOOP_HANDLER, ALWAYS_UNHEALTHY);
+        InstrumentedChannelPoolHandler channelPoolHandler = getSimpleHandler(key);
+        hostStats.put(key.host, channelPoolHandler);
+        return new SimpleChannelPool(bootstrap, channelPoolHandler, ALWAYS_UNHEALTHY);
       }
     }
   };
@@ -98,6 +77,20 @@ public class DefaultHttpClient implements HttpClientInternal {
 
   private DefaultHttpClient(DefaultHttpClient.Spec spec) {
     this.spec = spec;
+  }
+
+  private InstrumentedChannelPoolHandler getPoolingHandler(HttpChannelKey key) {
+    if (spec.enableMetricsCollection) {
+      return new InstrumentedFixedChannelPoolHandler(key, getPoolSize());
+    }
+    return new NoopFixedChannelPoolHandler(key);
+  }
+
+  private InstrumentedChannelPoolHandler getSimpleHandler(HttpChannelKey key) {
+    if (spec.enableMetricsCollection) {
+      return new InstrumentedSimpleChannelPoolHandler(key);
+    }
+    return new NoopSimpleChannelPoolHandler(key);
   }
 
   @Override
@@ -184,6 +177,7 @@ public class DefaultHttpClient implements HttpClientInternal {
     private Duration connectTimeout = Duration.ofSeconds(30);
     private Action<? super RequestSpec> requestInterceptor = Action.noop();
     private Action<? super HttpResponse> responseInterceptor = Action.noop();
+    private boolean enableMetricsCollection;
 
     private Spec() {
     }
@@ -198,6 +192,7 @@ public class DefaultHttpClient implements HttpClientInternal {
       this.connectTimeout = spec.connectTimeout;
       this.requestInterceptor = spec.requestInterceptor;
       this.responseInterceptor = spec.responseInterceptor;
+      this.enableMetricsCollection = spec.enableMetricsCollection;
     }
 
     @Override
@@ -259,6 +254,11 @@ public class DefaultHttpClient implements HttpClientInternal {
       responseInterceptor = responseInterceptor.append(response -> operation.then());
       return this;
     }
+
+    public HttpClientSpec enableMetricsCollection(boolean enableMetricsCollection) {
+      this.enableMetricsCollection = enableMetricsCollection;
+      return this;
+    }
   }
 
   @Override
@@ -295,6 +295,15 @@ public class DefaultHttpClient implements HttpClientInternal {
         .start(e ->
           action.execute(r)
         )
+    );
+  }
+
+  public HttpClientStats getHttpClientStats() {
+    return new HttpClientStats(
+      hostStats.entrySet().stream().collect(Collectors.toMap(
+        Map.Entry::getKey,
+        e -> e.getValue().getHostStats()
+      ))
     );
   }
 }

--- a/ratpack-core/src/main/java/ratpack/http/client/internal/HostStats.java
+++ b/ratpack-core/src/main/java/ratpack/http/client/internal/HostStats.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.http.client.internal;
+
+public class HostStats {
+  private final long activeConnectionCount;
+  private final long idleConnectionCount;
+  private final long totalConnectionCount;
+
+  public HostStats(long activeConnectionCount, long idleConnectionCount) {
+    this.activeConnectionCount = activeConnectionCount;
+    this.idleConnectionCount = idleConnectionCount;
+    this.totalConnectionCount = activeConnectionCount + idleConnectionCount;
+  }
+
+  public long getActiveConnectionCount() {
+    return activeConnectionCount;
+  }
+
+  public long getIdleConnectionCount() {
+    return idleConnectionCount;
+  }
+
+  public long getTotalConnectionCount() {
+    return totalConnectionCount;
+  }
+}

--- a/ratpack-core/src/main/java/ratpack/http/client/internal/HttpClientStats.java
+++ b/ratpack-core/src/main/java/ratpack/http/client/internal/HttpClientStats.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.http.client.internal;
+
+import java.util.Map;
+
+public class HttpClientStats {
+
+  private final Map<String, HostStats> statsPerHost;
+
+  public HttpClientStats(Map<String, HostStats> statsPerHost) {
+    this.statsPerHost = statsPerHost;
+  }
+
+  public Map<String, HostStats> getStatsPerHost() {
+    return statsPerHost;
+  }
+
+  /**
+   * @return The sum of {@link #getTotalActiveConnectionCount()} and {@link #getTotalIdleConnectionCount()},
+   * a long representing the total number of connections in the connection pool.
+   */
+  public long getTotalConnectionCount() {
+    return getTotalActiveConnectionCount() + getTotalIdleConnectionCount();
+  }
+
+  /**
+   * @return A long representing the number of active connections in the connection pool.
+   */
+  public long getTotalActiveConnectionCount() {
+    return statsPerHost
+      .values()
+      .stream()
+      .mapToLong(HostStats::getActiveConnectionCount)
+      .sum();
+  }
+
+  /**
+   * @return A long representing the number of idle connections in the connection pool.
+   */
+  public long getTotalIdleConnectionCount() {
+    return statsPerHost
+      .values()
+      .stream()
+      .mapToLong(HostStats::getIdleConnectionCount)
+      .sum();
+  }
+
+  @Override
+  public String toString() {
+    return "There are " + getTotalConnectionCount()
+      + " total connections, " + getTotalActiveConnectionCount()
+      + " are active and " + getTotalIdleConnectionCount() + " are idle.";
+  }
+
+}

--- a/ratpack-core/src/main/java/ratpack/http/client/internal/InstrumentedChannelPoolHandler.java
+++ b/ratpack-core/src/main/java/ratpack/http/client/internal/InstrumentedChannelPoolHandler.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.http.client.internal;
+
+import io.netty.channel.pool.ChannelPoolHandler;
+
+public interface InstrumentedChannelPoolHandler extends ChannelPoolHandler, ChannelPoolStats {
+
+}

--- a/ratpack-core/src/main/java/ratpack/http/client/internal/InstrumentedFixedChannelPoolHandler.java
+++ b/ratpack-core/src/main/java/ratpack/http/client/internal/InstrumentedFixedChannelPoolHandler.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.http.client.internal;
+
+import io.netty.channel.Channel;
+import java.util.concurrent.atomic.LongAdder;
+
+public class InstrumentedFixedChannelPoolHandler extends NoopFixedChannelPoolHandler {
+
+  private final LongAdder activeConnectionCount;
+  private final int maxConnectionCount;
+
+  public InstrumentedFixedChannelPoolHandler(HttpChannelKey channelKey, int poolSize) {
+    super(channelKey);
+    this.activeConnectionCount = new LongAdder();
+    this.maxConnectionCount = poolSize;
+  }
+
+  @Override
+  public void channelCreated(Channel ch) throws Exception {
+    super.channelCreated(ch);
+    activeConnectionCount.increment();
+  }
+
+  @Override
+  public void channelReleased(Channel ch) throws Exception {
+    super.channelReleased(ch);
+    activeConnectionCount.decrement();
+  }
+
+  @Override
+  public void channelAcquired(Channel ch) throws Exception {
+    super.channelAcquired(ch);
+    activeConnectionCount.increment();
+  }
+
+  @Override
+  public int getActiveConnectionCount() {
+    return activeConnectionCount.intValue();
+  }
+
+  @Override
+  public int getIdleConnectionCount() {
+    return maxConnectionCount - getActiveConnectionCount();
+  }
+
+}

--- a/ratpack-core/src/main/java/ratpack/http/client/internal/InstrumentedSimpleChannelPoolHandler.java
+++ b/ratpack-core/src/main/java/ratpack/http/client/internal/InstrumentedSimpleChannelPoolHandler.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.http.client.internal;
+
+import io.netty.channel.Channel;
+import java.util.concurrent.atomic.LongAdder;
+
+public class InstrumentedSimpleChannelPoolHandler extends NoopSimpleChannelPoolHandler {
+
+  private final LongAdder activeConnectionCount;
+
+  public InstrumentedSimpleChannelPoolHandler(HttpChannelKey channelKey) {
+    super(channelKey);
+    this.activeConnectionCount = new LongAdder();
+  }
+
+  @Override
+  public void channelCreated(Channel ch) throws Exception {
+    super.channelCreated(ch);
+    activeConnectionCount.increment();
+  }
+
+  @Override
+  public void channelReleased(Channel ch) throws Exception {
+    super.channelReleased(ch);
+    activeConnectionCount.decrement();
+  }
+
+  @Override
+  public void channelAcquired(Channel ch) throws Exception {
+    super.channelAcquired(ch);
+    activeConnectionCount.increment();
+  }
+
+  @Override
+  public int getActiveConnectionCount() {
+    return activeConnectionCount.intValue();
+  }
+
+  @Override
+  public int getIdleConnectionCount() {
+    return 0;
+  }
+
+}

--- a/ratpack-core/src/main/java/ratpack/http/client/internal/NoopFixedChannelPoolHandler.java
+++ b/ratpack-core/src/main/java/ratpack/http/client/internal/NoopFixedChannelPoolHandler.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.http.client.internal;
+
+import io.netty.channel.Channel;
+import io.netty.channel.pool.AbstractChannelPoolHandler;
+
+public class NoopFixedChannelPoolHandler extends AbstractChannelPoolHandler implements InstrumentedChannelPoolHandler {
+
+  private final String host;
+
+  public NoopFixedChannelPoolHandler(HttpChannelKey channelKey) {
+    this.host = channelKey.host;
+  }
+
+  @Override
+  public void channelCreated(Channel ch) throws Exception {
+
+  }
+
+  @Override
+  public void channelReleased(Channel ch) throws Exception {
+    if (ch.isOpen()) {
+      ch.config().setAutoRead(true);
+      ch.pipeline().addLast(IdlingConnectionHandler.INSTANCE);
+    }
+  }
+
+  @Override
+  public void channelAcquired(Channel ch) throws Exception {
+    ch.pipeline().remove(IdlingConnectionHandler.INSTANCE);
+  }
+
+  @Override
+  public String getHost() {
+    return this.host;
+  }
+
+  @Override
+  public int getActiveConnectionCount() {
+    return 0;
+  }
+
+  @Override
+  public int getIdleConnectionCount() {
+    return 0;
+  }
+}

--- a/ratpack-core/src/main/java/ratpack/http/client/internal/NoopSimpleChannelPoolHandler.java
+++ b/ratpack-core/src/main/java/ratpack/http/client/internal/NoopSimpleChannelPoolHandler.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.http.client.internal;
+
+import io.netty.channel.Channel;
+import io.netty.channel.pool.AbstractChannelPoolHandler;
+
+public class NoopSimpleChannelPoolHandler extends AbstractChannelPoolHandler implements InstrumentedChannelPoolHandler {
+
+  private final String host;
+
+  public NoopSimpleChannelPoolHandler(HttpChannelKey channelKey) {
+    this.host = channelKey.host;
+  }
+
+  @Override
+  public void channelCreated(Channel ch) throws Exception {
+  }
+
+  @Override
+  public void channelReleased(Channel ch) throws Exception {
+  }
+
+  @Override
+  public String getHost() {
+    return host;
+  }
+
+  @Override
+  public int getActiveConnectionCount() {
+    return 0;
+  }
+
+  @Override
+  public int getIdleConnectionCount() {
+    return 0;
+  }
+}

--- a/ratpack-core/src/test/groovy/ratpack/http/client/HttpClientKeepAliveInstrumentationSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/http/client/HttpClientKeepAliveInstrumentationSpec.groovy
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.http.client
+
+import io.netty.buffer.Unpooled
+import io.netty.channel.Channel
+import ratpack.exec.Blocking
+import ratpack.exec.ExecController
+import ratpack.exec.Execution
+import ratpack.stream.Streams
+import spock.util.concurrent.BlockingVariable
+import spock.util.concurrent.PollingConditions
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
+
+class HttpClientKeepAliveInstrumentationSpec extends BaseHttpClientSpec {
+
+  PollingConditions polling = new PollingConditions()
+
+  def poolingHttpClient = HttpClient.of {
+    it.poolSize(1)
+    it.enableMetricsCollection(true)
+  }
+
+  def "connection can be reused"() {
+    when:
+    otherApp {
+      get {
+        render "ok"
+      }
+    }
+    handlers {
+      get {
+        render poolingHttpClient.get(otherAppUrl()).map { it.body.text }
+      }
+    }
+
+    then:
+    text == "ok"
+    text == "ok"
+  }
+
+  def "keep alive connection is silently discarded when it closes"() {
+    when:
+    Channel channel = null
+    def latch = new CountDownLatch(1)
+    otherApp {
+      get {
+        channel = context.directChannelAccess.channel
+        channel.closeFuture().addListener {
+          latch.countDown()
+        }
+        render "ok"
+      }
+    }
+    handlers {
+      get {
+        render poolingHttpClient.get(otherAppUrl()).map { it.body.text }
+      }
+    }
+
+    then:
+    text == "ok"
+    latch.count == 1
+
+    when:
+    channel.close().sync()
+
+    then:
+    latch.await()
+    text == "ok"
+  }
+
+  def "clients can safely be used across different exec controllers"() {
+    when:
+    Channel channel
+    handlers { get { render poolingHttpClient.get(otherAppUrl()).map { it.body.text } } }
+    otherApp {
+      get {
+        channel = directChannelAccess.channel
+        render "ok"
+      }
+    }
+
+    then:
+    text == "ok"
+    channel.isOpen()
+
+    when:
+    application.close()
+    channel.closeFuture().get()
+
+    then:
+    text == "ok"
+  }
+
+  def "connection is removed from pool if server closes the connection"() {
+    when:
+    Channel channel1
+    Channel channel2
+    otherApp {
+      get {
+        Execution.fork().start {
+          it.sleep(Duration.ofMillis(500)).then {
+            def channel = context.directChannelAccess.channel
+            if (channel1 == null) {
+              channel1 = channel
+            } else {
+              channel2 = channel
+            }
+            channel.close()
+          }
+        }
+        header("content-length", 1024000)
+        response.sendStream Streams.periodically(context, Duration.ofMillis(100), { Unpooled.wrappedBuffer("a".bytes) })
+      }
+    }
+    handlers {
+      def http = HttpClient.of {
+        it.poolSize(1)
+      }
+      get {
+        render http.get(otherAppUrl()).map { it.body.text }
+      }
+    }
+
+    then:
+    get().statusCode == 500
+    get().statusCode == 500
+
+    and:
+    channel1.id().asShortText() != channel2.id().asShortText()
+  }
+
+  def "connection metrics can be tracked"() {
+    given:
+    String ok = 'ok'
+    def result = new BlockingVariable<String>()
+
+    when:
+    otherApp {
+      get {
+        Blocking.get({
+          return result.get()
+        })
+          .onError(it.&error)
+          .then(it.&render)
+      }
+    }
+
+    then:
+    assert poolingHttpClient.getHttpClientStats().totalActiveConnectionCount == 0
+    assert poolingHttpClient.getHttpClientStats().totalIdleConnectionCount == 0
+    assert poolingHttpClient.getHttpClientStats().totalConnectionCount == 0
+
+    when:
+    handlers {
+      get {
+        ExecController execController = it.get(ExecController)
+        execController.fork().start({
+          poolingHttpClient.get(otherAppUrl())
+            .then({ val ->
+            assert val.body.text == ok
+          })
+        })
+        render ok
+      }
+    }
+
+    then:
+    text == "ok"
+
+    polling.within(2) {
+      assert poolingHttpClient.getHttpClientStats().totalActiveConnectionCount == 1
+      assert poolingHttpClient.getHttpClientStats().totalIdleConnectionCount == 0
+      assert poolingHttpClient.getHttpClientStats().totalConnectionCount == 1
+    }
+
+    when:
+    result.set(ok)
+
+    then:
+    polling.within(2) {
+      assert poolingHttpClient.getHttpClientStats().totalActiveConnectionCount == 0
+      assert poolingHttpClient.getHttpClientStats().totalIdleConnectionCount == 1
+      assert poolingHttpClient.getHttpClientStats().totalConnectionCount == 1
+    }
+  }
+
+}

--- a/ratpack-core/src/test/groovy/ratpack/http/client/HttpClientSmokeSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/http/client/HttpClientSmokeSpec.groovy
@@ -22,8 +22,11 @@ import io.netty.handler.codec.http.HttpHeaderValues
 import io.netty.handler.codec.http.HttpHeaders
 import io.netty.util.CharsetUtil
 import ratpack.exec.Blocking
+import ratpack.exec.ExecController
 import ratpack.stream.Streams
 import spock.lang.IgnoreIf
+import spock.util.concurrent.BlockingVariable
+import spock.util.concurrent.PollingConditions
 
 import java.time.Duration
 import java.util.zip.GZIPInputStream
@@ -34,6 +37,8 @@ import static ratpack.sse.ServerSentEvents.serverSentEvents
 import static ratpack.stream.Streams.publish
 
 class HttpClientSmokeSpec extends BaseHttpClientSpec {
+
+  PollingConditions polling = new PollingConditions()
 
   def "can make simple get request"() {
     given:
@@ -852,6 +857,69 @@ BAR
 
     and:
     pathResponse.status.code == 404
+  }
+
+  def "can track http client metrics when pooling is disabled"() {
+    given:
+    String ok = 'ok'
+    def result = new BlockingVariable<String>()
+    def httpClient = HttpClient.of {
+      it.poolSize(0)
+      it.enableMetricsCollection(true)
+    }
+
+    bindings {
+      bindInstance(HttpClient, httpClient)
+    }
+
+    when:
+    otherApp {
+      get {
+        Blocking.get({
+          return result.get()
+        })
+          .onError(it.&error)
+          .then(it.&render)
+      }
+    }
+
+    then:
+    assert httpClient.getHttpClientStats().totalActiveConnectionCount == 0
+    assert httpClient.getHttpClientStats().totalIdleConnectionCount == 0
+    assert httpClient.getHttpClientStats().totalConnectionCount == 0
+
+    when:
+    handlers {
+      get {
+        ExecController execController = it.get(ExecController)
+        execController.fork().start({
+          httpClient.get(otherAppUrl())
+            .then({ val ->
+            assert val.body.text == ok
+          })
+        })
+        render ok
+      }
+    }
+
+    then:
+    text == "ok"
+
+    polling.within(2) {
+      assert httpClient.getHttpClientStats().totalActiveConnectionCount == 1
+      assert httpClient.getHttpClientStats().totalIdleConnectionCount == 0
+      assert httpClient.getHttpClientStats().totalConnectionCount == 1
+    }
+
+    when:
+    result.set(ok)
+
+    then:
+    polling.within(2) {
+      assert httpClient.getHttpClientStats().totalActiveConnectionCount == 0
+      assert httpClient.getHttpClientStats().totalIdleConnectionCount == 0
+      assert httpClient.getHttpClientStats().totalConnectionCount == 0
+    }
   }
 
 }

--- a/ratpack-core/src/test/groovy/ratpack/http/client/internal/HttpClientStatsSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/http/client/internal/HttpClientStatsSpec.groovy
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.http.client.internal
+
+import spock.lang.Specification
+
+class HttpClientStatsSpec extends Specification {
+
+  void 'it should collect HttpClientStats'() {
+    given:
+    Map<String, HostStats> statsPerHost = [
+      'ratpack.io': new HostStats(5, 95),
+      'alpha.ratpack.io': new HostStats(5, 95),
+      'omega.ratpack.io': new HostStats(5, 95),
+    ]
+
+    when:
+    HttpClientStats stats = new HttpClientStats(statsPerHost)
+
+    then:
+    assert stats.statsPerHost == statsPerHost
+    assert stats.totalActiveConnectionCount == 15
+    assert stats.totalIdleConnectionCount == 285
+    assert stats.totalConnectionCount == 300
+    assert stats.statsPerHost.get('ratpack.io').totalConnectionCount == 100
+    assert stats.statsPerHost.get('ratpack.io').idleConnectionCount == 95
+    assert stats.statsPerHost.get('ratpack.io').activeConnectionCount == 5
+  }
+}

--- a/ratpack-core/src/test/groovy/ratpack/http/client/internal/InstrumentedFixedChannelPoolHandlerSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/http/client/internal/InstrumentedFixedChannelPoolHandlerSpec.groovy
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.http.client.internal
+
+import io.netty.channel.Channel
+import io.netty.channel.ChannelConfig
+import io.netty.channel.ChannelPipeline
+import ratpack.exec.Execution
+import spock.lang.Specification
+import java.time.Duration
+
+class InstrumentedFixedChannelPoolHandlerSpec extends Specification {
+
+  int poolSize = 100
+  Execution execution = Mock(Execution)
+  URI uri = new URI('https://ratpack.io')
+  HttpChannelKey channelKey = new HttpChannelKey(uri, Duration.ofSeconds(30), execution)
+  ChannelPipeline pipeline = Mock(ChannelPipeline) {
+    _ * remove(IdlingConnectionHandler.INSTANCE)
+    _ * addLast(IdlingConnectionHandler.INSTANCE)
+  }
+  ChannelConfig config = Mock(ChannelConfig) {
+    _ * setAutoRead(true)
+  }
+  Channel channel = Mock(Channel) {
+    _ * config() >> config
+    _ * isOpen() >> true
+    _ * pipeline() >> pipeline
+  }
+
+  void 'it should handle construction and listening to ChannelPool changes'() {
+    when:
+    InstrumentedFixedChannelPoolHandler handler = new InstrumentedFixedChannelPoolHandler(channelKey, poolSize)
+
+    then:
+    assert handler.host == 'ratpack.io'
+    assert handler.getActiveConnectionCount() == 0
+    assert handler.getIdleConnectionCount() == poolSize
+
+    when:
+    handler.channelCreated(channel)
+
+    then:
+    assert handler.getActiveConnectionCount() == 1
+    assert handler.getIdleConnectionCount() == poolSize - 1
+
+    when:
+    handler.channelAcquired(channel)
+
+    then:
+    assert handler.getActiveConnectionCount() == 2
+    assert handler.getIdleConnectionCount() == poolSize - 2
+
+    when:
+    handler.channelReleased(channel)
+
+    then:
+    assert handler.getActiveConnectionCount() == 1
+    assert handler.getIdleConnectionCount() == poolSize - 1
+
+    when:
+    handler.channelReleased(channel)
+
+    then:
+    assert handler.getActiveConnectionCount() == 0
+    assert handler.getIdleConnectionCount() == poolSize
+  }
+
+}

--- a/ratpack-core/src/test/groovy/ratpack/http/client/internal/InstrumentedSimpleChannelPoolHandlerSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/http/client/internal/InstrumentedSimpleChannelPoolHandlerSpec.groovy
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.http.client.internal
+
+import io.netty.channel.Channel
+import ratpack.exec.Execution
+import spock.lang.Specification
+import java.time.Duration
+
+class InstrumentedSimpleChannelPoolHandlerSpec extends Specification {
+
+  Execution execution = Mock(Execution)
+  URI uri = new URI('https://ratpack.io')
+  HttpChannelKey channelKey = new HttpChannelKey(uri, Duration.ofSeconds(30), execution)
+  Channel channel = Mock(Channel)
+
+  void 'it should handle construction and listening to ChannelPool changes'() {
+    when:
+    InstrumentedSimpleChannelPoolHandler handler = new InstrumentedSimpleChannelPoolHandler(channelKey)
+
+    then:
+    assert handler.host == 'ratpack.io'
+    assert handler.getActiveConnectionCount() == 0
+    assert handler.getIdleConnectionCount() == 0
+
+    when:
+    handler.channelCreated(channel)
+
+    then:
+    assert handler.getActiveConnectionCount() == 1
+    assert handler.getIdleConnectionCount() == 0
+
+    when:
+    handler.channelAcquired(channel)
+
+    then:
+    assert handler.getActiveConnectionCount() == 2
+    assert handler.getIdleConnectionCount() == 0
+
+    when:
+    handler.channelReleased(channel)
+
+    then:
+    assert handler.getActiveConnectionCount() == 1
+    assert handler.getIdleConnectionCount() == 0
+
+    when:
+    handler.channelReleased(channel)
+
+    then:
+    assert handler.getActiveConnectionCount() == 0
+    assert handler.getIdleConnectionCount() == 0
+  }
+
+}

--- a/ratpack-core/src/test/groovy/ratpack/http/client/internal/NoopFixedChannelPoolHandlerSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/http/client/internal/NoopFixedChannelPoolHandlerSpec.groovy
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.http.client.internal
+
+import io.netty.channel.Channel
+import io.netty.channel.ChannelConfig
+import io.netty.channel.ChannelPipeline
+import ratpack.exec.Execution
+import spock.lang.Specification
+import java.time.Duration
+
+class NoopFixedChannelPoolHandlerSpec extends Specification {
+
+  Execution execution = Mock(Execution)
+  URI uri = new URI('https://ratpack.io')
+  HttpChannelKey channelKey = new HttpChannelKey(uri, Duration.ofSeconds(30), execution)
+  ChannelPipeline pipeline = Mock(ChannelPipeline) {
+    _ * remove(IdlingConnectionHandler.INSTANCE)
+    _ * addLast(IdlingConnectionHandler.INSTANCE)
+  }
+  ChannelConfig config = Mock(ChannelConfig) {
+    _ * setAutoRead(true)
+  }
+  Channel channel = Mock(Channel) {
+    _ * config() >> config
+    _ * isOpen() >> true
+    _ * pipeline() >> pipeline
+  }
+
+  void 'it should handle construction and listening to ChannelPool changes'() {
+    when:
+    NoopFixedChannelPoolHandler handler = new NoopFixedChannelPoolHandler(channelKey)
+
+    then:
+    assert handler.host == 'ratpack.io'
+    assert handler.getActiveConnectionCount() == 0
+    assert handler.getIdleConnectionCount() == 0
+
+    when:
+    handler.channelCreated(channel)
+
+    then:
+    assert handler.getActiveConnectionCount() == 0
+    assert handler.getIdleConnectionCount() == 0
+
+    when:
+    handler.channelAcquired(channel)
+
+    then:
+    assert handler.getActiveConnectionCount() == 0
+    assert handler.getIdleConnectionCount() == 0
+
+    when:
+    handler.channelReleased(channel)
+
+    then:
+    assert handler.getActiveConnectionCount() == 0
+    assert handler.getIdleConnectionCount() == 0
+  }
+
+}

--- a/ratpack-core/src/test/groovy/ratpack/http/client/internal/NoopSimpleChannelPoolHandlerSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/http/client/internal/NoopSimpleChannelPoolHandlerSpec.groovy
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.http.client.internal
+
+import io.netty.channel.Channel
+import ratpack.exec.Execution
+import spock.lang.Specification
+import java.time.Duration
+
+class NoopSimpleChannelPoolHandlerSpec extends Specification {
+
+  Execution execution = Mock(Execution)
+  URI uri = new URI('https://ratpack.io')
+  HttpChannelKey channelKey = new HttpChannelKey(uri, Duration.ofSeconds(30), execution)
+  Channel channel = Mock(Channel)
+
+  void 'it should handle construction and listening to ChannelPool changes'() {
+    when:
+    NoopSimpleChannelPoolHandler handler = new NoopSimpleChannelPoolHandler(channelKey)
+
+    then:
+    assert handler.host == 'ratpack.io'
+    assert handler.getActiveConnectionCount() == 0
+    assert handler.getIdleConnectionCount() == 0
+
+    when:
+    handler.channelCreated(channel)
+
+    then:
+    assert handler.getActiveConnectionCount() == 0
+    assert handler.getIdleConnectionCount() == 0
+
+    when:
+    handler.channelAcquired(channel)
+
+    then:
+    assert handler.getActiveConnectionCount() == 0
+    assert handler.getIdleConnectionCount() == 0
+
+    when:
+    handler.channelReleased(channel)
+
+    then:
+    assert handler.getActiveConnectionCount() == 0
+    assert handler.getIdleConnectionCount() == 0
+  }
+
+}

--- a/ratpack-dropwizard-metrics/src/main/java/ratpack/dropwizard/metrics/DropwizardMetricsModule.java
+++ b/ratpack-dropwizard-metrics/src/main/java/ratpack/dropwizard/metrics/DropwizardMetricsModule.java
@@ -181,6 +181,7 @@ public class DropwizardMetricsModule extends ConfigurableModule<DropwizardMetric
     bind(GraphiteReporter.class).toProvider(GraphiteReporterProvider.class).in(SINGLETON);
     bind(MetricRegistryPeriodicPublisher.class).in(SINGLETON);
     bind(MetricsBroadcaster.class).in(SINGLETON);
+    bind(HttpClientMetrics.class).in(SINGLETON);
     bind(Startup.class);
 
     bind(BlockingExecTimingInterceptor.class).toProvider(BlockingExecTimingInterceptorProvider.class).in(SINGLETON);

--- a/ratpack-dropwizard-metrics/src/main/java/ratpack/dropwizard/metrics/internal/HttpClientConfig.java
+++ b/ratpack-dropwizard-metrics/src/main/java/ratpack/dropwizard/metrics/internal/HttpClientConfig.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.dropwizard.metrics.internal;
+
+public class HttpClientConfig {
+
+  private boolean enabled;
+  private int pollingFrequencyInSeconds = 30;
+
+  /**
+   * The state of HttpClient metrics.
+   *
+   * @return the state of the HttpClient metrics
+   */
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  /**
+   * Set the state of HttpClient metrics.
+   * <p>
+   * Default is false.
+   * </p>
+   * @param enabled True if HttpClient metrics are published. False otherwise
+   * @return {@code this}
+   */
+  public HttpClientConfig enable(boolean enabled) {
+    this.enabled = enabled;
+    return this;
+  }
+
+  /**
+   * The frequency in seconds of which the HttpClient metrics will be refreshed.
+   * <p>
+   * Default is 30 seconds.
+   * </p>
+   *
+   * @return Number of seconds to wait between polling HttpClient for metrics.
+   */
+  public int getPollingFrequencyInSeconds() {
+    return this.pollingFrequencyInSeconds;
+  }
+
+  /**
+   * The frequency in seconds of which the HttpClient metrics will be refreshed.
+   * @param seconds Frequency in seconds of which to refresh HttpClient metrics.
+   * @return this
+   */
+  public HttpClientConfig pollingFrequencyInSeconds(int seconds) {
+    this.pollingFrequencyInSeconds = seconds;
+    return this;
+  }
+}

--- a/ratpack-dropwizard-metrics/src/main/java/ratpack/dropwizard/metrics/internal/HttpClientMetrics.java
+++ b/ratpack-dropwizard-metrics/src/main/java/ratpack/dropwizard/metrics/internal/HttpClientMetrics.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.dropwizard.metrics.internal;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricRegistry;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import ratpack.exec.ExecController;
+import ratpack.http.client.HttpClient;
+import ratpack.http.client.internal.DefaultHttpClient;
+import ratpack.http.client.internal.HttpClientStats;
+import ratpack.service.Service;
+import ratpack.service.StartEvent;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Singleton
+public class HttpClientMetrics implements Service, Runnable {
+
+  private static final String METRIC_PREFIX = "httpclient.";
+  private static final String TOTAL_ACTIVE_CONNECTIONS = getMetricName("total.active.connections");
+  private static final String TOTAL_IDLE_CONNECTIONS = getMetricName("total.idle.connections");
+  private static final String TOTAL_CONNECTIONS = getMetricName("total.connections");
+
+  private final HttpClient httpClient;
+  private final MetricRegistry metricRegistry;
+  private final HttpClientConfig config;
+  private final ConcurrentMap<String, HttpMetricGauge> gauges;
+
+  @Inject
+  public HttpClientMetrics(
+    HttpClient httpClient,
+    MetricRegistry metricRegistry
+  ) {
+    boolean enabled = Boolean.getBoolean("ratpack.metrics.httpclient.enabled");
+    int pollingFrequency = Integer.getInteger("ratpack.metrics.httpclient.pollingFrequency", 30);
+
+    this.httpClient = httpClient;
+    this.metricRegistry = metricRegistry;
+    this.config = new HttpClientConfig()
+      .enable(enabled)
+      .pollingFrequencyInSeconds(pollingFrequency);
+    this.gauges = new ConcurrentHashMap<>();
+  }
+
+  @Override
+  public void onStart(StartEvent event) throws Exception {
+    if (config.isEnabled() && httpClient instanceof DefaultHttpClient) {
+      ExecController execController = event.getRegistry().get(ExecController.class);
+      execController.getExecutor().scheduleAtFixedRate(this, 0, config.getPollingFrequencyInSeconds(), TimeUnit.SECONDS);
+    }
+  }
+
+  @Override
+  public void run() {
+    HttpClientStats httpClientStats = ((DefaultHttpClient) httpClient).getHttpClientStats();
+    gauge(TOTAL_ACTIVE_CONNECTIONS).setValue(httpClientStats.getTotalActiveConnectionCount());
+    gauge(TOTAL_IDLE_CONNECTIONS).setValue(httpClientStats.getTotalIdleConnectionCount());
+    gauge(TOTAL_CONNECTIONS).setValue(httpClientStats.getTotalConnectionCount());
+    httpClientStats.getStatsPerHost().forEach((host, stats) -> {
+        gauge(getHostMetricName(host, "total.active.connections"))
+          .setValue(stats.getActiveConnectionCount());
+        gauge(getHostMetricName(host, "total.idle.connections"))
+          .setValue(stats.getIdleConnectionCount());
+      gauge(getHostMetricName(host, "total.connections"))
+          .setValue(stats.getTotalConnectionCount());
+      });
+  }
+
+  private HttpMetricGauge gauge(String name) {
+    if (gauges.containsKey(name)) {
+      return gauges.get(name);
+    }
+    try {
+      HttpMetricGauge gauge = metricRegistry.register(name, new HttpMetricGauge());
+      gauges.put(name, gauge);
+      return gauge;
+    } catch (IllegalArgumentException e) {
+      // metricRegistry.register throws IllegalArgumentException when metric already exists.
+      final HttpMetricGauge gauge = gauges.get(name);
+      if (gauge != null && metricRegistry.getNames().contains(name)) {
+        return gauge;
+      }
+    }
+
+    throw new IllegalArgumentException(name + " is already used for a different type of metric");
+  }
+
+  private static String getMetricName(String name) {
+    return METRIC_PREFIX + name;
+  }
+
+  private static String getHostMetricName(String host, String name) {
+    return getMetricName(host + "." + name);
+  }
+
+  private static class HttpMetricGauge implements Gauge<Long> {
+
+    private AtomicLong value = new AtomicLong(0);
+
+    @Override
+    public Long getValue() {
+      return value.longValue();
+    }
+
+    public void setValue(Long val) {
+      value.set(val);
+    }
+  }
+}

--- a/ratpack-dropwizard-metrics/src/test/groovy/ratpack/dropwizard/metrics/MetricsSpec.groovy
+++ b/ratpack-dropwizard-metrics/src/test/groovy/ratpack/dropwizard/metrics/MetricsSpec.groovy
@@ -30,12 +30,22 @@ import io.netty.buffer.UnpooledByteBufAllocator
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import org.slf4j.Logger
+import ratpack.error.ServerErrorHandler
+import ratpack.error.internal.DefaultDevelopmentErrorHandler
 import ratpack.dropwizard.metrics.internal.PooledByteBufAllocatorMetricSet
 import ratpack.dropwizard.metrics.internal.UnpooledByteBufAllocatorMetricSet
 import ratpack.exec.Blocking
+import ratpack.exec.ExecController
 import ratpack.exec.Promise
+import ratpack.groovy.handling.GroovyChain
+import ratpack.groovy.test.embed.GroovyEmbeddedApp
+import ratpack.http.client.HttpClient
+import ratpack.http.client.internal.DefaultHttpClient
+import ratpack.test.embed.EmbeddedApp
 import ratpack.test.internal.RatpackGroovyDslSpec
 import ratpack.websocket.RecordingWebSocketClient
+import spock.lang.AutoCleanup
+import spock.util.concurrent.BlockingVariable
 import spock.util.concurrent.PollingConditions
 
 import java.time.Duration
@@ -49,6 +59,20 @@ class MetricsSpec extends RatpackGroovyDslSpec {
 
   @Rule
   TemporaryFolder reportDirectory
+
+  @AutoCleanup
+  EmbeddedApp otherApp
+
+  EmbeddedApp otherApp(@DelegatesTo(value = GroovyChain, strategy = Closure.DELEGATE_FIRST) Closure<?> closure) {
+    otherApp = GroovyEmbeddedApp.of {
+      registryOf { add ServerErrorHandler, new DefaultDevelopmentErrorHandler() }
+      handlers(closure)
+    }
+  }
+
+  URI otherAppUrl(String path = "") {
+    new URI("$otherApp.address$path")
+  }
 
   def setup() {
     SharedMetricRegistries.clear()
@@ -762,4 +786,78 @@ class MetricsSpec extends RatpackGroovyDslSpec {
     0 * reporter.onTimerAdded("foo.get-requests", !null)
   }
 
+  def "it should report http client metrics"() {
+    given:
+    System.setProperty("ratpack.metrics.httpclient.enabled", "true")
+    System.setProperty("ratpack.metrics.httpclient.pollingFrequency", "1")
+
+    MetricRegistry registry
+    String ok = 'ok'
+    def result = new BlockingVariable<String>()
+    def httpClient = HttpClient.of { DefaultHttpClient.Spec spec ->
+      spec.poolSize(0)
+      spec.enableMetricsCollection(true)
+    }
+
+    bindings {
+      bindInstance(HttpClient, httpClient)
+      module new DropwizardMetricsModule()
+    }
+
+    otherApp {
+      get {
+        Blocking.get({
+          return result.get()
+        })
+          .onError(it.&error)
+          .then(it.&render)
+      }
+    }
+
+    handlers { MetricRegistry metrics ->
+      registry = metrics
+      get {
+        ExecController execController = it.get(ExecController)
+        execController.fork().start({
+          httpClient.get(otherAppUrl())
+            .then({ val ->
+            assert val.body.text == ok
+          })
+        })
+        render ok
+      }
+    }
+
+    when:
+    text == ok
+
+    then:
+    polling.within(2) {
+      assert registry.getGauges().get('httpclient.total.active.connections').value == 1
+      assert registry.getGauges().get('httpclient.total.idle.connections').value == 0
+      assert registry.getGauges().get('httpclient.total.connections').value == 1
+      assert registry.getGauges().get("httpclient.${otherAppUrl().host}.total.active.connections").value == 1
+      assert registry.getGauges().get("httpclient.${otherAppUrl().host}.total.idle.connections").value == 0
+      assert registry.getGauges().get("httpclient.${otherAppUrl().host}.total.connections").value == 1
+
+
+    }
+
+    when:
+    result.set(ok)
+
+    then:
+    polling.within(2) {
+      assert registry.getGauges().get('httpclient.total.active.connections').value == 0
+      assert registry.getGauges().get('httpclient.total.idle.connections').value == 0
+      assert registry.getGauges().get('httpclient.total.connections').value == 0
+      assert registry.getGauges().get("httpclient.${otherAppUrl().host}.total.active.connections").value == 0
+      assert registry.getGauges().get("httpclient.${otherAppUrl().host}.total.idle.connections").value == 0
+      assert registry.getGauges().get("httpclient.${otherAppUrl().host}.total.connections").value == 0
+    }
+
+    cleanup:
+    System.setProperty("ratpack.metrics.httpclient.enabled", "false")
+    System.setProperty("ratpack.metrics.httpclient.pollingFrequency", "30")
+  }
 }


### PR DESCRIPTION
Attempt at adding some metric reporting on the HttpClient channel pools.

* Adds new flag to HttpClient to `enable` metric collection.
   * When flag is `false` HttpClient behaves same as today (default behavior)
   * When flag is `true` HttpClient will use instrumented channel pool handlers to track channel pool usage.
* Adds a new `HttpClientMetrics` class to ratpack-dropwizard-metrics to report on channel pool usage.  Default behavior is for it to be disabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1249)
<!-- Reviewable:end -->
