### PR TITLE
Adding PooledByteBufAllocatorMetricSet for Dropwizard metrics

### DIFF
--- a/ratpack-dropwizard-metrics/src/main/java/ratpack/dropwizard/metrics/ByteBufAllocatorConfig.java
+++ b/ratpack-dropwizard-metrics/src/main/java/ratpack/dropwizard/metrics/ByteBufAllocatorConfig.java
@@ -1,0 +1,40 @@
+package ratpack.dropwizard.metrics;
+
+public class ByteBufAllocatorConfig {
+  private boolean enabled = true;
+  private boolean detailed = true;
+
+  /* The flag whether byte buf allocator metric set should be initialized.
+   * @return the flag
+   */
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  /**
+   * Set the flag whether byte buf allocator metric set should be initialized.
+   *
+   * @param enabled True if metrics set should be initialzed. False otherwise
+   * @return this
+   */
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  /* The flag whether byte buf allocator metric set should be report detailed metrics.
+   * @return the flag
+   */
+  public boolean isDetailed() {
+    return detailed;
+  }
+
+  /**
+   * Set the flag whether byte buf allocator metric set should be report detailed metrics.
+   *
+   * @param detailed True if metrics set should be report detailed metrics. False otherwise
+   * @return this
+   */
+  public void setDetailed(boolean detailed) {
+    this.detailed = detailed;
+  }
+}

