### PR TITLE
Return a 404 when client requests a file using a data URL instead of throwing an NPE

### DIFF
--- a/ratpack-core/src/main/java/ratpack/file/internal/DefaultFileSystemBinding.java
+++ b/ratpack-core/src/main/java/ratpack/file/internal/DefaultFileSystemBinding.java
@@ -45,6 +45,10 @@ public class DefaultFileSystemBinding implements FileSystemBinding {
   }
 
   public Path file(String path) {
+    if (path == null) {
+      throw new IllegalArgumentException("Path must not be null");
+    }
+
     if (path.startsWith("/")) {
       path = path.substring(1);
     }

--- a/ratpack-core/src/main/java/ratpack/file/internal/FileHandler.java
+++ b/ratpack-core/src/main/java/ratpack/file/internal/FileHandler.java
@@ -50,11 +50,17 @@ public class FileHandler implements Handler {
       throw uncheck(e);
     }
 
-    Path asset = context.file(path);
-    if (asset != null) {
+    boolean assetFound = false;
 
-      servePath(context, asset);
-    } else {
+    if (path != null) {
+      Path asset = context.file(path);
+      if (asset != null) {
+        servePath(context, asset);
+        assetFound = true;
+      }
+    }
+
+    if (!assetFound) {
       context.clientError(404);
     }
   }

--- a/ratpack-core/src/test/groovy/ratpack/file/StaticFileSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/file/StaticFileSpec.groovy
@@ -444,6 +444,17 @@ class StaticFileSpec extends RatpackGroovyDslSpec {
     post("foo.txt").statusCode == 405
   }
 
+  def "getting a data URL returns 404"() {
+    when:
+    write("public/foo.txt", "bar")
+    handlers {
+      files { dir "public" }
+    }
+
+    then:
+    get("/data:application/json").statusCode == 404
+  }
+
   private static Date parseDateHeader(ReceivedResponse response, String name) {
     HttpHeaderDateFormat.get().parse(response.headers.get(name))
   }


### PR DESCRIPTION
We hit a strange corner case on a public-facing site where something (maybe a crawler or bot) was hitting a URL in a data-URL format (https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs) like /data:application/json.

Our app was trying to serve this up as a static file, but new URI(path).getPath() in FileHandler.handle() was returning null, which then got passed to DefaultFileSystemBinding.file(path) and that method in turn threw an NPE on path.startsWith("/") because path was null.

The changes in this PR verify the path and asset are not null before serving the asset and returns a 404 response code if either is null.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1304)
<!-- Reviewable:end -->
