### PR TITLE
Fixed formatting in lazybones template README file

### DIFF
--- a/ratpack-lazybones/src/templates/ratpack/README.md
+++ b/ratpack-lazybones/src/templates/ratpack/README.md
@@ -14,6 +14,7 @@ In this project you get:
 * Reloading enabled in build.gradle
 * A standard project structure:
 
+```
     <proj>
       |
       +- src
@@ -40,6 +41,7 @@ In this project you get:
               +- groovy
                    |
                    +- // Spock tests in here!
+```
 
 That's it! You can start the basic app with
 


### PR DESCRIPTION
README file generated with `lazybones create ratpack [projectName]` contains project directory structure, however it does not display correctly due to missing preformatted code block. This pull reuqest fixes it. 

PS: this is my very first, but not last contribution to Ratpack :-)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1325)
<!-- Reviewable:end -->
