### PR TITLE
Don't log exception when service could not started

### DIFF
--- a/ratpack-core/src/main/java/ratpack/service/internal/ServicesGraph.java
+++ b/ratpack-core/src/main/java/ratpack/service/internal/ServicesGraph.java
@@ -121,7 +121,6 @@ public class ServicesGraph {
     startLatch.await();
     StartupFailureException startupFailureException = failureRef.get();
     if (startupFailureException != null) {
-      LOGGER.error("Startup failure", startupFailureException);
       stop(new DefaultEvent(startEvent.getRegistry(), false));
       throw startupFailureException;
     }


### PR DESCRIPTION
PR for #1350.

I removed a logging of startup failure exception because it will be thrown later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1351)
<!-- Reviewable:end -->
