### PR TITLE
enhance request fixture with multipart form and file upload capabilities

### DIFF
--- a/ratpack-groovy-test/src/main/java/ratpack/groovy/test/handling/GroovyRequestFixture.java
+++ b/ratpack-groovy-test/src/main/java/ratpack/groovy/test/handling/GroovyRequestFixture.java
@@ -29,6 +29,8 @@ import ratpack.registry.RegistrySpec;
 import ratpack.server.ServerConfigBuilder;
 import ratpack.test.handling.HandlingResult;
 import ratpack.test.handling.RequestFixture;
+import ratpack.test.http.MultipartFileSpec;
+import ratpack.test.http.MultipartFormSpec;
 
 import java.util.Map;
 
@@ -166,6 +168,30 @@ public interface GroovyRequestFixture extends RequestFixture {
    */
   @Override
   GroovyRequestFixture body(String text, String contentType);
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  MultipartFileSpec file();
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  RequestFixture file(String field, String filename, String data);
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  MultipartFormSpec form();
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  GroovyRequestFixture form(Map<String, String> fields);
 
   /**
    * {@inheritDoc}

--- a/ratpack-groovy-test/src/main/java/ratpack/groovy/test/handling/internal/DefaultGroovyRequestFixture.java
+++ b/ratpack-groovy-test/src/main/java/ratpack/groovy/test/handling/internal/DefaultGroovyRequestFixture.java
@@ -29,6 +29,8 @@ import ratpack.registry.RegistrySpec;
 import ratpack.server.ServerConfigBuilder;
 import ratpack.test.handling.HandlingResult;
 import ratpack.test.handling.RequestFixture;
+import ratpack.test.http.MultipartFileSpec;
+import ratpack.test.http.MultipartFormSpec;
 
 import java.util.Map;
 
@@ -71,6 +73,28 @@ public class DefaultGroovyRequestFixture implements GroovyRequestFixture {
   @Override
   public GroovyRequestFixture body(String text, String contentType) {
     delegate.body(text, contentType);
+    return this;
+  }
+
+  @Override
+  public MultipartFileSpec file() {
+    return delegate.file();
+  }
+
+  @Override
+  public GroovyRequestFixture file(String field, String filename, String data) {
+    delegate.file(field, filename, data);
+    return this;
+  }
+
+  @Override
+  public MultipartFormSpec form() {
+    return delegate.form();
+  }
+
+  @Override
+  public GroovyRequestFixture form(Map<String, String> data) {
+    delegate.form(data);
     return this;
   }
 

--- a/ratpack-site/src/test/groovy/ratpack/site/crawl/Crawler.groovy
+++ b/ratpack-site/src/test/groovy/ratpack/site/crawl/Crawler.groovy
@@ -201,7 +201,7 @@ abstract class Crawler {
         }
       }
 
-      def sc = SSLContext.getInstance("SSL")
+      def sc = SSLContext.getDefault()
       sc.init([] as KeyManager[], [trustManager] as TrustManager[], new SecureRandom())
       https.setSSLSocketFactory(new DelegatingSSLSocketFactory(sc.socketFactory))
     }

--- a/ratpack-test/src/main/java/ratpack/test/handling/RequestFixture.java
+++ b/ratpack-test/src/main/java/ratpack/test/handling/RequestFixture.java
@@ -29,6 +29,8 @@ import ratpack.registry.RegistrySpec;
 import ratpack.server.ServerConfig;
 import ratpack.server.ServerConfigBuilder;
 import ratpack.test.handling.internal.DefaultRequestFixture;
+import ratpack.test.http.MultipartFileSpec;
+import ratpack.test.http.MultipartFormSpec;
 
 import java.util.Map;
 
@@ -171,6 +173,44 @@ public interface RequestFixture {
    * @return this
    */
   RequestFixture body(String text, String contentType);
+
+  /**
+   * A specification of a file to upload (see RFC2388)
+   * <p>
+   * Can be used to construct a multipart form with files
+   *
+   * @return a specification of a multipart file
+   */
+  MultipartFileSpec file();
+
+  /**
+   * Uploads a file via a multipart form (see RFC2388)
+   *
+   * @param field form field name
+   * @param filename filename of uploaded file
+   * @param data content of file
+   * @return this
+   */
+  RequestFixture file(String field, String filename, String data);
+
+  /**
+   * A specification of a multipart form (see RFC2388)
+   * <p>
+   * Can be used to construct a multipart form with name value pairs and files
+   * <p>
+   * Note that more than one value and more than one file can be associated with a single field
+   *
+   * @return a specification of a multipart form
+   */
+  MultipartFormSpec form();
+
+  /**
+   * Sets the fields on a multipart form (see RFC2388)
+   *
+   * @param fields map of field name to field value
+   * @return this
+   */
+  RequestFixture form(Map<String, String> fields);
 
   /**
    * A specification of the context registry.

--- a/ratpack-test/src/main/java/ratpack/test/http/MultipartFileSpec.java
+++ b/ratpack-test/src/main/java/ratpack/test/http/MultipartFileSpec.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.test.http;
+
+public interface MultipartFileSpec {
+
+  /**
+   * Add the file to the parent multipart form
+   * <p>
+   * Note: Must be called to include the file into the payload.
+   *
+   * @return a specification of a multipart form
+   */
+  MultipartFormSpec add();
+
+  /**
+   * Specify the content type
+   * <p>
+   * Required. Defaults to 'text/plain'.
+   *
+   * @return a specification of a multipart file
+   */
+  MultipartFileSpec contentType(String contentType);
+
+  /**
+   * Specify the file contents
+   * <p>
+   * Required. No default provided.
+   *
+   * @return a specification of a multipart file
+   */
+  MultipartFileSpec data(byte[] data);
+
+  /**
+   * Specify the file contents
+   * <p>
+   * Required. No default provided.
+   * <p>
+   * Note: this value is encoded into a byte array using UTF-8
+   *
+   * @return a specification of a multipart file
+   */
+  MultipartFileSpec data(String data);
+
+  /**
+   * Specify the form field
+   * <p>
+   * Optional. No default provided.
+   * <p>
+   * Valid options include BASE64, QUOTED-PRINTABLE, 8BIT, 7BIT, BINARY.
+   * Custom encodings of the for X-<encodingname> are also supported.
+   * See https://www.w3.org/Protocols/rfc1341/5_Content-Transfer-Encoding.html for more information.
+   * <p>
+   * Note: Netty will need to understand this encoding scheme.
+   *
+   * @return a specification of a multipart file
+   */
+  MultipartFileSpec encoding(String encoding);
+
+  /**
+   * Specify the form field
+   * <p>
+   * Required. Defaults to 'file'.
+   *
+   * @return a specification of a multipart file
+   */
+  MultipartFileSpec field(String field);
+
+  /**
+   * Specify the uploaded filename
+   * <p>
+   * Required. Defaults to 'filename.txt'.
+   *
+   * @return a specification of a multipart file
+   */
+  MultipartFileSpec name(String name);
+
+}

