### PR TITLE
Handling trailing slash in path in DefaultHttpUrlBuilder

### DIFF
--- a/ratpack-core/src/main/java/ratpack/http/internal/DefaultHttpUrlBuilder.java
+++ b/ratpack-core/src/main/java/ratpack/http/internal/DefaultHttpUrlBuilder.java
@@ -23,6 +23,7 @@ import com.google.common.collect.MultimapBuilder;
 import com.google.common.escape.Escaper;
 import com.google.common.net.UrlEscapers;
 import io.netty.handler.codec.http.QueryStringDecoder;
+import io.netty.util.internal.StringUtil;
 import ratpack.http.HttpUrlBuilder;
 import ratpack.util.MultiValueMap;
 import ratpack.util.internal.InternalRatpackError;
@@ -117,24 +118,29 @@ public class DefaultHttpUrlBuilder implements HttpUrlBuilder {
   @Override
   public HttpUrlBuilder encodedPath(String path) {
     Objects.requireNonNull(path, "path must not be null");
-    Arrays.asList(path.split("/")).forEach(pathSegments::add);
+    Arrays.asList(path.split("/", -1)).forEach(pathSegments::add);
     return this;
   }
 
   @Override
   public HttpUrlBuilder path(String path) {
     Objects.requireNonNull(path, "path must not be null");
-    Arrays.asList(path.split("/")).forEach(this::segment);
+    Arrays.asList(path.split("/", -1)).forEach(this::segment);
     return this;
   }
 
   @Override
   public HttpUrlBuilder segment(String pathSegment, Object... args) {
     Objects.requireNonNull(pathSegment, "pathSegment must not be null");
-    if (args.length == 0) {
-      pathSegments.add(PATH_SEGMENT_ESCAPER.escape(pathSegment));
+    if (StringUtil.isNullOrEmpty(pathSegment)) {
+      hasTrailingSlash = true;
     } else {
-      pathSegments.add(PATH_SEGMENT_ESCAPER.escape(String.format(pathSegment, args)));
+      hasTrailingSlash = false;
+      if (args.length == 0) {
+        pathSegments.add(PATH_SEGMENT_ESCAPER.escape(pathSegment));
+      } else {
+        pathSegments.add(PATH_SEGMENT_ESCAPER.escape(String.format(pathSegment, args)));
+      }
     }
     return this;
   }

--- a/ratpack-core/src/test/groovy/ratpack/http/HttpUrlBuilderSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/http/HttpUrlBuilderSpec.groovy
@@ -122,6 +122,13 @@ class HttpUrlBuilderSpec extends Specification {
     build { encodedPath "foo%2Fbar" } == "http://localhost/foo%2Fbar"
   }
 
+  def "can append trailing slash"() {
+    expect:
+    build { path("foo/") } == "http://localhost/foo/"
+    build { path("foo/").path("/foo/") } == "http://localhost/foo/foo/"
+    build { path("foo/").params("bar") } == "http://localhost/foo/?bar"
+  }
+
   def "round trip - #string"() {
     expect:
     build(string) == string


### PR DESCRIPTION
Allows to add paths that contain trailing slash.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1263)
<!-- Reviewable:end -->
