### PR TITLE
Fix HTTP Client with encoded query parameters

### DIFF
--- a/ratpack-core/src/main/java/ratpack/http/client/internal/RequestActionSupport.java
+++ b/ratpack-core/src/main/java/ratpack/http/client/internal/RequestActionSupport.java
@@ -46,7 +46,6 @@ import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLParameters;
 import java.net.URI;
-import java.net.URL;
 import java.security.NoSuchAlgorithmException;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
@@ -252,11 +251,10 @@ abstract class RequestActionSupport<T> implements Upstream<T> {
               redirectRequestConfig = redirectConfigurer.append(redirectRequestConfig);
               URI locationUri;
               if (ABSOLUTE_PATTERN.matcher(locationValue).matches()) {
-                URL redirectUrl = new URL(locationValue);
-                locationUri = new URI(redirectUrl.getProtocol(), redirectUrl.getUserInfo(), redirectUrl.getHost(), redirectUrl.getPort(), redirectUrl.getPath(), redirectUrl.getQuery(), redirectUrl.getRef());
+                locationUri = new URI(locationValue);
               } else {
-                QueryStringDecoder decoder = new QueryStringDecoder(locationValue);
-                locationUri = new URI(channelKey.ssl ? "https" : "http", null, channelKey.host, channelKey.port, decoder.rawPath(), decoder.rawQuery(), null);
+                URI partial = URI.create(locationValue);
+                locationUri = new URI(channelKey.ssl ? "https" : "http", null, channelKey.host, channelKey.port, partial.getPath(), partial.getQuery(), null);
               }
 
               onRedirect(locationUri, redirectCount + 1, redirectRequestConfig).connect(downstream);


### PR DESCRIPTION
We upgraded to 1.7.1, but discovered an issue whereby encoded query params sent back as part of a redirect Location header would be double encoded when the redirect was performed.

This should fix it (and doesn't break the fix introduced by https://github.com/ratpack/ratpack/issues/1436) for relative params.

Both relative and absolute redirect Locations were affected, and this should fix both 😎 

Not sure if there's a chance of an expedited 1.7.2 to include this?

Cheers, and keep up the good work!

Tim

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1469)
<!-- Reviewable:end -->
