### PR TITLE
Don't put spaces around the = in assignments

### DIFF
--- a/scripts/triggerExampleProjects
+++ b/scripts/triggerExampleProjects
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SNAP_KEY = $1
+SNAP_KEY=$1
 
 if [ "$BRANCH_NAME" = "master" ]; then
   curl -XPOST -uerdi:$SNAP_KEY https://api.snap-ci.com/project/ratpack/example-ratpack-gradle-java-app/branch/latest/trigger


### PR DESCRIPTION
Shells are space sensitive. `foo=42` means to assign `42` to the variable `foo`. `foo = 42` means to run a command named `foo`, and pass `=` as `$1` and `42` as `$2`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1299)
<!-- Reviewable:end -->
