### PR TITLE
Exposing connection pool queue size in HttpClient

### DIFF
--- a/ratpack-core/src/main/java/ratpack/http/client/HttpClient.java
+++ b/ratpack-core/src/main/java/ratpack/http/client/HttpClient.java
@@ -121,6 +121,13 @@ public interface HttpClient extends AutoCloseable {
   int getPoolSize();
 
   /**
+   * The number of connections that the client will queue if pool was depleted for any given server.
+   *
+   * @since 1.6
+   */
+  int getPoolQueueSize();
+
+  /**
    * The default read timeout value.
    *
    * @since 1.4

--- a/ratpack-core/src/main/java/ratpack/http/client/HttpClientSpec.java
+++ b/ratpack-core/src/main/java/ratpack/http/client/HttpClientSpec.java
@@ -58,6 +58,21 @@ public interface HttpClientSpec {
   HttpClientSpec poolSize(int poolSize);
 
   /**
+   * The maximum number of requests that will be queued if connection pool was depleted.
+   * <p>
+   * Defaults to {@link Integer#MAX_VALUE}.
+   * <p>
+   * Setting this option is recommended, because the http client queues requests when the pool is depleted. Once
+   * a connection is available, the request is processed and all resources released.
+   * <p>
+   * The option is not applied if pool size is not set.
+   *
+   * @param poolQueueSize the connection pool queue size
+   * @return {@code this}
+   */
+  HttpClientSpec poolQueueSize(int poolQueueSize);
+
+  /**
    * The maximum size to allow for responses.
    * <p>
    * Defaults to {@link ServerConfig#DEFAULT_MAX_CONTENT_LENGTH}.
@@ -100,7 +115,7 @@ public interface HttpClientSpec {
      * @since 1.5
      */
   HttpClientSpec responseMaxChunkSize(int numBytes);
-  
+
   /**
    * Add an interceptor for all requests handled by this client.
    * <p>

--- a/ratpack-core/src/main/java/ratpack/http/client/internal/DefaultHttpClient.java
+++ b/ratpack-core/src/main/java/ratpack/http/client/internal/DefaultHttpClient.java
@@ -82,7 +82,7 @@ public class DefaultHttpClient implements HttpClientInternal {
         .option(ChannelOption.SO_KEEPALIVE, isPooling());
 
       if (isPooling()) {
-        ChannelPool channelPool = new FixedChannelPool(bootstrap, POOLING_HANDLER, getPoolSize());
+        ChannelPool channelPool = new FixedChannelPool(bootstrap, POOLING_HANDLER, getPoolSize(), getPoolQueueSize());
         ((ExecControllerInternal) key.execution.getController()).onClose(() -> {
           remove(key);
           channelPool.close();
@@ -103,6 +103,11 @@ public class DefaultHttpClient implements HttpClientInternal {
   @Override
   public int getPoolSize() {
     return spec.poolSize;
+  }
+
+  @Override
+  public int getPoolQueueSize() {
+    return spec.poolQueueSize;
   }
 
   private boolean isPooling() {
@@ -172,6 +177,7 @@ public class DefaultHttpClient implements HttpClientInternal {
 
     private ByteBufAllocator byteBufAllocator = PooledByteBufAllocator.DEFAULT;
     private int poolSize;
+    private int poolQueueSize = Integer.MAX_VALUE;
     private int maxContentLength = ServerConfig.DEFAULT_MAX_CONTENT_LENGTH;
     private int responseMaxChunkSize = 8192;
     private Duration readTimeout = Duration.ofSeconds(30);
@@ -185,6 +191,7 @@ public class DefaultHttpClient implements HttpClientInternal {
     private Spec(Spec spec) {
       this.byteBufAllocator = spec.byteBufAllocator;
       this.poolSize = spec.poolSize;
+      this.poolQueueSize = spec.poolQueueSize;
       this.maxContentLength = spec.maxContentLength;
       this.responseMaxChunkSize = spec.responseMaxChunkSize;
       this.readTimeout = spec.readTimeout;
@@ -196,6 +203,12 @@ public class DefaultHttpClient implements HttpClientInternal {
     @Override
     public HttpClientSpec poolSize(int poolSize) {
       this.poolSize = poolSize;
+      return this;
+    }
+
+    @Override
+    public HttpClientSpec poolQueueSize(int poolQueueSize) {
+      this.poolQueueSize = poolQueueSize;
       return this;
     }
 

--- a/ratpack-core/src/test/groovy/ratpack/http/client/HttpClientConnectionPoolSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/http/client/HttpClientConnectionPoolSpec.groovy
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.http.client
+
+import ratpack.exec.ExecResult
+import ratpack.test.exec.ExecHarness
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+
+import java.util.concurrent.Callable
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+
+class HttpClientConnectionPoolSpec extends BaseHttpClientSpec {
+
+  @AutoCleanup(value = "shutdown")
+  @Shared
+  def executor = Executors.newCachedThreadPool()
+
+  @Shared
+  def harness = ExecHarness.harness()
+
+  def "pool limits the number of connection and its queue"() {
+    given:
+    def blockLatch = new CountDownLatch(1)
+    def orderLatch = new CountDownLatch(1)
+
+    def poolingHttpClient = HttpClient.of {
+      it.poolSize(1).poolQueueSize(1)
+    }
+
+    otherApp {
+      get {
+        orderLatch.countDown()
+        blockLatch.await()
+        render "ok"
+      }
+    }
+    def requestClosure = { poolingHttpClient.get(otherAppUrl()).map { r -> r.body.text } }
+
+    when:
+    def blockedFuture = executor.submit({ harness.yield(requestClosure) } as Callable<ExecResult<String>>)
+    orderLatch.await()
+
+    def queuedOrRejectedFuture1 = executor.submit({ harness.yield(requestClosure) } as Callable<ExecResult<String>>)
+    def queuedOrRejectedFuture2 = executor.submit({ harness.yield(requestClosure) } as Callable<ExecResult<String>>)
+
+    then:
+    !blockedFuture.isDone()
+
+    blockLatch.countDown()
+    blockedFuture.get().value == "ok"
+
+    queuedOrRejectedFuture1.get().error ^ queuedOrRejectedFuture2.get().error
+
+    with(queuedOrRejectedFuture1.get()) {
+        error ?
+          throwable.message == "Too many outstanding acquire operations"
+          : value == "ok"
+    }
+    with(queuedOrRejectedFuture2.get()) {
+      error ?
+        throwable.message == "Too many outstanding acquire operations"
+        : value == "ok"
+    }
+  }
+}


### PR DESCRIPTION
Http client uses `FixedChannelPool` for connection pooling per route. When the pool is depleted all other requests are queued in `Queue<AcquireTask> pendingAcquireQueue`. The default size of the queue is `Integer.MAX_VALUE`, which can lead to problems with memory in production deployment.

This fix enables to set the queue size with `HttpClientSpec`.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1285)
<!-- Reviewable:end -->
