### PR TITLE
Change Link Crawler

### DIFF
--- a/ratpack-site/src/test/groovy/ratpack/site/crawl/Crawler.groovy
+++ b/ratpack-site/src/test/groovy/ratpack/site/crawl/Crawler.groovy
@@ -201,7 +201,7 @@ abstract class Crawler {
         }
       }
 
-      def sc = SSLContext.getInstance("SSL")
+      def sc = SSLContext.getDefault()
       sc.init([] as KeyManager[], [trustManager] as TrustManager[], new SecureRandom())
       https.setSSLSocketFactory(new DelegatingSSLSocketFactory(sc.socketFactory))
     }


### PR DESCRIPTION
Switch to using default SSL context as that now seems to have the best support for updating sites dropping old TLS

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1374)
<!-- Reviewable:end -->
