### PR TITLE
Don't allow an empty session ID.

### DIFF
--- a/ratpack-session/src/main/java/ratpack/session/internal/CookieBasedSessionId.java
+++ b/ratpack-session/src/main/java/ratpack/session/internal/CookieBasedSessionId.java
@@ -70,7 +70,7 @@ public class CookieBasedSessionId implements SessionId {
             break;
           }
         }
-        cookieSessionId = match == null ? Optional.empty() : Optional.of(AsciiString.of(match.value()));
+        cookieSessionId = (match == null || match.value().isEmpty()) ? Optional.empty() : Optional.of(AsciiString.of(match.value()));
       }
     }
 


### PR DESCRIPTION
This prevents the scenario where on logout the session ID is set to "" in the cookie
and a subsequent login transmits "" as the session ID and it is used.

@beckje01 @ldaley  - I've open this against master, but I started it from v1.5.4, so we can release it as a patch version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1346)
<!-- Reviewable:end -->