--- a/ratpack-test/src/main/java/ratpack/test/http/MultipartFormSpec.java
+++ b/ratpack-test/src/main/java/ratpack/test/http/MultipartFormSpec.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.test.http;
+
+public interface MultipartFormSpec {
+
+  /**
+   * Add a field to the multipart form
+   * <p>
+   * Note: Can be called multiple times to associate more than one value with a given field.
+   *
+   * @param name the field name
+   * @param value the field value
+   * @return a specification of a multipart form
+   */
+  MultipartFormSpec field(String name, String value);
+
+  /**
+   * A specification of a file to upload (see RFC2388)
+   * <p>
+   * Can be used to construct a multipart form with files
+   *
+   * @return a specification of a multipart file
+   */
+  MultipartFileSpec file();
+
+}

--- a/ratpack-test/src/main/java/ratpack/test/http/internal/DefaultMultipartForm.java
+++ b/ratpack-test/src/main/java/ratpack/test/http/internal/DefaultMultipartForm.java
@@ -1,0 +1,396 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.test.http.internal;
+
+import ratpack.test.http.MultipartFileSpec;
+import ratpack.test.http.MultipartFormSpec;
+
+import java.io.UnsupportedEncodingException;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/*
+    As defined in RFC 1867 and 2388 (see https://tools.ietf.org/html/rfc1867)
+ */
+public class DefaultMultipartForm {
+
+  private final Data data;
+  private final Writer writer;
+  private final Map<String, String> _headers;
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  private DefaultMultipartForm(Data data) {
+    this.data = data;
+    this.writer = new Writer(data);
+    this._headers = new HashMap<>();
+    _headers.put("Content-Type", getContentType());
+  }
+
+  public String getBody() {
+    return writer.write();
+  }
+
+  public String getContentType() {
+    return String.format("multipart/form-data; boundary=%s", data.boundary);
+  }
+
+  public Map<String, String> getHeaders() {
+    return Collections.unmodifiableMap(_headers);
+  }
+
+  final static class Writer {
+
+    private final Data data;
+
+    Writer(Data data) {
+      this.data = data;
+    }
+
+    String write() {
+      StringBuilder result = new StringBuilder();
+
+      addFields(data.fields, data.boundary, result);
+      addFiles(data.files, data.boundary, result);
+      closeBoundary(data.boundary, result);
+
+      return result.toString();
+    }
+
+    private void addFields(Map<String, Set<String>> fields, String boundary, StringBuilder out) {
+      fields.forEach((name, values) -> {
+        values.forEach((value) -> {
+          openBoundary(boundary, out);
+          declareField(name, out);
+          data(value.getBytes(), out);
+        });
+      });
+    }
+
+    private void addFiles(Map<String, Set<File>> files, String boundary, StringBuilder out) {
+      files.forEach((name, filesByField) -> {
+        openBoundary(boundary, out);
+        if (filesByField.size() > 1) {
+          addMultipleFilesToField(filesByField, name, out);
+        } else {
+          addSingleFileToField(filesByField, out);
+        }
+      });
+    }
+
+    private void addMultipleFilesToField(Set<File> files, String name, StringBuilder out) {
+      String subBoundary = generateSubBoundary(data.boundary, name);
+
+      declareField(name, out);
+      type(String.format("multipart/mixed, boundary=%s\n", subBoundary), out);
+      files.forEach((file) -> {
+        openBoundary(subBoundary, out);
+        disposition(String.format("attachment; filename=\"%s\"", file.getName()), out);
+        file(file, out);
+      });
+      closeBoundary(subBoundary, out);
+    }
+
+    private void addSingleFileToField(Set<File> files, StringBuilder out) {
+      File file = files.stream().findFirst().get();
+      disposition(String.format("form-data; name=\"%s\"; filename=\"%s\"",
+        file.getField(), file.getName()), out);
+      file(file, out);
+    }
+
+    private void data(byte[] value, StringBuilder out) {
+      out.append("\n");
+      out.append(new String(value));
+      out.append("\n");
+    }
+
+    private void declareField(String name, StringBuilder out) {
+      disposition(String.format("form-data; name=\"%s\"", name), out);
+    }
+
+    private void disposition(String value, StringBuilder out) {
+      label("Content-Disposition", value, out);
+    }
+
+    private void encoding(String value, StringBuilder out) {
+      if (value != null && !value.isEmpty()) {
+        label("Content-Transfer-Encoding", value, out);
+      }
+    }
+
+    private void file(File file, StringBuilder out) {
+      type(file.getContentType(), out);
+      encoding(file.getEncoding(), out);
+      data(file.getData(), out);
+    }
+
+    private String generateSubBoundary(String boundary, String name) {
+      return String.format("%s_%s", boundary, name);
+    }
+
+    private void type(String value, StringBuilder out) {
+      label("Content-Type", value, out);
+    }
+
+    private void label(String label, String value, StringBuilder out) {
+      out.append(label);
+      out.append(": ");
+      out.append(value);
+      out.append("\n");
+    }
+
+    private void openBoundary(String boundary, StringBuilder out) {
+      out.append("--");
+      out.append(boundary);
+      out.append("\n");
+    }
+
+    private void closeBoundary(String boundary, StringBuilder out) {
+      out.append("--");
+      out.append(boundary);
+      out.append("--\n");
+    }
+
+  }
+
+  final static class Data {
+
+    final String boundary;
+    final Map<String, Set<String>> fields;
+    final Map<String, Set<File>> files;
+
+    Data(String boundary, Map<String, Set<String>> fields, Map<String, Set<File>> files) {
+      this.boundary = boundary;
+      this.fields = Collections.unmodifiableMap(fields);
+      this.files = Collections.unmodifiableMap(files);
+    }
+
+  }
+
+  public final static class Builder implements MultipartFormSpec {
+
+    private final String _boundary;
+    private final Map<String, Set<String>> _fields;
+    private final Map<String, Set<File>> _files;
+
+    private Builder() {
+      this._boundary = generateBoundary();
+      this._fields = new TreeMap<>();
+      this._files = new TreeMap<>();
+    }
+
+    public String getBoundary() {
+      return _boundary;
+    }
+
+    public Map<String, Set<String>> getFields() {
+      return Collections.unmodifiableMap(_fields);
+    }
+
+    public Map<String, Set<File>> getFiles() {
+      return Collections.unmodifiableMap(_files);
+    }
+
+    public DefaultMultipartForm build() {
+      return new DefaultMultipartForm(new Data(_boundary, _fields, _files));
+    }
+
+    public Builder field(String name, String value) {
+      if (!_fields.containsKey(name)) {
+        _fields.put(name, new TreeSet<>());
+      }
+      _fields.get(name).add(value);
+
+      return this;
+    }
+
+    public Builder fields(Map<String, String> data) {
+      data.forEach(this::field);
+
+      return this;
+    }
+
+    public FileBuilder file() {
+      return new FileBuilder(this);
+    }
+
+    private Builder add(File file) {
+      String name = file.getField();
+      if (!_files.containsKey(name)) {
+        _files.put(name, new TreeSet<>());
+      }
+      _files.get(name).add(file);
+
+      return this;
+    }
+
+    private static String generateBoundary() {
+      return String.format("TEST%d", System.currentTimeMillis());
+    }
+
+  }
+
+  public final static class FileBuilder implements MultipartFileSpec {
+
+    private final Builder _builder;
+
+    private String _contentType;
+    private byte[] _data;
+    private String _encoding;
+    private String _field;
+    private String _name;
+
+    private FileBuilder(Builder builder) {
+      this._builder = builder;
+      this._contentType = "text/plain";
+      this._field = "file";
+      this._name = "filename.txt";
+    }
+
+    public Builder add() {
+      File file = new File(_field, _contentType, _encoding, _name, _data);
+      file.validate();
+
+      return _builder.add(file);
+    }
+
+    public FileBuilder contentType(String contentType) {
+      this._contentType = contentType;
+
+      return this;
+    }
+
+    public FileBuilder data(byte[] data) {
+      this._data = data;
+
+      return this;
+    }
+
+    public FileBuilder data(String data) {
+      try {
+        this._data = data.getBytes("UTF-8");
+      } catch(UnsupportedEncodingException uee) {
+        throw new IllegalArgumentException(uee);
+      }
+
+      return this;
+    }
+
+    public FileBuilder encoding(String encoding) {
+      this._encoding = encoding;
+
+      return this;
+    }
+
+    public FileBuilder field(String field) {
+      this._field = field;
+
+      return this;
+    }
+
+    public FileBuilder name(String name) {
+      this._name = name;
+
+      return this;
+    }
+
+  }
+
+  public final static class File implements Comparable<File> {
+
+    private final String _contentType;
+    private final byte[] _data;
+    private final String _encoding;
+    private final String _field;
+    private final String _name;
+
+    private File(String field, String contentType, String encoding, String name, byte[] data) {
+      this._contentType = contentType;
+      this._data = data;
+      this._encoding = encoding;
+      this._field = field;
+      this._name = name;
+    }
+
+    public String getContentType() {
+      return _contentType;
+    }
+
+    public byte[] getData() {
+      return _data;
+    }
+
+    public String getEncoding() {
+      return _encoding;
+    }
+
+    public String getField() {
+      return _field;
+    }
+
+    public String getName() {
+      return _name;
+    }
+
+    @Override
+    public int compareTo(File file) {
+      int result = this._field.compareTo(file._field);
+      if (result == 0) {
+        result = this._name.compareTo(file._name);
+      }
+
+      return result;
+    }
+
+    private void validate() {
+      if (!(isValueSet(_contentType) && isValueSet(_data) && isValueSet(_field) && isValueSet(_name))) {
+        throw new IllegalArgumentException(
+          String.format("File requires contentType, name and data (%s, %s, %s, %s)",
+            _field, _contentType, _name, _data));
+      }
+      if (isValueSet(_encoding) && !Encoding.isValid(_encoding)) {
+        throw new IllegalArgumentException(
+          String.format("Invalid content transfer encoding: [%s]", _encoding));
+      }
+    }
+
+    private boolean isValueSet(String value) {
+      return value != null && !value.isEmpty();
+    }
+
+    private boolean isValueSet(byte[] value) {
+      return value != null && !(value.length == 0);
+    }
+
+  }
+
+  public final static class Encoding {
+
+    final static List<String> VALUES = Stream.of("BASE64", "QUOTED-PRINTABLE", "8BIT", "7BIT", "BINARY")
+      .collect(Collectors.toList());
+
+    static boolean isValid(String value) {
+      return VALUES.stream().anyMatch((constant)
+        -> value.equalsIgnoreCase(constant) || value.toUpperCase().startsWith("X-"));
+    }
+
+  }
+
+}

