### PR TITLE
Provide Powerful Retries for Promises

### DIFF
--- a/ratpack-exec/src/main/java/ratpack/exec/Promise.java
+++ b/ratpack-exec/src/main/java/ratpack/exec/Promise.java
@@ -2355,7 +2355,7 @@ public interface Promise<T> {
    * @return a promise with a retry error handler
    * @see #retry(int, BiFunction)
    * @since 1.5
-   * @deprecated since 1.6, use {@link #retry(RetryBuilder, BiAction)}
+   * @deprecated since 1.7, use {@link #retry(RetryBuilder, BiAction)}
    */
   @Deprecated
   default Promise<T> retry(int maxAttempts, Duration delay, @NonBlocking BiAction<? super Integer, ? super Throwable> onError) {
@@ -2376,7 +2376,7 @@ public interface Promise<T> {
    * @return a promise with a retry error handler
    * @see #retry(int, Duration, BiAction)
    * @since 1.5
-   * @deprecated since 1.6, use {@link #retry(RetryBuilder, BiAction)}
+   * @deprecated since 1.7, use {@link #retry(RetryBuilder, BiAction)}
    */
   @Deprecated
   default Promise<T> retry(int maxAttempts, BiFunction<? super Integer, ? super Throwable, Promise<Duration>> onError) {
@@ -2440,7 +2440,7 @@ public interface Promise<T> {
    * @param retryPolicy policy to govern this retry behaviour
    * @param onError the error handler
    * @return a promise with a retry error handler
-   * @since 1.6
+   * @since 1.7
    */
   default Promise<T> retry(RetryPolicy retryPolicy, BiAction<? super Integer, ? super Throwable> onError) {
     return transform(up -> down -> DefaultPromise.retry(retryPolicy, up, down, onError));

--- a/ratpack-exec/src/main/java/ratpack/exec/internal/DefaultPromise.java
+++ b/ratpack-exec/src/main/java/ratpack/exec/internal/DefaultPromise.java
@@ -17,7 +17,9 @@
 package ratpack.exec.internal;
 
 import ratpack.exec.*;
+import ratpack.exec.util.retry.RetryPolicy;
 import ratpack.func.Action;
+import ratpack.func.BiAction;
 import ratpack.func.BiFunction;
 import ratpack.func.Block;
 import ratpack.func.Function;
@@ -111,6 +113,45 @@ public class DefaultPromise<T> implements Promise<T> {
           public void success(Duration value) {
             Execution.sleep(value, () ->
               retryAttempt(attemptNum + 1, maxAttempts, up, down, onError)
+            );
+          }
+
+          @Override
+          public void error(Throwable throwable) {
+            down.error(throwable);
+          }
+
+          @Override
+          public void complete() {
+            down.complete();
+          }
+        });
+      }
+    }));
+  }
+
+  public static <T> void retry(RetryPolicy retryPolicy, Upstream<? extends T> up, Downstream<? super T> down, BiAction<? super Integer, ? super Throwable> onError) throws Exception {
+    up.connect(down.onError(e -> {
+      if (retryPolicy.isExhausted()) {
+        down.error(e);
+      } else {
+        Promise<Duration> delay;
+        try {
+          onError.execute(retryPolicy.attempts(), e);
+          delay = retryPolicy.delay();
+        } catch (Throwable errorHandlerError) {
+          if (errorHandlerError != e) {
+            errorHandlerError.addSuppressed(e);
+          }
+          down.error(errorHandlerError);
+          return;
+        }
+
+        delay.connect(new Downstream<Duration>() {
+          @Override
+          public void success(Duration value) {
+            Execution.sleep(value, () ->
+              retry(retryPolicy.increaseAttempt(), up, down, onError)
             );
           }
 

--- a/ratpack-exec/src/main/java/ratpack/exec/util/retry/AttemptRetryPolicy.java
+++ b/ratpack-exec/src/main/java/ratpack/exec/util/retry/AttemptRetryPolicy.java
@@ -29,7 +29,7 @@ import java.time.Duration;
  * That number doesn't include the initial request, meaning it will give up after 6 calls, but only 5 retries.
  *
  * @see AttemptRetryPolicyBuilder
- * @since 1.6
+ * @since 1.7
  */
 public final class AttemptRetryPolicy implements RetryPolicy {
 

--- a/ratpack-exec/src/main/java/ratpack/exec/util/retry/AttemptRetryPolicy.java
+++ b/ratpack-exec/src/main/java/ratpack/exec/util/retry/AttemptRetryPolicy.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.exec.util.retry;
+
+import ratpack.exec.Promise;
+import ratpack.exec.util.retry.internal.DefaultAttemptRetryPolicyBuilder;
+import ratpack.func.Action;
+
+import java.time.Duration;
+
+/**
+ * An attempt based implementation of {@link RetryPolicy}.
+ * <p>
+ * This strategy will signal end of retries when the configurable max of retry attempts is surpassed, 5 by default.
+ * That number doesn't include the initial request, meaning it will give up after 6 calls, but only 5 retries.
+ *
+ * @see AttemptRetryPolicyBuilder
+ * @since 1.6
+ */
+public final class AttemptRetryPolicy implements RetryPolicy {
+
+  private final Delay delay;
+  private final int maxAttempts;
+  private int attempts = 1;
+
+  public AttemptRetryPolicy(Delay delay, int maxAttempts) {
+    this.delay = delay;
+    this.maxAttempts = maxAttempts;
+  }
+
+  /**
+   * Builds a new attempt based retry policy from the given definition.
+   * @param definition the attempt based retry policy definition
+   * @return an attempt based retry policy
+   * @throws Exception any thrown by building the attempt based retry policy
+   */
+  public static AttemptRetryPolicy of(Action<? super AttemptRetryPolicyBuilder> definition) throws Exception {
+    return definition.with(new DefaultAttemptRetryPolicyBuilder()).build();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public boolean isExhausted() {
+    return attempts > maxAttempts;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public int attempts() {
+    return attempts;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Promise<Duration> delay() {
+    return delay.delay(attempts);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public RetryPolicy increaseAttempt() {
+    attempts++;
+    return this;
+  }
+
+}

--- a/ratpack-exec/src/main/java/ratpack/exec/util/retry/AttemptRetryPolicyBuilder.java
+++ b/ratpack-exec/src/main/java/ratpack/exec/util/retry/AttemptRetryPolicyBuilder.java
@@ -16,8 +16,6 @@
 
 package ratpack.exec.util.retry;
 
-import ratpack.func.Action;
-
 import java.time.Duration;
 
 /**

--- a/ratpack-exec/src/main/java/ratpack/exec/util/retry/AttemptRetryPolicyBuilder.java
+++ b/ratpack-exec/src/main/java/ratpack/exec/util/retry/AttemptRetryPolicyBuilder.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.exec.util.retry;
+
+import ratpack.func.Action;
+
+import java.time.Duration;
+
+/**
+ * Builds an {@link AttemptRetryPolicy}
+ * @see AttemptRetryPolicy#of(Action)
+ * @since 1.6
+ */
+public interface AttemptRetryPolicyBuilder {
+
+  /**
+   * By default, retries will wait 1 second between executions.
+   */
+  Delay DEFAULT_DELAY = FixedDelay.of(Duration.ofSeconds(1));
+
+  /**
+   * By default, this retry policy will give up after the fifth retry attempt.
+   */
+  int DEFAULT_MAX_ATTEMPTS = 5;
+
+  /**
+   * Builds an {@link AttemptRetryPolicy}
+   * @return a retry policy
+   */
+  AttemptRetryPolicy build();
+
+  /**
+   * The delay strategy
+   * @param delay the delay strategy
+   * @return this
+   */
+  AttemptRetryPolicyBuilder delay(Delay delay);
+
+  /**
+   * Maximum number of allowed retry attempts
+   * @param maxAttempts maximum number of allowed retry attempts
+   * @return this
+   */
+  AttemptRetryPolicyBuilder maxAttempts(int maxAttempts);
+
+}

--- a/ratpack-exec/src/main/java/ratpack/exec/util/retry/AttemptRetryPolicyBuilder.java
+++ b/ratpack-exec/src/main/java/ratpack/exec/util/retry/AttemptRetryPolicyBuilder.java
@@ -21,7 +21,7 @@ import java.time.Duration;
 /**
  * Builds an {@link AttemptRetryPolicy}
  * @see AttemptRetryPolicy#of(Action)
- * @since 1.6
+ * @since 1.7
  */
 public interface AttemptRetryPolicyBuilder {
 

--- a/ratpack-exec/src/main/java/ratpack/exec/util/retry/Delay.java
+++ b/ratpack-exec/src/main/java/ratpack/exec/util/retry/Delay.java
@@ -23,7 +23,7 @@ import java.time.Duration;
 /**
  * A strategy object to model delays between retries.
  * @see RetryPolicy
- * @since 1.6
+ * @since 1.7
  */
 public interface Delay {
 

--- a/ratpack-exec/src/main/java/ratpack/exec/util/retry/Delay.java
+++ b/ratpack-exec/src/main/java/ratpack/exec/util/retry/Delay.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.exec.util.retry;
+
+import ratpack.exec.Promise;
+
+import java.time.Duration;
+
+/**
+ * A strategy object to model delays between retries.
+ * @see RetryPolicy
+ * @since 1.6
+ */
+public interface Delay {
+
+  /**
+   * Builds a promise wrapping a duration that will instruct the caller how long to wait between retries.
+   * @param attempt current retry attempt to provide sophisticated delay strategies
+   * @return a promise wrapping a duration that will instruct the caller how long to wait between retries.
+   */
+  Promise<Duration> delay(Integer attempt);
+
+}

--- a/ratpack-exec/src/main/java/ratpack/exec/util/retry/DurationRetryPolicy.java
+++ b/ratpack-exec/src/main/java/ratpack/exec/util/retry/DurationRetryPolicy.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.exec.util.retry;
+
+import ratpack.exec.Promise;
+import ratpack.exec.util.retry.internal.DefaultDurationRetryPolicyBuilder;
+import ratpack.func.Action;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+
+/**
+ * A duration based implementation of {@link RetryPolicy}.
+ * <p>
+ * This strategy will signal end of retries when the elapsed time from the first error occurrence surpasses the configurable
+ * max duration, 30 seconds by default.
+ *
+ * <pre class="java">{@code
+ * import ratpack.exec.ExecResult;
+ * import ratpack.exec.Promise;
+ * import ratpack.exec.util.retry.DurationRetryPolicy;
+ * import ratpack.exec.util.retry.RetryPolicy;
+ * import ratpack.exec.util.retry.FixedDelay;
+ * import ratpack.test.exec.ExecHarness;
+ * import ratpack.test.internal.time.FixedWindableClock;
+ *
+ * import java.time.Duration;
+ * import java.time.Instant;
+ * import java.time.ZoneOffset;
+ * import java.util.Arrays;
+ * import java.util.LinkedList;
+ * import java.util.List;
+ * import java.util.concurrent.atomic.AtomicInteger;
+ *
+ * import static org.junit.Assert.assertEquals;
+ *
+ * public class Example {
+ *   private static final List<String> LOG = new LinkedList<>();
+ *
+ *   public static void main(String... args) throws Exception {
+ *     AtomicInteger source = new AtomicInteger();
+ *     FixedWindableClock clock = new FixedWindableClock(Instant.now(), ZoneOffset.UTC);
+ *
+ *     RetryPolicy retryPolicy = DurationRetryPolicy.of(b -> b
+ *       .delay(FixedDelay.of(Duration.ofMillis(500)))
+ *       .maxDuration(Duration.ofSeconds(10))
+ *       .clock(clock));
+ *
+ *     RuntimeException e = new RuntimeException("!");
+ *
+ *     Throwable result = ExecHarness.yieldSingle(exec ->
+ *       Promise.sync(source::incrementAndGet)
+ *         .mapIf(i -> i == 3, i -> {
+ *           clock.windClock(Duration.ofMinutes(5));
+ *           return i;
+ *          })
+ *         .map(i -> { throw new IllegalStateException(); })
+ *         .retry(retryPolicy, (i, t) -> LOG.add("retry attempt: " + i))
+ *     ).getThrowable();
+ *
+ *     assertEquals("java.lang.IllegalStateException", result.getClass().getCanonicalName());
+ *     assertEquals(Arrays.asList("retry attempt: 1", "retry attempt: 2"), LOG);
+ *   }
+ * }
+ * }</pre>
+ *
+ * @see DurationRetryPolicyBuilder
+ * @since 1.6
+ */
+public class DurationRetryPolicy implements RetryPolicy {
+
+  private final Delay delay;
+  private final Duration maxDuration;
+  private Instant start;
+  private int attempts = 1;
+  private Clock clock;
+
+  public DurationRetryPolicy(Delay delay, Duration maxDuration, Clock clock) {
+    this.delay = delay;
+    this.maxDuration = maxDuration;
+    this.clock = clock;
+  }
+
+  /**
+   * Builds a new duration based retry policy from the given definition.
+   * @param definition the duration based retry policy definition
+   * @return a duration based retry policy
+   * @throws Exception any thrown by building the duration based retry policy
+   */
+  public static DurationRetryPolicy of(Action<? super DurationRetryPolicyBuilder> definition) throws Exception {
+    return definition.with(new DefaultDurationRetryPolicyBuilder()).build();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public boolean isExhausted() {
+    if (start == null) {
+      start = clock.instant();
+    }
+    Instant limit = start.plusMillis(maxDuration.toMillis());
+    Instant now = clock.instant();
+    return now.isAfter(limit);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public int attempts() {
+    return attempts;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Promise<Duration> delay() {
+    return delay.delay(attempts);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public RetryPolicy increaseAttempt() {
+    attempts++;
+    return this;
+  }
+
+}

--- a/ratpack-exec/src/main/java/ratpack/exec/util/retry/DurationRetryPolicy.java
+++ b/ratpack-exec/src/main/java/ratpack/exec/util/retry/DurationRetryPolicy.java
@@ -80,7 +80,7 @@ import java.time.Instant;
  * }</pre>
  *
  * @see DurationRetryPolicyBuilder
- * @since 1.6
+ * @since 1.7
  */
 public class DurationRetryPolicy implements RetryPolicy {
 

--- a/ratpack-exec/src/main/java/ratpack/exec/util/retry/DurationRetryPolicyBuilder.java
+++ b/ratpack-exec/src/main/java/ratpack/exec/util/retry/DurationRetryPolicyBuilder.java
@@ -17,7 +17,6 @@
 package ratpack.exec.util.retry;
 
 import com.google.common.annotations.VisibleForTesting;
-import ratpack.func.Action;
 
 import java.time.Clock;
 import java.time.Duration;

--- a/ratpack-exec/src/main/java/ratpack/exec/util/retry/DurationRetryPolicyBuilder.java
+++ b/ratpack-exec/src/main/java/ratpack/exec/util/retry/DurationRetryPolicyBuilder.java
@@ -16,8 +16,6 @@
 
 package ratpack.exec.util.retry;
 
-import com.google.common.annotations.VisibleForTesting;
-
 import java.time.Clock;
 import java.time.Duration;
 
@@ -50,7 +48,7 @@ public interface DurationRetryPolicyBuilder {
   DurationRetryPolicy build();
 
   /**
-   * The delay strategy
+   * The delay strategy.
    *
    * @param delay the delay strategy
    * @return this
@@ -58,7 +56,7 @@ public interface DurationRetryPolicyBuilder {
   DurationRetryPolicyBuilder delay(Delay delay);
 
   /**
-   * Maximum duration until timeout of the retry policy
+   * Maximum duration until timeout of the retry policy.
    *
    * @param maxDuration the maximum duration
    * @return this
@@ -66,12 +64,11 @@ public interface DurationRetryPolicyBuilder {
   DurationRetryPolicyBuilder maxDuration(Duration maxDuration);
 
   /**
-   * Clock used to determine current time. Exposed for testing purposes.
+   * Clock used to determine current time.
    *
    * @param clock clock used to determine current time
    * @return this
    */
-  @VisibleForTesting
   DurationRetryPolicyBuilder clock(Clock clock);
 
 }

--- a/ratpack-exec/src/main/java/ratpack/exec/util/retry/DurationRetryPolicyBuilder.java
+++ b/ratpack-exec/src/main/java/ratpack/exec/util/retry/DurationRetryPolicyBuilder.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.exec.util.retry;
+
+import com.google.common.annotations.VisibleForTesting;
+import ratpack.func.Action;
+
+import java.time.Clock;
+import java.time.Duration;
+
+/**
+ * Builds a {@link DurationRetryPolicy}
+ * @see DurationRetryPolicy#of(Action)
+ * @since 1.6
+ */
+public interface DurationRetryPolicyBuilder {
+
+  /**
+   * By default, retries will wait 1 second between executions.
+   */
+  Delay DEFAULT_DELAY = FixedDelay.of(Duration.ofSeconds(1));
+
+  /**
+   * By default, this retry policy will give up after 30 seconds since the first error occurrence.
+   */
+  Duration DEFAULT_MAX_DURATION = Duration.ofSeconds(30);
+
+  /**
+   * There should be no reasons for changing this on production code.
+   */
+  Clock DEFAULT_CLOCK = Clock.systemDefaultZone();
+
+  /**
+   * Builds a {@link DurationRetryPolicy}
+   * @return a retry policy
+   */
+  DurationRetryPolicy build();
+
+  /**
+   * The delay strategy
+   *
+   * @param delay the delay strategy
+   * @return this
+   */
+  DurationRetryPolicyBuilder delay(Delay delay);
+
+  /**
+   * Maximum duration until timeout of the retry policy
+   *
+   * @param maxDuration the maximum duration
+   * @return this
+   */
+  DurationRetryPolicyBuilder maxDuration(Duration maxDuration);
+
+  /**
+   * Clock used to determine current time. Exposed for testing purposes.
+   *
+   * @param clock clock used to determine current time
+   * @return this
+   */
+  @VisibleForTesting
+  DurationRetryPolicyBuilder clock(Clock clock);
+
+}

--- a/ratpack-exec/src/main/java/ratpack/exec/util/retry/DurationRetryPolicyBuilder.java
+++ b/ratpack-exec/src/main/java/ratpack/exec/util/retry/DurationRetryPolicyBuilder.java
@@ -22,7 +22,7 @@ import java.time.Duration;
 /**
  * Builds a {@link DurationRetryPolicy}
  * @see DurationRetryPolicy#of(Action)
- * @since 1.6
+ * @since 1.7
  */
 public interface DurationRetryPolicyBuilder {
 

--- a/ratpack-exec/src/main/java/ratpack/exec/util/retry/FixedDelay.java
+++ b/ratpack-exec/src/main/java/ratpack/exec/util/retry/FixedDelay.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.exec.util.retry;
+
+import ratpack.exec.Promise;
+
+import java.time.Duration;
+
+/**
+ * A fixed duration based implementation of {@link Delay}.
+ * @since 1.6
+ */
+public class FixedDelay implements Delay {
+
+  private final Duration delay;
+
+  private FixedDelay(Duration delay) {
+    this.delay = delay;
+  }
+
+  /**
+   * Builds a fixed duration delay.
+   * @param duration the fixed duration
+   * @return a fixed delay
+   */
+  public static FixedDelay of(Duration duration) {
+    return new FixedDelay(duration);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Promise<Duration> delay(Integer attempt) {
+    return Promise.value(delay);
+  }
+}

--- a/ratpack-exec/src/main/java/ratpack/exec/util/retry/FixedDelay.java
+++ b/ratpack-exec/src/main/java/ratpack/exec/util/retry/FixedDelay.java
@@ -22,7 +22,7 @@ import java.time.Duration;
 
 /**
  * A fixed duration based implementation of {@link Delay}.
- * @since 1.6
+ * @since 1.7
  */
 public class FixedDelay implements Delay {
 

--- a/ratpack-exec/src/main/java/ratpack/exec/util/retry/IndexedDelay.java
+++ b/ratpack-exec/src/main/java/ratpack/exec/util/retry/IndexedDelay.java
@@ -62,7 +62,7 @@ import java.util.function.Function;
  * }
  * }</pre>
  *
- * @since 1.6
+ * @since 1.7
  */
 public class IndexedDelay implements Delay {
 

--- a/ratpack-exec/src/main/java/ratpack/exec/util/retry/IndexedDelay.java
+++ b/ratpack-exec/src/main/java/ratpack/exec/util/retry/IndexedDelay.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.exec.util.retry;
+
+import ratpack.exec.Promise;
+
+import java.time.Duration;
+import java.util.function.Function;
+
+/**
+ * A index based implementation of {@link Delay}. By being configurable through an injected function, callers can implement customs backoff algorithms.
+ *
+ * <pre class="java">{@code
+ * import ratpack.exec.ExecResult;
+ * import ratpack.exec.Promise;
+ * import ratpack.exec.util.retry.AttemptRetryPolicy;
+ * import ratpack.exec.util.retry.RetryPolicy;
+ * import ratpack.exec.util.retry.IndexedDelay;
+ * import ratpack.test.exec.ExecHarness;
+ *
+ * import java.time.Duration;
+ * import java.util.Arrays;
+ * import java.util.LinkedList;
+ * import java.util.List;
+ * import java.util.concurrent.atomic.AtomicInteger;
+ *
+ * import static org.junit.Assert.assertEquals;
+ *
+ * public class Example {
+ *   private static final List<String> LOG = new LinkedList<>();
+ *
+ *   public static void main(String... args) throws Exception {
+ *     AtomicInteger source = new AtomicInteger();
+ *
+ *     RetryPolicy retryPolicy = AttemptRetryPolicy.of(b -> b
+ *       .delay(IndexedDelay.of(i -> Duration.ofMillis(500).multipliedBy(i)))
+ *       .maxAttempts(3));
+ *
+ *     ExecResult<Integer> result = ExecHarness.yieldSingle(exec ->
+ *       Promise.sync(source::incrementAndGet)
+ *         .mapIf(i -> i < 3, i -> { throw new IllegalStateException(); })
+ *         .retry(retryPolicy, (i, t) -> LOG.add("retry attempt: " + i))
+ *     );
+ *
+ *     assertEquals(Integer.valueOf(3), result.getValue());
+ *     assertEquals(Arrays.asList("retry attempt: 1", "retry attempt: 2"), LOG);
+ *   }
+ * }
+ * }</pre>
+ *
+ * @since 1.6
+ */
+public class IndexedDelay implements Delay {
+
+  private Function<? super Integer, Duration> indexedDelay;
+
+  private IndexedDelay(Function<? super Integer, Duration> indexedDelay) {
+    this.indexedDelay = indexedDelay;
+  }
+
+  /**
+   * Builds an index based delay.
+   * @param indexedDelay a function expecting a retry attempt and returning the delay duration
+   * @return an indexed delay
+   */
+  public static IndexedDelay of(Function<? super Integer, Duration> indexedDelay) {
+    return new IndexedDelay(indexedDelay);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Promise<Duration> delay(Integer attempt) {
+    return Promise.value(indexedDelay.apply(attempt));
+  }
+}

--- a/ratpack-exec/src/main/java/ratpack/exec/util/retry/RetryPolicy.java
+++ b/ratpack-exec/src/main/java/ratpack/exec/util/retry/RetryPolicy.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.exec.util.retry;
+
+import ratpack.exec.Promise;
+import ratpack.func.BiAction;
+
+import java.time.Duration;
+
+/**
+ * A strategy object to govern retry behaviours.
+ * <p>
+ * Implementors should define their own exhaustion policy, i.e. when they will give up retrying.
+ * Implementors should track retry attempts, even if they don't leverage it when deciding exhaustion.
+ * Exampled of other uses are logging or to customize delays.
+ * Implementors should also define what kind of delay will be executed between retries.
+ * @see Delay and its implementors for different strategies.
+ *
+ * <pre class="java">{@code
+ * import ratpack.exec.ExecResult;
+ * import ratpack.exec.Promise;
+ * import ratpack.exec.util.retry.AttemptRetryPolicy;
+ * import ratpack.exec.util.retry.RetryPolicy;
+ * import ratpack.exec.util.retry.FixedDelay;
+ * import ratpack.test.exec.ExecHarness;
+ *
+ * import java.time.Duration;
+ * import java.util.Arrays;
+ * import java.util.LinkedList;
+ * import java.util.List;
+ * import java.util.concurrent.atomic.AtomicInteger;
+ *
+ * import static org.junit.Assert.assertEquals;
+ *
+ * public class Example {
+ *   private static final List<String> LOG = new LinkedList<>();
+ *
+ *   public static void main(String... args) throws Exception {
+ *     AtomicInteger source = new AtomicInteger();
+ *
+ *     RetryPolicy retryPolicy = AttemptRetryPolicy.of(b -> b
+ *       .delay(FixedDelay.of(Duration.ofMillis(500)))
+ *       .maxAttempts(3));
+ *
+ *     ExecResult<Integer> result = ExecHarness.yieldSingle(exec ->
+ *       Promise.sync(source::incrementAndGet)
+ *         .mapIf(i -> i < 3, i -> { throw new IllegalStateException(); })
+ *         .retry(retryPolicy, (i, t) -> LOG.add("retry attempt: " + i))
+ *     );
+ *
+ *     assertEquals(Integer.valueOf(3), result.getValue());
+ *     assertEquals(Arrays.asList("retry attempt: 1", "retry attempt: 2"), LOG);
+ *   }
+ * }
+ * }</pre>
+ *
+ * @see Promise#retry(RetryPolicy, BiAction)
+ * @since 1.6
+ */
+public interface RetryPolicy {
+
+  /**
+   * If the caller should stop retrying.
+   * @return TRUE if the caller should stop retrying
+   */
+  boolean isExhausted();
+
+  /**
+   * Attempts performed so far. Starts on 1, i.e. when no retry has been performed yet this returns 1.
+   * @return attempts performed so far.
+   */
+  int attempts();
+
+  /**
+   * Increase number of attempts.
+   * @return this policy after updating the internal state around attempts
+   */
+  RetryPolicy increaseAttempt();
+
+  /**
+   * Promise that returns the waiting time before retrying.
+   * @return promise that returns the waiting time before retrying
+   * @see Delay and its implementors for different strategies
+   */
+  Promise<Duration> delay();
+
+}

--- a/ratpack-exec/src/main/java/ratpack/exec/util/retry/RetryPolicy.java
+++ b/ratpack-exec/src/main/java/ratpack/exec/util/retry/RetryPolicy.java
@@ -17,7 +17,6 @@
 package ratpack.exec.util.retry;
 
 import ratpack.exec.Promise;
-import ratpack.func.BiAction;
 
 import java.time.Duration;
 

--- a/ratpack-exec/src/main/java/ratpack/exec/util/retry/RetryPolicy.java
+++ b/ratpack-exec/src/main/java/ratpack/exec/util/retry/RetryPolicy.java
@@ -68,7 +68,7 @@ import java.time.Duration;
  * }</pre>
  *
  * @see Promise#retry(RetryPolicy, BiAction)
- * @since 1.6
+ * @since 1.7
  */
 public interface RetryPolicy {
 

--- a/ratpack-exec/src/main/java/ratpack/exec/util/retry/internal/DefaultAttemptRetryPolicyBuilder.java
+++ b/ratpack-exec/src/main/java/ratpack/exec/util/retry/internal/DefaultAttemptRetryPolicyBuilder.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.exec.util.retry.internal;
+
+import ratpack.exec.util.retry.AttemptRetryPolicy;
+import ratpack.exec.util.retry.AttemptRetryPolicyBuilder;
+import ratpack.exec.util.retry.Delay;
+
+public class DefaultAttemptRetryPolicyBuilder implements AttemptRetryPolicyBuilder {
+
+  private Delay delay = DEFAULT_DELAY;
+  private int maxAttempts = DEFAULT_MAX_ATTEMPTS;
+
+  @Override
+  public AttemptRetryPolicyBuilder delay(Delay delay) {
+      this.delay = delay;
+      return this;
+  }
+
+  @Override
+  public AttemptRetryPolicyBuilder maxAttempts(int maxAttempts) {
+      this.maxAttempts = maxAttempts;
+      return this;
+  }
+
+  @Override
+  public AttemptRetryPolicy build() {
+        return new AttemptRetryPolicy(delay, maxAttempts);
+    }
+}

--- a/ratpack-exec/src/main/java/ratpack/exec/util/retry/internal/DefaultDurationRetryPolicyBuilder.java
+++ b/ratpack-exec/src/main/java/ratpack/exec/util/retry/internal/DefaultDurationRetryPolicyBuilder.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.exec.util.retry.internal;
+
+import ratpack.exec.util.retry.Delay;
+import ratpack.exec.util.retry.DurationRetryPolicy;
+import ratpack.exec.util.retry.DurationRetryPolicyBuilder;
+
+import java.time.Clock;
+import java.time.Duration;
+
+public class DefaultDurationRetryPolicyBuilder implements DurationRetryPolicyBuilder {
+
+  private Delay delay = DEFAULT_DELAY;
+  private Duration maxDuration = DEFAULT_MAX_DURATION;
+  private Clock clock = DEFAULT_CLOCK;
+
+  @Override
+  public DurationRetryPolicyBuilder delay(Delay delay) {
+      this.delay = delay;
+      return this;
+  }
+
+  @Override
+  public DurationRetryPolicyBuilder maxDuration(Duration maxDuration) {
+      this.maxDuration = maxDuration;
+      return this;
+  }
+
+  @Override
+  public DurationRetryPolicyBuilder clock(Clock clock) {
+      this.clock = clock;
+      return this;
+  }
+
+  @Override
+  public DurationRetryPolicy build() {
+        return new DurationRetryPolicy(delay, maxDuration, clock);
+    }
+}

--- a/ratpack-exec/src/test/groovy/ratpack/exec/PromiseRetrySpec.groovy
+++ b/ratpack-exec/src/test/groovy/ratpack/exec/PromiseRetrySpec.groovy
@@ -16,12 +16,38 @@
 
 package ratpack.exec
 
+import ratpack.exec.util.retry.AttemptRetryPolicy
+import ratpack.exec.util.retry.DurationRetryPolicy
+import ratpack.exec.util.retry.FixedDelay
+import ratpack.exec.util.retry.IndexedDelay
+import ratpack.test.internal.time.FixedWindableClock
+
 import java.time.Duration
+import java.time.Instant
+import java.time.ZoneOffset
 import java.util.concurrent.atomic.AtomicInteger
 
 class PromiseRetrySpec extends BaseExecutionSpec {
 
-  def "can retry failed promise and succeed"() {
+  def clock = new FixedWindableClock(Instant.now(), ZoneOffset.UTC)
+
+  def attemptFixedRetryStrategy = AttemptRetryPolicy.of { it
+    .delay(FixedDelay.of(Duration.ofMillis(5)))
+    .maxAttempts(3)
+  }
+
+  def attemptIndexedRetryStrategy = AttemptRetryPolicy.of { it
+    .delay(IndexedDelay.of { i -> Duration.ofMillis(5).multipliedBy(i) })
+    .maxAttempts(3)
+  }
+
+  def durationRetryStrategy = DurationRetryPolicy.of { it
+    .delay(FixedDelay.of(Duration.ofMillis(5)))
+    .maxDuration(Duration.ofSeconds(10))
+    .clock(clock)
+  }
+
+  def "can retry failed promise and succeed (deprecated method)"() {
     when:
     def i = new AtomicInteger()
 
@@ -36,7 +62,7 @@ class PromiseRetrySpec extends BaseExecutionSpec {
     events == ["retry1", "retry2", 3, "complete"]
   }
 
-  def "can retry failed promise and fail"() {
+  def "can retry failed promise and fail (deprecated method)"() {
     when:
     def e = new RuntimeException("!")
 
@@ -50,7 +76,7 @@ class PromiseRetrySpec extends BaseExecutionSpec {
     events == ["retry1", "retry2", "retry3", e, "complete"]
   }
 
-  def "can retry failed promise with fixed delay and succeed"() {
+  def "can retry failed promise with fixed delay and succeed (deprecated method)"() {
     when:
     def i = new AtomicInteger()
 
@@ -65,7 +91,7 @@ class PromiseRetrySpec extends BaseExecutionSpec {
     events == ["retry1", "retry2", 3, "complete"]
   }
 
-  def "can retry failed promise with fixed delay and fail"() {
+  def "can retry failed promise with fixed delay and fail (deprecated method)"() {
     when:
     def e = new RuntimeException("!")
 
@@ -79,13 +105,91 @@ class PromiseRetrySpec extends BaseExecutionSpec {
     events == ["retry1", "retry2", "retry3", e, "complete"]
   }
 
-  def "promise retry action is an execution segment"() {
+  def "promise retry action is an execution segmen (deprecated method)t"() {
     when:
     def e = new RuntimeException("!")
 
     exec({
       Promise.error(e)
         .retry(3, Duration.ofMillis(5), { n, ex -> Operation.of { events << "retry$n" }.then() })
+        .then { events << "then" }
+    }, events.&add)
+
+    then:
+    events == ["retry1", "retry2", "retry3", e, "complete"]
+  }
+
+  def "can retry failed promise until a number of attempts and succeed"() {
+    when:
+    def i = new AtomicInteger()
+
+    exec {
+      Promise.sync { i.incrementAndGet() }
+        .mapIf({ it < 3 }, { throw new IllegalStateException() })
+        .retry(attemptFixedRetryStrategy, { n, e -> events << "retry$n" })
+        .then(events.&add)
+    }
+
+    then:
+    events == ["retry1", "retry2", 3, "complete"]
+  }
+
+  def "can retry with an indexed delay failed promise until a number of attempts and succeed"() {
+    when:
+    def i = new AtomicInteger()
+
+    exec {
+      Promise.sync { i.incrementAndGet() }
+        .mapIf({ it < 3 }, { throw new IllegalStateException() })
+        .retry(attemptIndexedRetryStrategy, { n, e -> events << "retry$n" })
+        .then(events.&add)
+    }
+
+    then:
+    events == ["retry1", "retry2", 3, "complete"]
+  }
+
+  def "can retry failed promise until a number of attempts and fail"() {
+    when:
+    def e = new RuntimeException("!")
+
+    exec({
+      Promise.error(e)
+        .retry(attemptFixedRetryStrategy, { n, ex -> events << "retry$n" })
+        .then { events << "then" }
+    }, events.&add)
+
+    then:
+    events == ["retry1", "retry2", "retry3", e, "complete"]
+  }
+
+  def "can retry failed promise until a duration and succeed"() {
+    when:
+    def i = new AtomicInteger()
+
+    exec {
+      Promise.sync { i.incrementAndGet() }
+        .mapIf({ it < 3 }, { throw new IllegalStateException() })
+        .retry(durationRetryStrategy, { n, e -> events << "retry$n" })
+        .then(events.&add)
+    }
+
+    then:
+    events == ["retry1", "retry2", 3, "complete"]
+  }
+
+  def "can retry failed promise until a duration and fail"() {
+    when:
+    def e = new RuntimeException("!")
+
+    exec({
+      Promise.error(e)
+        .retry(durationRetryStrategy, { n, ex ->
+        events << "retry$n"
+        if (n == 3) {
+          clock.windClock(Duration.ofMinutes(5))
+        }
+      })
         .then { events << "then" }
     }, events.&add)
 

--- a/ratpack-test-internal/src/main/groovy/ratpack/test/internal/time/FixedWindableClock.java
+++ b/ratpack-test-internal/src/main/groovy/ratpack/test/internal/time/FixedWindableClock.java
@@ -1,0 +1,40 @@
+package ratpack.test.internal.time;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.temporal.TemporalAmount;
+
+/**
+ * Similar to a java.time.Clock.FixedClock, but allows you to wind time forwards and backwards.
+ */
+public final class FixedWindableClock extends Clock {
+
+  private Instant now;
+  private final ZoneId zoneId;
+
+  public FixedWindableClock(Instant now, ZoneId zoneId) {
+    this.now = now;
+    this.zoneId = zoneId;
+  }
+
+  @Override
+  public ZoneId getZone() {
+    return zoneId;
+  }
+
+  @Override
+  public Clock withZone(ZoneId zone) {
+    return new FixedWindableClock(now, zone);
+  }
+
+  @Override
+  public Instant instant() {
+    return now;
+  }
+
+  public void windClock(TemporalAmount amount) {
+    now = now.plus(amount);
+  }
+
+}

--- a/ratpack-test-internal/src/main/groovy/ratpack/test/internal/time/FixedWindableClock.java
+++ b/ratpack-test-internal/src/main/groovy/ratpack/test/internal/time/FixedWindableClock.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ratpack.test.internal.time;
 
 import java.time.Clock;


### PR DESCRIPTION
Rebase and Version changes for https://github.com/ratpack/ratpack/pull/1405

This PR extends the existing retry API on Promise type to support more strategies than the attempts based current one.

This is achieved by providing a couple of new strategies: RetryPolicy and Delay. The former defines the exhaustion strategy, or when the retries should stop. The latter defines the delay between those retries, enabling the users the ability to provide their own backoff mechanisms.

Existing APIs have been properly deprecated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1431)
<!-- Reviewable:end -->
