### PR TITLE
Add errorIntercept method to HttpClientSpec.

### DIFF
--- a/ratpack-core/src/main/java/ratpack/http/client/HttpClientSpec.java
+++ b/ratpack-core/src/main/java/ratpack/http/client/HttpClientSpec.java
@@ -152,6 +152,17 @@ public interface HttpClientSpec {
   HttpClientSpec responseIntercept(Operation operation);
 
   /**
+   * Add an interceptor for errors thrown by this client (eg. connection refused, timeouts)
+   * <p>
+   * This function is additive.
+   *
+   * @param interceptor the action to perform on the error before propagating.
+   * @return {@code this}
+   * @since 1.6
+   */
+  HttpClientSpec errorIntercept(Action<? super Throwable> interceptor);
+
+  /**
    * Enable metric collection on HTTP Client.
    * <p>
    * Defaults to false.

--- a/ratpack-core/src/main/java/ratpack/http/client/internal/DefaultHttpClient.java
+++ b/ratpack-core/src/main/java/ratpack/http/client/internal/DefaultHttpClient.java
@@ -180,6 +180,7 @@ public class DefaultHttpClient implements HttpClientInternal {
     private Duration connectTimeout = Duration.ofSeconds(30);
     private Action<? super RequestSpec> requestInterceptor = Action.noop();
     private Action<? super HttpResponse> responseInterceptor = Action.noop();
+    private Action<? super Throwable> errorInterceptor = Action.noop();
     private boolean enableMetricsCollection;
 
     private Spec() {
@@ -259,6 +260,12 @@ public class DefaultHttpClient implements HttpClientInternal {
     }
 
     @Override
+    public HttpClientSpec errorIntercept(Action<? super Throwable> interceptor) {
+      errorInterceptor = errorInterceptor.append(interceptor);
+      return this;
+    }
+
+    @Override
     public HttpClientSpec enableMetricsCollection(boolean enableMetricsCollection) {
       this.enableMetricsCollection = enableMetricsCollection;
       return this;
@@ -279,7 +286,8 @@ public class DefaultHttpClient implements HttpClientInternal {
   public Promise<ReceivedResponse> request(URI uri, final Action<? super RequestSpec> requestConfigurer) {
     return intercept(
       Promise.async(downstream -> new ContentAggregatingRequestAction(uri, this, 0, Execution.current(), requestConfigurer.append(spec.requestInterceptor)).connect(downstream)),
-      spec.responseInterceptor
+      spec.responseInterceptor,
+      spec.errorInterceptor
     );
   }
 
@@ -287,19 +295,24 @@ public class DefaultHttpClient implements HttpClientInternal {
   public Promise<StreamedResponse> requestStream(URI uri, Action<? super RequestSpec> requestConfigurer) {
     return intercept(
       Promise.async(downstream -> new ContentStreamingRequestAction(uri, this, 0, Execution.current(), requestConfigurer.append(spec.requestInterceptor)).connect(downstream)),
-      spec.responseInterceptor
+      spec.responseInterceptor,
+      spec.errorInterceptor
     );
   }
 
-  private <T extends HttpResponse> Promise<T> intercept(Promise<T> promise, Action<? super HttpResponse> action) {
-    return promise.next(r ->
-      ExecController.require()
-        .fork()
-        .eventLoop(Execution.current().getEventLoop())
-        .start(e ->
-          action.execute(r)
-        )
-    );
+  private <T extends HttpResponse> Promise<T> intercept(Promise<T> promise, Action<? super HttpResponse> action, Action<? super Throwable> errorAction) {
+    return promise.onError(Exception.class, t -> {
+        errorAction.execute(t);
+        throw t;
+      })
+      .next(r ->
+        ExecController.require()
+          .fork()
+          .eventLoop(Execution.current().getEventLoop())
+          .start(e ->
+            action.execute(r)
+          )
+      );
   }
 
   public HttpClientStats getHttpClientStats() {

--- a/ratpack-core/src/test/groovy/ratpack/http/client/HttpClientInterceptorSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/http/client/HttpClientInterceptorSpec.groovy
@@ -246,7 +246,7 @@ class HttpClientInterceptorSpec extends BaseHttpClientSpec {
 
     bindings {
       bindInstance HttpClient, HttpClient.of { spec ->
-        spec.errorIntercept() { throwable ->
+        spec.errorIntercept { throwable ->
           Operation.of {
             latch.countDown()
           }.then()


### PR DESCRIPTION
This method is analagous to the existing responseIntercept method, but for requests that have not resulted in a response, eg. connection refused, connection and read timeouts, invalid responses, etc.

Extends the functionality added in https://github.com/ratpack/ratpack/commit/b9bd8cf1807d5b12d5b389438813f485615f0e13 as part of https://github.com/ratpack/ratpack/issues/975.

For tracing needs, we typically need to close the client-side trace (and populate it with any error details) in the event of unexpected failure as well as the expected response.

See https://github.com/lw346/ratpack-opentracing/blob/49bfb54baec68731bb0fd6c66ce8b467ca31de41/src/main/java/uk/me/lwood/ratpack/opentracing/client/SpanPropagationHandler.java#L61 for an example of use in an OpenTracing canonical style.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1381)
<!-- Reviewable:end -->