--- a/ratpack-dropwizard-metrics/src/main/java/ratpack/dropwizard/metrics/ByteBufAllocatorConfig.java
+++ b/ratpack-dropwizard-metrics/src/main/java/ratpack/dropwizard/metrics/ByteBufAllocatorConfig.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ratpack.dropwizard.metrics;
 
 public class ByteBufAllocatorConfig {

--- a/ratpack-dropwizard-metrics/src/main/java/ratpack/dropwizard/metrics/DropwizardMetricsConfig.java
+++ b/ratpack-dropwizard-metrics/src/main/java/ratpack/dropwizard/metrics/DropwizardMetricsConfig.java
@@ -33,8 +33,6 @@ public class DropwizardMetricsConfig {
   public static final Duration DEFAULT_INTERVAL = Duration.ofSeconds(30);
 
   private boolean jvmMetrics;
-  private boolean byteBufAllocatorMetrics;
-  private boolean detailedByteBufAllocatorMetrics;
   private boolean requestTimingMetrics = true;
   private boolean blockingTimingMetrics = true;
   private Map<String, String> requestMetricGroups;
@@ -44,6 +42,7 @@ public class DropwizardMetricsConfig {
   private Optional<CsvConfig> csv = Optional.empty();
   private Optional<Slf4jConfig> slf4j = Optional.empty();
   private Optional<GraphiteConfig> graphite = Optional.empty();
+  private Optional<ByteBufAllocatorConfig> byteBufAllocator = Optional.empty();
 
   /**
    * The state of jvm metrics collection.
@@ -65,45 +64,41 @@ public class DropwizardMetricsConfig {
   }
 
   /**
-   * The state of byte buf allocator metrics collection.
+   * Get the settings for the byte buf allocator metric set.
    *
-   * @return True if byte buf allocator metrics collection is enabled. False otherwise
+   * @return the metric set settings
    * @since 1.6
    */
-  public boolean isByteBufAllocatorMetrics() {
-    return byteBufAllocatorMetrics;
+  public Optional<ByteBufAllocatorConfig> getByteBufAllocator() {
+    return byteBufAllocator;
   }
 
   /**
-   * The state of request timing metrics reporting.
-   * @param byteBufAllocatorMetrics True if byte buf allocator metrics are to be reported. False otherwise
+   * @return this
+   * @see #byteBufAllocator(ratpack.func.Action)
+   * @since 1.6
+   */
+  public DropwizardMetricsConfig byteBufAllocator() {
+    return byteBufAllocator(Action.noop());
+  }
+
+  /**
+   * Configure the byte buf allocator metric set.
+   *
+   * @param configure the configuration for the byte buf allocator metric set
    * @return this
    * @since 1.6
    */
-  public DropwizardMetricsConfig byteBufAllocatorMetrics(boolean byteBufAllocatorMetrics) {
-    this.byteBufAllocatorMetrics = byteBufAllocatorMetrics;
-    return this;
-  }
-
-  /**
-   * The state of detailed byte buf allocator metrics collection. (byte buf allocator metrics needs to be enabled)
-   *
-   * @return True if detailed byte buf allocator metrics collection is enabled. False otherwise
-   * @since 1.6
-   */
-  public boolean isDetailedByteBufAllocatorMetrics() {
-    return detailedByteBufAllocatorMetrics;
-  }
-
-  /**
-   * The state of detailed byte buf allocator metrics reporting.
-   * @param detailedByteBufAllocatorMetrics True if detailed byte buf allocator metrics are to be reported. False otherwise
-   * @return this
-   * @since 1.6
-   */
-  public DropwizardMetricsConfig detailedByteBufAllocatorMetrics(boolean detailedByteBufAllocatorMetrics) {
-    this.detailedByteBufAllocatorMetrics = detailedByteBufAllocatorMetrics;
-    return this;
+  public DropwizardMetricsConfig byteBufAllocator(Action<? super ByteBufAllocatorConfig> configure) {
+    try {
+      configure.execute(byteBufAllocator.orElseGet(() -> {
+        byteBufAllocator = Optional.of(new ByteBufAllocatorConfig());
+        return byteBufAllocator.get();
+      }));
+      return this;
+    } catch (Exception e) {
+      throw uncheck(e);
+    }
   }
 
   /**

--- a/ratpack-dropwizard-metrics/src/main/java/ratpack/dropwizard/metrics/DropwizardMetricsConfig.java
+++ b/ratpack-dropwizard-metrics/src/main/java/ratpack/dropwizard/metrics/DropwizardMetricsConfig.java
@@ -33,6 +33,8 @@ public class DropwizardMetricsConfig {
   public static final Duration DEFAULT_INTERVAL = Duration.ofSeconds(30);
 
   private boolean jvmMetrics;
+  private boolean byteBufAllocatorMetrics;
+  private boolean detailedByteBufAllocatorMetrics;
   private boolean requestTimingMetrics = true;
   private boolean blockingTimingMetrics = true;
   private Map<String, String> requestMetricGroups;
@@ -59,6 +61,48 @@ public class DropwizardMetricsConfig {
    */
   public DropwizardMetricsConfig jvmMetrics(boolean jvmMetrics) {
     this.jvmMetrics = jvmMetrics;
+    return this;
+  }
+
+  /**
+   * The state of byte buf allocator metrics collection.
+   *
+   * @return True if byte buf allocator metrics collection is enabled. False otherwise
+   * @since 1.6
+   */
+  public boolean isByteBufAllocatorMetrics() {
+    return byteBufAllocatorMetrics;
+  }
+
+  /**
+   * The state of request timing metrics reporting.
+   * @param byteBufAllocatorMetrics True if byte buf allocator metrics are to be reported. False otherwise
+   * @return this
+   * @since 1.6
+   */
+  public DropwizardMetricsConfig byteBufAllocatorMetrics(boolean byteBufAllocatorMetrics) {
+    this.byteBufAllocatorMetrics = byteBufAllocatorMetrics;
+    return this;
+  }
+
+  /**
+   * The state of detailed byte buf allocator metrics collection. (byte buf allocator metrics needs to be enabled)
+   *
+   * @return True if detailed byte buf allocator metrics collection is enabled. False otherwise
+   * @since 1.6
+   */
+  public boolean isDetailedByteBufAllocatorMetrics() {
+    return detailedByteBufAllocatorMetrics;
+  }
+
+  /**
+   * The state of detailed byte buf allocator metrics reporting.
+   * @param detailedByteBufAllocatorMetrics True if detailed byte buf allocator metrics are to be reported. False otherwise
+   * @return this
+   * @since 1.6
+   */
+  public DropwizardMetricsConfig detailedByteBufAllocatorMetrics(boolean detailedByteBufAllocatorMetrics) {
+    this.detailedByteBufAllocatorMetrics = detailedByteBufAllocatorMetrics;
     return this;
   }
 

--- a/ratpack-dropwizard-metrics/src/main/java/ratpack/dropwizard/metrics/DropwizardMetricsModule.java
+++ b/ratpack-dropwizard-metrics/src/main/java/ratpack/dropwizard/metrics/DropwizardMetricsModule.java
@@ -27,6 +27,7 @@ import com.google.inject.Injector;
 import com.google.inject.Provider;
 import com.google.inject.matcher.Matchers;
 import com.google.inject.multibindings.Multibinder;
+import io.netty.buffer.PooledByteBufAllocator;
 import ratpack.dropwizard.metrics.internal.*;
 import ratpack.guice.ConfigurableModule;
 import ratpack.handling.HandlerDecorator;
@@ -239,6 +240,18 @@ public class DropwizardMetricsModule extends ConfigurableModule<DropwizardMetric
         metricRegistry.registerAll(new GarbageCollectorMetricSet());
         metricRegistry.registerAll(new ThreadStatesGaugeSet());
         metricRegistry.registerAll(new MemoryUsageGaugeSet());
+      }
+
+      if (config.isByteBufAllocatorMetrics()) {
+        final MetricRegistry metricRegistry = injector.getInstance(MetricRegistry.class);
+        // Ratpack uses default PooledByteBufAllocator to allocate request bodies and other things.
+        // Allocator is resolved in static block in PooledByteBufAllocator based on OS, presence of Unsafe package, etc.
+        metricRegistry.registerAll(
+          new PooledByteBufAllocatorMetricSet(
+            PooledByteBufAllocator.DEFAULT,
+            config.isDetailedByteBufAllocatorMetrics()
+          )
+        );
       }
     }
 

--- a/ratpack-dropwizard-metrics/src/main/java/ratpack/dropwizard/metrics/PooledByteBufAllocatorMetricSet.java
+++ b/ratpack-dropwizard-metrics/src/main/java/ratpack/dropwizard/metrics/PooledByteBufAllocatorMetricSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ratpack-dropwizard-metrics/src/main/java/ratpack/dropwizard/metrics/PooledByteBufAllocatorMetricSet.java
+++ b/ratpack-dropwizard-metrics/src/main/java/ratpack/dropwizard/metrics/PooledByteBufAllocatorMetricSet.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.dropwizard.metrics;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricSet;
+import io.netty.buffer.PoolArenaMetric;
+import io.netty.buffer.PoolChunkListMetric;
+import io.netty.buffer.PoolSubpageMetric;
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.buffer.PooledByteBufAllocatorMetric;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import static java.lang.String.format;
+
+/**
+ * Metric set exposing {@link PooledByteBufAllocator} metrics about memory allocations. Metric set
+ * can be initialized to provide basic or detailed metrics. Detailed metrics contain information about
+ * specific arenas (chunk of memory allocated using malloc).
+ */
+public class PooledByteBufAllocatorMetricSet implements MetricSet {
+
+  private final PooledByteBufAllocator pooledByteBufAllocator;
+  private final boolean includeArenas;
+  private final Map<String, Metric> metrics;
+
+  /**
+   * Metric set constructor
+   *
+   * @param pooledByteBufAllocator allocator which would expose metrics
+   */
+  public PooledByteBufAllocatorMetricSet(PooledByteBufAllocator pooledByteBufAllocator) {
+    this(pooledByteBufAllocator, false);
+  }
+
+  /**
+   * Metric set constructor
+   *
+   * @param pooledByteBufAllocator allocator which would expose metrics
+   * @param includeArenas          boolean whether detailed metrics should be collected(memory arenas)
+   */
+  public PooledByteBufAllocatorMetricSet(PooledByteBufAllocator pooledByteBufAllocator, boolean includeArenas) {
+    this.pooledByteBufAllocator = pooledByteBufAllocator;
+    this.includeArenas = includeArenas;
+    this.metrics = new HashMap<>();
+
+    initMetrics();
+  }
+
+  private void initMetrics() {
+    final PooledByteBufAllocatorMetric metric = pooledByteBufAllocator.metric();
+
+    metrics.put("numDirectArenas", (Gauge<Integer>) () -> metric.numDirectArenas());
+    metrics.put("numHeapArenas", (Gauge<Integer>) () -> metric.numHeapArenas());
+    metrics.put("numThreadLocalCaches", (Gauge<Integer>) () -> metric.numThreadLocalCaches());
+    metrics.put("smallCacheSize", (Gauge<Integer>) () -> metric.smallCacheSize());
+    metrics.put("tinyCacheSize", (Gauge<Integer>) () -> metric.tinyCacheSize());
+    metrics.put("normalCacheSize", (Gauge<Integer>) () -> metric.normalCacheSize());
+    metrics.put("chunkSize", (Gauge<Integer>) () -> metric.chunkSize());
+
+    metrics.put("usedDirectMemory", (Gauge<Long>) () -> metric.usedDirectMemory());
+    metrics.put("usedHeapMemory", (Gauge<Long>) () -> metric.usedHeapMemory());
+
+    if (includeArenas) {
+      final Iterator<PoolArenaMetric> directArenasIterator = metric.directArenas().iterator();
+      initPoolArenaMetrics(directArenasIterator);
+
+
+      final Iterator<PoolArenaMetric> heapArenasIterator = metric.heapArenas().iterator();
+      initPoolArenaMetrics(heapArenasIterator);
+    }
+  }
+
+  private void initPoolArenaMetrics(final Iterator<PoolArenaMetric> poolArenasIterator) {
+    int counter = 0;
+    while (poolArenasIterator.hasNext()) {
+      final PoolArenaMetric poolArenaMetric = poolArenasIterator.next();
+      final String prefix = format("poolArena.%s", counter);
+
+      metrics.put(format("%s.activeAllocations", prefix), (Gauge<Long>) () -> poolArenaMetric.numActiveAllocations());
+      metrics.put(format("%s.numActiveBytes", prefix), (Gauge<Long>) () -> poolArenaMetric.numActiveBytes());
+      metrics.put(format("%s.numActiveHugeAllocations", prefix), (Gauge<Long>) () -> poolArenaMetric.numActiveHugeAllocations());
+      metrics.put(format("%s.numActiveNormalAllocations", prefix), (Gauge<Long>) () -> poolArenaMetric.numActiveNormalAllocations());
+      metrics.put(format("%s.numActiveSmallAllocations", prefix), (Gauge<Long>) () -> poolArenaMetric.numActiveSmallAllocations());
+      metrics.put(format("%s.numActiveTinyAllocations", prefix), (Gauge<Long>) () -> poolArenaMetric.numActiveTinyAllocations());
+      metrics.put(format("%s.numAllocations", prefix), (Gauge<Long>) () -> poolArenaMetric.numAllocations());
+      metrics.put(format("%s.numDeallocations", prefix), (Gauge<Long>) () -> poolArenaMetric.numDeallocations());
+      metrics.put(format("%s.numHugeAllocations", prefix), (Gauge<Long>) () -> poolArenaMetric.numHugeAllocations());
+      metrics.put(format("%s.numHugeDeallocations", prefix), (Gauge<Long>) () -> poolArenaMetric.numHugeDeallocations());
+      metrics.put(format("%s.numNormalAllocations", prefix), (Gauge<Long>) () -> poolArenaMetric.numNormalAllocations());
+      metrics.put(format("%s.numNormalDeallocations", prefix), (Gauge<Long>) () -> poolArenaMetric.numNormalDeallocations());
+      metrics.put(format("%s.numSmallAllocations", prefix), (Gauge<Long>) () -> poolArenaMetric.numSmallAllocations());
+      metrics.put(format("%s.numSmallDeallocations", prefix), (Gauge<Long>) () -> poolArenaMetric.numSmallDeallocations());
+      metrics.put(format("%s.numTinyAllocations", prefix), (Gauge<Long>) () -> poolArenaMetric.numTinyAllocations());
+      metrics.put(format("%s.numTinyDeallocations", prefix), (Gauge<Long>) () -> poolArenaMetric.numTinyDeallocations());
+      metrics.put(format("%s.numSmallSubpages", prefix), (Gauge<Integer>) () -> poolArenaMetric.numSmallSubpages());
+      metrics.put(format("%s.numTinySubpages", prefix), (Gauge<Integer>) () -> poolArenaMetric.numTinySubpages());
+
+      final Iterator<PoolChunkListMetric> chunksIterator = poolArenaMetric.chunkLists().iterator();
+      initPoolChunkListMetrics(prefix, chunksIterator);
+
+      final Iterator<PoolSubpageMetric> smallSubpagesIterator = poolArenaMetric.smallSubpages().iterator();
+      initSubpageMetrics(prefix, "smallSubpage", smallSubpagesIterator);
+
+      final Iterator<PoolSubpageMetric> tinySubpagesIterator = poolArenaMetric.tinySubpages().iterator();
+      initSubpageMetrics(prefix, "tinySubpage", tinySubpagesIterator);
+
+      counter++;
+    }
+  }
+
+  private void initPoolChunkListMetrics(final String prefix, final Iterator<PoolChunkListMetric> chunksIterator) {
+    int counter = 0;
+    while (chunksIterator.hasNext()) {
+      final PoolChunkListMetric poolChunkMetrics = chunksIterator.next();
+
+      final String poolChunkPrefix = format("poolChunkList.%s", counter);
+
+      metrics.put(format("%s.%s.maxUsage", prefix, poolChunkPrefix), (Gauge<Integer>) () -> poolChunkMetrics.maxUsage());
+      metrics.put(format("%s.%s.minUsage", prefix, poolChunkPrefix), (Gauge<Integer>) () -> poolChunkMetrics.minUsage());
+
+      counter++;
+    }
+  }
+
+  private void initSubpageMetrics(final String prefix, final String subpageName, final Iterator<PoolSubpageMetric> subpagesIterator) {
+    int counter = 0;
+    while (subpagesIterator.hasNext()) {
+      final PoolSubpageMetric poolSubpageMetric = subpagesIterator.next();
+
+      final String subpagePrefix = format("%s.%s", subpageName, counter);
+
+      metrics.put(format("%s.%s.elementSize", prefix, subpagePrefix), (Gauge<Integer>) () -> poolSubpageMetric.elementSize());
+      metrics.put(format("%s.%s.maxNumElements", prefix, subpagePrefix), (Gauge<Integer>) () -> poolSubpageMetric.maxNumElements());
+      metrics.put(format("%s.%s.numAvailable", prefix, subpagePrefix), (Gauge<Integer>) () -> poolSubpageMetric.numAvailable());
+      metrics.put(format("%s.%s.pageSize", prefix, subpagePrefix), (Gauge<Integer>) () -> poolSubpageMetric.pageSize());
+
+      counter++;
+    }
+  }
+
+  @Override
+  public Map<String, Metric> getMetrics() {
+    return metrics;
+  }
+}

--- a/ratpack-dropwizard-metrics/src/main/java/ratpack/dropwizard/metrics/UnpooledByteBufAllocatorMetricSet.java
+++ b/ratpack-dropwizard-metrics/src/main/java/ratpack/dropwizard/metrics/UnpooledByteBufAllocatorMetricSet.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ratpack.dropwizard.metrics;
 
 import com.codahale.metrics.Gauge;

--- a/ratpack-dropwizard-metrics/src/main/java/ratpack/dropwizard/metrics/UnpooledByteBufAllocatorMetricSet.java
+++ b/ratpack-dropwizard-metrics/src/main/java/ratpack/dropwizard/metrics/UnpooledByteBufAllocatorMetricSet.java
@@ -1,0 +1,43 @@
+package ratpack.dropwizard.metrics;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricSet;
+import io.netty.buffer.ByteBufAllocatorMetric;
+import io.netty.buffer.UnpooledByteBufAllocator;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Metric set exposing {@link UnpooledByteBufAllocator} metrics about memory allocations.
+ */
+public class UnpooledByteBufAllocatorMetricSet implements MetricSet {
+
+  private final UnpooledByteBufAllocator unpooledByteBufAllocator;
+  private final Map<String, Metric> metrics;
+
+  /**
+   * Metric set constructor
+   *
+   * @param unpooledByteBufAllocator allocator which would expose metrics
+   */
+  public UnpooledByteBufAllocatorMetricSet(UnpooledByteBufAllocator unpooledByteBufAllocator) {
+    this.unpooledByteBufAllocator = unpooledByteBufAllocator;
+    this.metrics = new HashMap<>();
+
+    initMetrics();
+  }
+
+  private void initMetrics() {
+    final ByteBufAllocatorMetric metric = unpooledByteBufAllocator.metric();
+
+    metrics.put("usedDirectMemory", (Gauge<Long>) () -> metric.usedDirectMemory());
+    metrics.put("usedHeapMemory", (Gauge<Long>) () -> metric.usedHeapMemory());
+  }
+
+  @Override
+  public Map<String, Metric> getMetrics() {
+    return metrics;
+  }
+}

--- a/ratpack-dropwizard-metrics/src/test/groovy/ratpack/dropwizard/metrics/MetricsSpec.groovy
+++ b/ratpack-dropwizard-metrics/src/test/groovy/ratpack/dropwizard/metrics/MetricsSpec.groovy
@@ -24,6 +24,9 @@ import com.codahale.metrics.annotation.Metered
 import com.codahale.metrics.annotation.Timed
 import com.codahale.metrics.graphite.GraphiteSender
 import groovy.json.JsonSlurper
+import io.netty.buffer.ByteBufAllocator
+import io.netty.buffer.PooledByteBufAllocator
+import io.netty.buffer.UnpooledByteBufAllocator
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import org.slf4j.Logger
@@ -409,15 +412,17 @@ class MetricsSpec extends RatpackGroovyDslSpec {
     (1.._) * reporter.onGaugeAdded(!null, { it.class.name.startsWith("com.codahale.metrics.jvm.MemoryUsageGaugeSet") })
   }
 
-  def "can collect byte buf allocator metrics"() {
-
+  def "can collect #allocator metrics"() {
     def reporter = Mock(MetricRegistryListener)
 
     given:
     bindings {
+      bindInstance ByteBufAllocator, allocator
       module new DropwizardMetricsModule(), {
-        it.byteBufAllocatorMetrics(true)
-          .detailedByteBufAllocatorMetrics(true)
+        it.byteBufAllocator { c ->
+          c.setEnabled(true)
+          c.setDetailed(true)
+        }
       }
     }
 
@@ -434,8 +439,13 @@ class MetricsSpec extends RatpackGroovyDslSpec {
 
     then:
     (1.._) * reporter.onGaugeAdded(!null, {
-      it.class.name.startsWith("ratpack.dropwizard.metrics.PooledByteBufAllocatorMetricSet")
+      it.class.name.startsWith("ratpack.dropwizard.metrics.${expected}ByteBufAllocatorMetricSet")
     })
+
+    where:
+    allocator                        | expected
+    PooledByteBufAllocator.DEFAULT   | 'Pooled'
+    UnpooledByteBufAllocator.DEFAULT | 'Unpooled'
   }
 
   def "can use metrics endpoint"() {

--- a/ratpack-dropwizard-metrics/src/test/groovy/ratpack/dropwizard/metrics/MetricsSpec.groovy
+++ b/ratpack-dropwizard-metrics/src/test/groovy/ratpack/dropwizard/metrics/MetricsSpec.groovy
@@ -285,7 +285,7 @@ class MetricsSpec extends RatpackGroovyDslSpec {
 
   }
 
-  def "can properly capture timing events" () {
+  def "can properly capture timing events"() {
     MetricRegistry registry
 
     given:
@@ -407,6 +407,35 @@ class MetricsSpec extends RatpackGroovyDslSpec {
     (1.._) * reporter.onGaugeAdded(!null, { it.class.name.startsWith("com.codahale.metrics.jvm.GarbageCollectorMetricSet") })
     (1.._) * reporter.onGaugeAdded(!null, { it.class.name.startsWith("com.codahale.metrics.jvm.ThreadStatesGaugeSet") })
     (1.._) * reporter.onGaugeAdded(!null, { it.class.name.startsWith("com.codahale.metrics.jvm.MemoryUsageGaugeSet") })
+  }
+
+  def "can collect byte buf allocator metrics"() {
+
+    def reporter = Mock(MetricRegistryListener)
+
+    given:
+    bindings {
+      module new DropwizardMetricsModule(), {
+        it.byteBufAllocatorMetrics(true)
+          .detailedByteBufAllocatorMetrics(true)
+      }
+    }
+
+    handlers { MetricRegistry metrics ->
+      metrics.addListener(reporter)
+
+      all {
+        render ""
+      }
+    }
+
+    when:
+    get()
+
+    then:
+    (1.._) * reporter.onGaugeAdded(!null, {
+      it.class.name.startsWith("ratpack.dropwizard.metrics.PooledByteBufAllocatorMetricSet")
+    })
   }
 
   def "can use metrics endpoint"() {

--- a/ratpack-dropwizard-metrics/src/test/groovy/ratpack/dropwizard/metrics/PooledByteBufAllocatorMetricSetSpec.groovy
+++ b/ratpack-dropwizard-metrics/src/test/groovy/ratpack/dropwizard/metrics/PooledByteBufAllocatorMetricSetSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 
 package ratpack.dropwizard.metrics
 

--- a/ratpack-dropwizard-metrics/src/test/groovy/ratpack/dropwizard/metrics/PooledByteBufAllocatorMetricSetSpec.groovy
+++ b/ratpack-dropwizard-metrics/src/test/groovy/ratpack/dropwizard/metrics/PooledByteBufAllocatorMetricSetSpec.groovy
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package ratpack.dropwizard.metrics
+
+import com.codahale.metrics.Gauge
+import io.netty.buffer.PooledByteBufAllocator
+import spock.lang.Specification
+
+class PooledByteBufAllocatorMetricSetSpec extends Specification {
+
+  def "initialize metric set"() {
+    given:
+    def allocator = new PooledByteBufAllocator(false, 1, 1, 4096,
+      1, 1, 1, 1, false)
+
+    when:
+    def metricSet = new PooledByteBufAllocatorMetricSet(allocator)
+
+    then:
+    // defaults for PooledByteBufAllocator
+    with(metricSet.metrics) { it ->
+      size() == 9
+      (it.numDirectArenas as Gauge).value == 1
+      (it.numHeapArenas as Gauge).value == 1
+      (it.numThreadLocalCaches as Gauge).value == 0
+      (it.smallCacheSize as Gauge).value == 1
+      (it.tinyCacheSize as Gauge).value == 1
+      (it.normalCacheSize as Gauge).value == 1
+      (it.chunkSize as Gauge).value == 8192
+      (it.usedDirectMemory as Gauge).value == 0
+      (it.usedHeapMemory as Gauge).value == 0
+    }
+  }
+
+  def "initialize metric set with detailed metrics - arenas"() {
+    given:
+    def allocator = new PooledByteBufAllocator(false, 1, 1, 4096,
+      1, 1, 1, 1, false)
+
+    when:
+    def metricSet = new PooledByteBufAllocatorMetricSet(allocator, true)
+
+    then:
+    // defaults for PooledByteBufAllocator
+    with(metricSet.metrics) { it ->
+      size() == 39
+      (it.numDirectArenas as Gauge).value == 1
+      (it.numHeapArenas as Gauge).value == 1
+      (it.numThreadLocalCaches as Gauge).value == 0
+      (it.smallCacheSize as Gauge).value == 1
+      (it.tinyCacheSize as Gauge).value == 1
+      (it.normalCacheSize as Gauge).value == 1
+      (it.chunkSize as Gauge).value == 8192
+      (it.usedDirectMemory as Gauge).value == 0
+      (it.usedHeapMemory as Gauge).value == 0
+
+      (it.'poolArena.0.numDeallocations' as Gauge).value == 0
+      (it.'poolArena.0.numActiveNormalAllocations' as Gauge).value == 0
+      (it.'poolArena.0.numSmallAllocations' as Gauge).value == 0
+      (it.'poolArena.0.numSmallSubpages' as Gauge).value == 3
+      (it.'poolArena.0.numTinySubpages' as Gauge).value == 32
+      (it.'poolArena.0.numNormalAllocations' as Gauge).value == 0
+      (it.'poolArena.0.numActiveTinyAllocations' as Gauge).value == 0
+      (it.'poolArena.0.numTinyAllocations' as Gauge).value == 0
+      (it.'poolArena.0.numSmallDeallocations' as Gauge).value == 0
+      (it.'poolArena.0.numActiveSmallAllocations' as Gauge).value == 0
+      (it.'poolArena.0.numTinyDeallocations' as Gauge).value == 0
+      (it.'poolArena.0.numHugeDeallocations' as Gauge).value == 0
+      (it.'poolArena.0.numActiveBytes' as Gauge).value == 0
+      (it.'poolArena.0.numNormalDeallocations' as Gauge).value == 0
+      (it.'poolArena.0.numActiveHugeAllocations' as Gauge).value == 0
+      (it.'poolArena.0.numAllocations' as Gauge).value == 0
+      (it.'poolArena.0.numHugeAllocations' as Gauge).value == 0
+      (it.'poolArena.0.activeAllocations' as Gauge).value == 0
+
+
+      (it.'poolArena.0.poolChunkList.0.minUsage' as Gauge).value == 1
+      (it.'poolArena.0.poolChunkList.0.maxUsage' as Gauge).value == 25
+      (it.'poolArena.0.poolChunkList.1.minUsage' as Gauge).value == 1
+      (it.'poolArena.0.poolChunkList.1.maxUsage' as Gauge).value == 50
+      (it.'poolArena.0.poolChunkList.2.minUsage' as Gauge).value == 25
+      (it.'poolArena.0.poolChunkList.2.maxUsage' as Gauge).value == 75
+      (it.'poolArena.0.poolChunkList.4.minUsage' as Gauge).value == 75
+      (it.'poolArena.0.poolChunkList.4.maxUsage' as Gauge).value == 100
+      (it.'poolArena.0.poolChunkList.3.minUsage' as Gauge).value == 50
+      (it.'poolArena.0.poolChunkList.3.maxUsage' as Gauge).value == 100
+      (it.'poolArena.0.poolChunkList.5.minUsage' as Gauge).value == 100
+      (it.'poolArena.0.poolChunkList.5.maxUsage' as Gauge).value == 100
+    }
+  }
+}

--- a/ratpack-dropwizard-metrics/src/test/groovy/ratpack/dropwizard/metrics/UnpooledByteBufAllocatorMetricSetSpec.groovy
+++ b/ratpack-dropwizard-metrics/src/test/groovy/ratpack/dropwizard/metrics/UnpooledByteBufAllocatorMetricSetSpec.groovy
@@ -8,7 +8,7 @@ class UnpooledByteBufAllocatorMetricSetSpec extends Specification {
 
   def "initialize metric set"() {
     given:
-    def allocator = new UnpooledByteBufAllocator(false);
+    def allocator = new UnpooledByteBufAllocator(false)
 
     when:
     def metricSet = new UnpooledByteBufAllocatorMetricSet(allocator)

--- a/ratpack-dropwizard-metrics/src/test/groovy/ratpack/dropwizard/metrics/UnpooledByteBufAllocatorMetricSetSpec.groovy
+++ b/ratpack-dropwizard-metrics/src/test/groovy/ratpack/dropwizard/metrics/UnpooledByteBufAllocatorMetricSetSpec.groovy
@@ -1,0 +1,23 @@
+package ratpack.dropwizard.metrics
+
+import com.codahale.metrics.Gauge
+import io.netty.buffer.UnpooledByteBufAllocator
+import spock.lang.Specification
+
+class UnpooledByteBufAllocatorMetricSetSpec extends Specification {
+
+  def "initialize metric set"() {
+    given:
+    def allocator = new UnpooledByteBufAllocator(false);
+
+    when:
+    def metricSet = new UnpooledByteBufAllocatorMetricSet(allocator)
+
+    then:
+    with(metricSet.metrics) { it ->
+      size() == 2
+      (it.usedDirectMemory as Gauge).value == 0
+      (it.usedHeapMemory as Gauge).value == 0
+    }
+  }
+}

--- a/ratpack-dropwizard-metrics/src/test/groovy/ratpack/dropwizard/metrics/UnpooledByteBufAllocatorMetricSetSpec.groovy
+++ b/ratpack-dropwizard-metrics/src/test/groovy/ratpack/dropwizard/metrics/UnpooledByteBufAllocatorMetricSetSpec.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ratpack.dropwizard.metrics
 
 import com.codahale.metrics.Gauge


### PR DESCRIPTION
JVM memory metric set is not enough for production monitoring(exposes only heap/off heap usage) and there is no way to get more details what Netty does under the hood. This can become handy for example when Ratpack handles large body requests.
Notes:
* adding Dropwizard metric set
* exposing Netty's byte buf allocation metrics
* exposes metrics from PooledByteBufAllocator.DEFAULT because it is used by RatpackDefaultServer
* can expose more detailed metrics(about arenas - chunk of memory allocated using malloc)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1288)
<!-- Reviewable:end -->
