### PR TITLE
Model executions as a tree allowing upward traversal

### DIFF
--- a/ratpack-exec/src/main/java/ratpack/exec/ExecSpec.java
+++ b/ratpack-exec/src/main/java/ratpack/exec/ExecSpec.java
@@ -84,10 +84,12 @@ public interface ExecSpec {
   /**
    * Specifies an action to be taken just before the execution starts.
    * <p>
-   * The action will be invoked after the execution registry has been populated.
+   * The action will be invoked after {@link #register(Action)} and any {@link ExecInitializer}'s.
    * <p>
-   * When forking from another execution, the current execution for the callback is <i>that</i> execution
-   * and not the execution being created. That is, it is the parent execution of the new execution.
+   * The {@link Execution#current() current execution} during the given callback is the
+   * parent execution of the new execution being started.
+   * If the execution is being created from outside of an execution,
+   * there will be no current execution during the callback.
    * <p>
    * This method is not additive.
    * That is, any subsequent calls replace the previous value.
@@ -100,8 +102,10 @@ public interface ExecSpec {
   /**
    * Populates the execution's registry.
    * <p>
-   * When forking from another execution, the current execution for the callback is <i>that</i> execution
-   * and not the execution being created. That is, it is the parent execution of the new execution.
+   * The {@link Execution#current() current execution} during the given callback is the
+   * parent execution of the new execution being started.
+   * If the execution is being created from outside of an execution,
+   * there will be no current execution during the callback.
    * <p>
    * This method is not additive.
    * That is, any subsequent calls replace the previous value.

--- a/ratpack-exec/src/main/java/ratpack/exec/ExecSpec.java
+++ b/ratpack-exec/src/main/java/ratpack/exec/ExecSpec.java
@@ -86,6 +86,9 @@ public interface ExecSpec {
    * <p>
    * The action will be invoked after the execution registry has been populated.
    * <p>
+   * When forking from another execution, the current execution for the callback is <i>that</i> execution
+   * and not the execution being created. That is, it is the parent execution of the new execution.
+   * <p>
    * This method is not additive.
    * That is, any subsequent calls replace the previous value.
 
@@ -96,6 +99,9 @@ public interface ExecSpec {
 
   /**
    * Populates the execution's registry.
+   * <p>
+   * When forking from another execution, the current execution for the callback is <i>that</i> execution
+   * and not the execution being created. That is, it is the parent execution of the new execution.
    * <p>
    * This method is not additive.
    * That is, any subsequent calls replace the previous value.

--- a/ratpack-exec/src/main/java/ratpack/exec/Execution.java
+++ b/ratpack-exec/src/main/java/ratpack/exec/Execution.java
@@ -168,6 +168,34 @@ public interface Execution extends MutableRegistry {
   EventLoop getEventLoop();
 
   /**
+   * A reference to this execution.
+   *
+   * @return a reference to this execution
+   * @since 1.6
+   */
+  ExecutionRef getRef();
+
+  /**
+   * A ref to the execution that forked this execution.
+   *
+   * @throws IllegalStateException if this is a top level exception with no parent
+   * @return a ref to the execution that forked this execution
+   * @see #maybeParent()
+   */
+  default ExecutionRef getParent() {
+    return getRef().getParent();
+  }
+
+  /**
+   * A ref to the execution that forked this execution, if it has a parent.
+   *
+   * @return a ref to the execution that forked this execution
+   */
+  default Optional<ExecutionRef> maybeParent() {
+    return getRef().maybeParent();
+  }
+
+  /**
    * Registers a closeable that will be closed when the execution completes.
    * <p>
    * Where possible, care should be taken to have the given closeable not throw exceptions.

--- a/ratpack-exec/src/main/java/ratpack/exec/Execution.java
+++ b/ratpack-exec/src/main/java/ratpack/exec/Execution.java
@@ -181,6 +181,7 @@ public interface Execution extends MutableRegistry {
    * @throws IllegalStateException if this is a top level exception with no parent
    * @return a ref to the execution that forked this execution
    * @see #maybeParent()
+   * @since 1.6
    */
   default ExecutionRef getParent() {
     return getRef().getParent();
@@ -190,6 +191,7 @@ public interface Execution extends MutableRegistry {
    * A ref to the execution that forked this execution, if it has a parent.
    *
    * @return a ref to the execution that forked this execution
+   * @since 1.6
    */
   default Optional<ExecutionRef> maybeParent() {
     return getRef().maybeParent();

--- a/ratpack-exec/src/main/java/ratpack/exec/ExecutionRef.java
+++ b/ratpack-exec/src/main/java/ratpack/exec/ExecutionRef.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.exec;
+
+import ratpack.registry.Registry;
+
+import java.util.Optional;
+
+/**
+ * A reference to an {@link Execution} that is usable from outside of it.
+ *
+ * An execution ref is-a registry.
+ * It is a read only view of the actual execution registry, while the execution is active.
+ * Once the execution has completed, the registry is effectively empty.
+ * Note that there are no guarantees that the registry is immutable.
+ * The execution may mutate the registry or its entries.
+ * Concurrent access via this reference is however safe.
+ *
+ * A ref avoids holding a long lived reference to the actual execution and its registry.
+ * Therefore, holding a reference to an execution-ref in memory does not prevent the execution's
+ * registry from being garbage collected.
+ *
+ * @see Execution#getParent()
+ * @since 1.6
+ */
+public interface ExecutionRef extends Registry {
+
+  /**
+   * A ref to the execution that forked this execution.
+   *
+   * @throws IllegalStateException if this is a top level exception with no parent
+   * @return a ref to the execution that forked this execution
+   * @see #maybeParent()
+   */
+  ExecutionRef getParent() throws IllegalStateException;
+
+  /**
+   * A ref to the execution that forked this execution, if it has a parent.
+   *
+   * @return a ref to the execution that forked this execution
+   */
+  Optional<ExecutionRef> maybeParent();
+
+  /**
+   * Whether the execution this refers to is complete.
+   *
+   * This method is equivalent to {@link Execution#isComplete()}.
+   *
+   * @return whether the execution this refers to is complete
+   */
+  boolean isComplete();
+
+}

--- a/ratpack-exec/src/main/java/ratpack/registry/Registry.java
+++ b/ratpack-exec/src/main/java/ratpack/registry/Registry.java
@@ -383,7 +383,7 @@ public interface Registry {
    * @since 1.4
    */
   static MutableRegistry mutable() {
-    return new SimpleMutableRegistry();
+    return new DefaultMutableRegistry();
   }
 
 }

--- a/ratpack-exec/src/main/java/ratpack/registry/internal/DefaultMutableRegistry.java
+++ b/ratpack-exec/src/main/java/ratpack/registry/internal/DefaultMutableRegistry.java
@@ -16,7 +16,6 @@
 
 package ratpack.registry.internal;
 
-import com.google.common.collect.Lists;
 import com.google.common.reflect.TypeToken;
 import ratpack.api.Nullable;
 import ratpack.func.Function;
@@ -25,26 +24,26 @@ import ratpack.registry.NotInRegistryException;
 import ratpack.registry.Registry;
 import ratpack.registry.RegistrySpec;
 
-import java.util.ArrayList;
+import java.util.Deque;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.function.Supplier;
 
-public class SimpleMutableRegistry implements MutableRegistry {
+public class DefaultMutableRegistry implements MutableRegistry {
 
-  private final List<RegistryEntry<?>> entries = new ArrayList<>();
-  private final Registry registry = new MultiEntryRegistry(Lists.reverse(entries));
+  private final Deque<RegistryEntry<?>> entries = new ConcurrentLinkedDeque<>();
+  private final Registry registry = new MultiEntryRegistry(entries);
 
   @Override
   public <O> RegistrySpec addLazy(TypeToken<O> type, Supplier<? extends O> supplier) {
-    entries.add(new LazyRegistryEntry<>(type, supplier));
+    entries.push(new LazyRegistryEntry<>(type, supplier));
     return this;
   }
 
   @Override
   public <O> RegistrySpec add(TypeToken<O> type, O object) {
-    entries.add(new DefaultRegistryEntry<>(type, object));
+    entries.push(new DefaultRegistryEntry<>(type, object));
     return this;
   }
 

--- a/ratpack-exec/src/test/groovy/ratpack/exec/BaseExecutionSpec.groovy
+++ b/ratpack-exec/src/test/groovy/ratpack/exec/BaseExecutionSpec.groovy
@@ -28,7 +28,7 @@ class BaseExecutionSpec extends Specification {
   @AutoCleanup
   ExecHarness execHarness = ExecHarness.harness()
 
-  List<Object> events = []
+  List<Object> events = [].asSynchronized()
   def latch = new CountDownLatch(1)
 
   def exec(Action<? super Execution> action, Action<? super Throwable> onError = { events << it }) {
@@ -38,11 +38,17 @@ class BaseExecutionSpec extends Specification {
   def execStarter(Action<? super ExecStarter> exec) {
     def spec = execHarness.controller.fork()
       .onError { events << it }
-      .onComplete { events << "complete"; latch.countDown() }
+      .onComplete {
+      events << "complete"; latch.countDown()
+    }
 
     exec.execute(spec)
 
     latch.await()
+  }
+
+  void counts(int counts) {
+    this.latch = new CountDownLatch(counts)
   }
 
 }

--- a/ratpack-exec/src/test/groovy/ratpack/exec/HierarchicalExecutionSpec.groovy
+++ b/ratpack-exec/src/test/groovy/ratpack/exec/HierarchicalExecutionSpec.groovy
@@ -133,4 +133,19 @@ class HierarchicalExecutionSpec extends BaseExecutionSpec {
     then:
     events == ["true", "complete"]
   }
+
+  def "top level execution has no parent"() {
+    when:
+    exec {
+      try {
+        it.parent
+        events << "no"
+      } catch (IllegalStateException e) {
+        events << it.maybeParent().map { true }.orElse(false).toString()
+      }
+    }
+
+    then:
+    events == ["false", "complete"]
+  }
 }

--- a/ratpack-exec/src/test/groovy/ratpack/exec/HierarchicalExecutionSpec.groovy
+++ b/ratpack-exec/src/test/groovy/ratpack/exec/HierarchicalExecutionSpec.groovy
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.exec
+
+import ratpack.exec.util.Promised
+import ratpack.func.Action
+
+class HierarchicalExecutionSpec extends BaseExecutionSpec {
+
+  def "current execution is parent during initializer of child"() {
+    given:
+    counts(2)
+
+    when:
+    exec { e ->
+      e.add("foo")
+      Execution.fork()
+        .register { it.add(Execution.current().get(String) + "-bar") }
+        .onStart { events << "child-on-start"; events << Execution.current().get(String); sleep 500 }
+        .onComplete { events << "child-complete"; latch.countDown() }
+        .start { events << "child-start"; events << Execution.current().get(String) }
+    }
+
+    then:
+    events == ["child-on-start", "foo", "complete", "child-start", "foo-bar", "child-complete"]
+  }
+
+  def "ref registry is empty when execution completes"() {
+    when:
+    ExecutionRef ref
+    exec { e ->
+      e.add("foo")
+      ref = e.ref
+      events << ref.get(String)
+    }
+
+    then:
+    events == ["foo", "complete"]
+    ref.getAll(Object).toList().empty
+  }
+
+  def "parent is available during child execution"() {
+    when:
+    def p1 = new Promised<Void>()
+
+    exec { e ->
+      e.add("parent")
+      Execution.fork().start {
+        events << it.parent.get(String)
+        p1.success(null)
+      }
+
+      p1.promise().then(Action.noop())
+    }
+
+    then:
+    events == ["parent", "complete"]
+  }
+
+  def "parent is available transitively"() {
+    when:
+    def p1 = new Promised<Void>()
+
+    exec { e ->
+      e.add("root")
+      Execution.fork().start {
+        Execution.fork().start {
+          events << it.parent.parent.get(String)
+          p1.success(null)
+        }
+      }
+
+      p1.promise().then {}
+    }
+
+    then:
+    events == ["root", "complete"]
+  }
+
+  def "can query whether parent is complete"() {
+    when:
+    counts 2
+    def p1 = new Promised<Void>()
+    def p2 = new Promised<Void>()
+
+    exec { e ->
+      e.onComplete { p2.success(null) }
+      Execution.fork().onStart {}.start {
+        events << Execution.current().parent.complete.toString()
+        p1.success(null)
+        p2.promise().then {
+          events << Execution.current().parent.complete.toString()
+          latch.countDown()
+        }
+      }
+      p1.promise().then(Action.noop())
+    }
+
+    then:
+    events == ["false", "complete", "true"]
+  }
+
+  def "current execution is parent during initializer"() {
+    given:
+    counts 2
+
+    when:
+    exec {
+      it.fork()
+        .register {
+        it.add(ExecInitializer, {
+          events << (it.parent == Execution.current().ref).toString()
+        } as ExecInitializer)
+      }.start {
+        latch.countDown()
+      }
+    }
+
+    then:
+    events == ["true", "complete"]
+  }
+}

--- a/ratpack-exec/src/test/groovy/ratpack/exec/HierarchicalExecutionSpec.groovy
+++ b/ratpack-exec/src/test/groovy/ratpack/exec/HierarchicalExecutionSpec.groovy
@@ -18,6 +18,7 @@ package ratpack.exec
 
 import ratpack.exec.util.Promised
 import ratpack.func.Action
+import spock.util.concurrent.PollingConditions
 
 class HierarchicalExecutionSpec extends BaseExecutionSpec {
 
@@ -50,7 +51,7 @@ class HierarchicalExecutionSpec extends BaseExecutionSpec {
 
     then:
     events == ["foo", "complete"]
-    ref.getAll(Object).toList().empty
+    new PollingConditions().eventually { ref.getAll(Object).toList().empty }
   }
 
   def "parent is available during child execution"() {

--- a/ratpack-exec/src/test/groovy/ratpack/registry/internal/DefaultMutableRegistrySpec.groovy
+++ b/ratpack-exec/src/test/groovy/ratpack/registry/internal/DefaultMutableRegistrySpec.groovy
@@ -22,13 +22,13 @@ import ratpack.registry.Registry
 import ratpack.registry.RegistrySpec
 import ratpack.test.internal.registry.RegistryContractSpec
 
-class SimpleMutableRegistrySpec extends RegistryContractSpec {
+class DefaultMutableRegistrySpec extends RegistryContractSpec {
 
-  def r = new SimpleMutableRegistry()
+  def r = Registry.mutable()
 
   @Override
   Registry build(Action<? super RegistrySpec> spec) {
-    def r = new SimpleMutableRegistry()
+    def r = new DefaultMutableRegistry()
     spec.execute(r)
     r
   }


### PR DESCRIPTION
The current execution when forking an execution becomes the parent of the forked execution.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1311)
<!-- Reviewable:end -->
