### PR TITLE
TypedData getBytes

### DIFF
--- a/ratpack-core/src/main/java/ratpack/form/internal/DefaultUploadedFile.java
+++ b/ratpack-core/src/main/java/ratpack/form/internal/DefaultUploadedFile.java
@@ -67,6 +67,11 @@ public class DefaultUploadedFile implements UploadedFile {
   }
 
   @Override
+  public byte[] copyBytes() {
+    return typedData.copyBytes();
+  }
+
+  @Override
   public void writeTo(OutputStream outputStream) throws IOException {
     typedData.writeTo(outputStream);
   }

--- a/ratpack-core/src/main/java/ratpack/http/TypedData.java
+++ b/ratpack-core/src/main/java/ratpack/http/TypedData.java
@@ -54,9 +54,21 @@ public interface TypedData {
   /**
    * The raw data as bytes.
    *
+   * @deprecated This returns the entire underlying buffer, not accounting for the actual data's offset or length in the buffer. See {@link #copyBytes()}
+   *
    * @return the raw data as bytes.
    */
+  @Deprecated
   byte[] getBytes();
+
+  /**
+   * The raw data as bytes. This will create an array copy of the data.
+   *
+   * @since 1.6
+   *
+   * @return the raw data as bytes.
+   */
+  byte[] copyBytes();
 
   /**
    * The raw data as a (unmodifiable) buffer.

--- a/ratpack-core/src/main/java/ratpack/http/internal/ByteBufBackedTypedData.java
+++ b/ratpack-core/src/main/java/ratpack/http/internal/ByteBufBackedTypedData.java
@@ -67,6 +67,21 @@ public class ByteBufBackedTypedData implements TypedData {
   @Override
   public byte[] getBytes() {
     if (byteBuf.hasArray()) {
+      return byteBuf.array();
+    } else {
+      ByteArrayOutputStream baos = new ByteArrayOutputStream(byteBuf.writerIndex());
+      try {
+        writeTo(baos);
+      } catch (IOException e) {
+        throw uncheck(e);
+      }
+      return baos.toByteArray();
+    }
+  }
+
+  @Override
+  public byte[] copyBytes() {
+    if (byteBuf.hasArray()) {
       byte[] bytes = new byte[byteBuf.readableBytes()];
       int readerIndex = byteBuf.readerIndex();
       byteBuf.getBytes(readerIndex, bytes);

--- a/ratpack-core/src/test/groovy/ratpack/http/internal/TypedDataSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/http/internal/TypedDataSpec.groovy
@@ -22,13 +22,13 @@ import spock.lang.Specification
 
 class TypedDataSpec extends Specification {
 
-  def "can return bytes from array-backed Netty buffers"() {
+  def "can return byte copy from array-backed Netty buffers"() {
     given:
     def buffer = Unpooled.buffer(2000)
     buffer.writeBytes("foo".bytes)
     def typedData = new ByteBufBackedTypedData(buffer, DefaultMediaType.get("text/plain"))
 
     expect:
-    typedData.bytes == "foo".bytes
+    typedData.copyBytes() == "foo".bytes
   }
 }

--- a/release-notes.md
+++ b/release-notes.md
@@ -3,6 +3,7 @@ This file contains the in progress release notes during the cycle.
 It should not be considered the final announcement for any release at any time.
 -->
 
+
 # v1.6.0
 * Upgrade to Jackson 2.9.5
 * Upgrade to Caffeine 2.6.2


### PR DESCRIPTION
Keeps the orginal getBytes logic but adds a supported copyBytes that is safe to use.

Fixes: #1353 
Includes: #1354

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1408)
<!-- Reviewable:end -->
