### PR TITLE
Add regression test for #1369

### DIFF
--- a/ratpack-exec/src/main/java/ratpack/exec/internal/CachingUpstream.java
+++ b/ratpack-exec/src/main/java/ratpack/exec/internal/CachingUpstream.java
@@ -136,7 +136,6 @@ public class CachingUpstream<T> implements Upstream<T> {
     Instant expiresAt;
     if (ttl.isNegative()) {
       expiresAt = null; // eternal
-      upstream = null; // release
     } else if (ttl.isZero()) {
       expiresAt = clock.instant().minus(Duration.ofSeconds(1));
     } else {
@@ -149,6 +148,10 @@ public class CachingUpstream<T> implements Upstream<T> {
     downstream.accept(result);
 
     tryDrain();
+
+    if (expiresAt == null) {
+      upstream = null; // release
+    }
   }
 
   private static class Cached<T> {


### PR DESCRIPTION
Work in progress. Added regression test for #1369 The problem still exists, and from time to time one (or multiple) test hangs at releasing the countdown latch.

```
ratpack.exec.PromiseCachingSpec > can cache multiple subscribers (42) FAILED
    Method timed out after 10,00 seconds
        at java.util.concurrent.locks.LockSupport.park(LockSupport.java:175)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer.parkAndCheckInterrupt(AbstractQueuedSynchronizer.java:836)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer.doAcquireSharedInterruptibly(AbstractQueuedSynchronizer.java:997)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireSharedInterruptibly(AbstractQueuedSynchronizer.java:1304)
        at java.util.concurrent.CountDownLatch.await(CountDownLatch.java:231)
        at ratpack.test.exec.internal.DefaultExecHarness.yield(DefaultExecHarness.java:61)
        at ratpack.test.exec.ExecHarness.yield(ExecHarness.java:122)
        at ratpack.test.exec.ExecHarness.yieldSingle(ExecHarness.java:149)
        at ratpack.exec.PromiseCachingSpec.can cache multiple subscribers(PromiseCachingSpec.groovy:245)

ratpack.exec.PromiseCachingSpec > can cache multiple subscribers (43) FAILED
    Method timed out after 10,00 seconds
        at java.util.concurrent.locks.LockSupport.park(LockSupport.java:175)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer.parkAndCheckInterrupt(AbstractQueuedSynchronizer.java:836)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer.doAcquireSharedInterruptibly(AbstractQueuedSynchronizer.java:997)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireSharedInterruptibly(AbstractQueuedSynchronizer.java:1304)
        at java.util.concurrent.CountDownLatch.await(CountDownLatch.java:231)
        at ratpack.test.exec.internal.DefaultExecHarness.yield(DefaultExecHarness.java:61)
        at ratpack.test.exec.ExecHarness.yield(ExecHarness.java:122)
        at ratpack.test.exec.ExecHarness.yieldSingle(ExecHarness.java:149)
        at ratpack.exec.PromiseCachingSpec.can cache multiple subscribers(PromiseCachingSpec.groovy:245)
```

You can run the test with 

```
$ ./gradlew :ratpack-exec:clean :ratpack-exec:test --tests ratpack.exec.PromiseCachingSpec
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1453)
<!-- Reviewable:end -->
