### PR TITLE
[#1496] fixed lazybones template zip archive file name

### DIFF
--- a/ratpack-lazybones/ratpack-lazybones.gradle
+++ b/ratpack-lazybones/ratpack-lazybones.gradle
@@ -83,6 +83,7 @@ packageTemplateRatpack {
       throw new GradleException("Cannot publish lazybones template with a snapshot version: $version")
     }
   }
+  archiveFileName.set("ratpack-template-${project.version}.zip")
 }
 
 task writeTestConfig(type: WriteTestConfig) {


### PR DESCRIPTION
Fixes #1496.

I couldn't find any way to unit-test this change, however, I still want to give you some evidence that this change does the trick. Here is the result of 

```
$ ./gradlew --no-daemon ratpack-lazybones:packageTemplateRatpack
```

with this change applied:

![Przechwycenie obrazu ekranu_2019-11-08_21-20-54](https://user-images.githubusercontent.com/1258405/68508123-e1ba5f80-026d-11ea-9529-fcb5933adcdc.png)

The generated zip archive file is `${buildDir}/distributions/ratpack-template-1.8.0-SNAPSHOT.zip`

And here is the same command with out it.

![Przechwycenie obrazu ekranu_2019-11-08_21-19-52](https://user-images.githubusercontent.com/1258405/68508192-08789600-026e-11ea-9c9f-1a627cf4b4a7.png)

The generated zip archive file is `${buildDir}/distributions/ratpack-lazybones-1.8.0-SNAPSHOT.zip`

To run those verification tests I had to allow temporarily to package zip archive from the SNAPSHOT version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1497)
<!-- Reviewable:end -->
