### PR TITLE
Add predicate form to Promise.mapError

### DIFF
--- a/ratpack-exec/src/test/groovy/ratpack/exec/PromiseErrorSpec.groovy
+++ b/ratpack-exec/src/test/groovy/ratpack/exec/PromiseErrorSpec.groovy
@@ -251,11 +251,24 @@ class PromiseErrorSpec extends Specification {
     events == [e, "complete"]
   }
 
-  def "can flatmapmap error of type"() {
+  def "can flatmap error of type"() {
     when:
     def e = new IllegalStateException()
     exec({
       Promise.error(new IllegalArgumentException()).flatMapError(IllegalArgumentException) {
+        Promise.error(e)
+      }.then(events.&add)
+    }, events.&add)
+
+    then:
+    events == [e, "complete"]
+  }
+
+  def "can flatmap error based on predicate"() {
+    when:
+    def e = new IllegalStateException()
+    exec({
+      Promise.error(new IllegalArgumentException('!')).flatMapError { it.message == '!' } {
         Promise.error(e)
       }.then(events.&add)
     }, events.&add)

--- a/ratpack-exec/src/test/groovy/ratpack/exec/PromiseErrorSpec.groovy
+++ b/ratpack-exec/src/test/groovy/ratpack/exec/PromiseErrorSpec.groovy
@@ -201,6 +201,19 @@ class PromiseErrorSpec extends Specification {
     events == [e, "complete"]
   }
 
+  def "can map error based on predicate"() {
+    when:
+    def e = new IllegalStateException()
+    exec({
+      Promise.error(new IllegalArgumentException("!")).mapError { it.message == "!" } {
+        throw e
+      }.then(events.&add)
+    }, events.&add)
+
+    then:
+    events == [e, "complete"]
+  }
+
   def "error map does not apply when error is of different type"() {
     when:
     def e1 = new IllegalArgumentException()


### PR DESCRIPTION
Noticed the other day that `Promise.mapError` was missing a form that maps on a `Predicate`

This plugs that hole  ⛳️

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1335)
<!-- Reviewable:end -->