--- a/ratpack-test/src/test/groovy/ratpack/test/http/DefaultMultipartFormSpec.groovy
+++ b/ratpack-test/src/test/groovy/ratpack/test/http/DefaultMultipartFormSpec.groovy
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.test.http
+
+import ratpack.test.http.internal.DefaultMultipartForm
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/*
+    As defined in RFC 1867 and 2388 (see https://tools.ietf.org/html/rfc1867)
+ */
+
+class DefaultMultipartFormSpec extends Specification {
+
+    def 'form with single field'() {
+        given:
+            builder.field(field.key, field.value)
+
+        when:
+            def form = builder.build()
+
+        then:
+            form.headers == ['Content-Type': "multipart/form-data; boundary=${boundary}"]
+            form.body ==
+"""--${boundary}
+Content-Disposition: form-data; name="${field.key}"
+
+${field.value}
+--${boundary}--
+"""
+
+        where:
+            builder = DefaultMultipartForm.builder()
+            boundary = builder.boundary
+            field = ['name': 'Werner Heisenberg'].find { true }
+    }
+
+    def 'form with multiple fields'() {
+        given:
+            builder.fields(fields)
+
+        when:
+            def form = builder.build()
+
+        then:
+            form.headers == ['Content-Type': "multipart/form-data; boundary=${boundary}"]
+            form.body ==
+"""--${boundary}
+Content-Disposition: form-data; name="${name.key}"
+
+${name.value}
+--${boundary}
+Content-Disposition: form-data; name="${role.key}"
+
+${role.value}
+--${boundary}--
+"""
+
+        where:
+            builder = DefaultMultipartForm.builder()
+            boundary = builder.boundary
+            fields = ['name': 'Werner Heisenberg', 'role': 'theoretical physicist']
+            name = fields.find { it.key == 'name' }
+            role = fields.find { it.key == 'role' }
+    }
+
+    def 'upload single file'() {
+        given:
+            builder.file()
+                .field(field)
+                .contentType(contentType)
+                .name(name)
+                .data(data).add()
+
+        when:
+            def form = builder.build()
+
+        then:
+            form.headers == ['Content-Type': "multipart/form-data; boundary=${boundary}"]
+            form.body ==
+"""--${boundary}
+Content-Disposition: form-data; name="${field}"; filename="${name}"
+Content-Type: ${contentType}
+
+${data}
+--${boundary}--
+"""
+
+        where:
+            builder = DefaultMultipartForm.builder()
+            boundary = builder.boundary
+            field = 'upload'
+            name = 'filename.txt'
+            contentType = 'text/plain'
+            data = '<content>'
+    }
+
+    def 'upload file with specific encoding'() {
+        given:
+            builder.file()
+                .field(field)
+                .contentType(contentType)
+                .encoding(encoding)
+                .name(name)
+                .data(data).add()
+
+        when:
+            def form = builder.build()
+
+        then:
+            form.headers == ['Content-Type': "multipart/form-data; boundary=${boundary}"]
+            form.body ==
+"""--${boundary}
+Content-Disposition: form-data; name="${field}"; filename="${name}"
+Content-Type: ${contentType}
+Content-Transfer-Encoding: ${encoding}
+
+${data}
+--${boundary}--
+"""
+
+        where:
+            builder = DefaultMultipartForm.builder()
+            boundary = builder.boundary
+            encoding = 'binary'
+            field = 'upload'
+            name = 'filename.jpg'
+            contentType = 'image/jpg'
+            data = '<content>'
+    }
+
+    def 'upload multiple files against single field'() {
+        given:
+            builder.file()
+                .field(field)
+                .contentType(file1.contentType)
+                .name(file1.name)
+                .data(file1.data).add()
+
+        and:
+            builder.file()
+                .field(field)
+                .contentType(file2.contentType)
+                .encoding(file2.encoding)
+                .name(file2.name)
+                .data(file2.data).add()
+
+        when:
+            def form = builder.build()
+
+        then:
+            form.headers == ['Content-Type': "multipart/form-data; boundary=${boundary}"]
+            form.body ==
+"""--${boundary}
+Content-Disposition: form-data; name="${field}"
+Content-Type: multipart/mixed, boundary=${subBoundary}
+
+--${subBoundary}
+Content-Disposition: attachment; filename="${file1.name}"
+Content-Type: ${file1.contentType}
+
+${file1.data}
+--${subBoundary}
+Content-Disposition: attachment; filename="${file2.name}"
+Content-Type: ${file2.contentType}
+Content-Transfer-Encoding: ${file2.encoding}
+
+${file2.data}
+--${subBoundary}--
+--${boundary}--
+"""
+
+        where:
+            builder = DefaultMultipartForm.builder()
+            boundary = builder.boundary
+            field = 'multiupload'
+            subBoundary = "${boundary}_${field}"
+
+            file1 = [name: 'filename.txt', contentType: 'text/plain', data: '<content>']
+            file2 = [name: 'other.png', contentType: 'image/png', encoding: 'base64', data: 'UE5HSU1BR0U=']
+    }
+
+    @Unroll('#encoding file transfer encoding satisfies spec')
+    def 'file transfer encoding satisfies spec'() {
+        given:
+            builder.file()
+                .field('upload')
+                .contentType('image/jpg')
+                .encoding(encoding)
+                .name('filename.jpg')
+                .data('<content>').add()
+
+        when:
+            builder.build()
+
+        then:
+            noExceptionThrown()
+
+        where:
+            builder = DefaultMultipartForm.builder()
+            encoding << ['BASE64', 'QUOTED-PRINTABLE', '8BIT', '7BIT', 'BINARY', 'X-CUSTOM-ENCODING'].collect {
+                [it, it.toLowerCase()]
+            }.flatten()
+    }
+
+    def 'invalid file transfer encoding is not accepted'() {
+        when:
+            builder.file()
+                .field('upload')
+                .contentType('image/jpg')
+                .encoding(encoding)
+                .name('filename.jpg')
+                .data('<content>').add()
+
+        then:
+            thrown(IllegalArgumentException)
+
+        where:
+            builder = DefaultMultipartForm.builder()
+            encoding = 'LINEAR-B'
+    }
+
+}


### PR DESCRIPTION
Enhancements to RequestFixture to support multipart requests including file uploads.

The Content-Transfer-Encoding will probably need some further elaboration if there proves to be wider need of this testing feature.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1373)
<!-- Reviewable:end -->
