### PR TITLE
Add support for binary websocket frames

### DIFF
--- a/ratpack-core/src/main/java/ratpack/websocket/WebSocket.java
+++ b/ratpack-core/src/main/java/ratpack/websocket/WebSocket.java
@@ -29,10 +29,27 @@ public interface WebSocket {
 
   boolean isOpen();
 
+  /**
+   * @deprecated please use {@link #sendText(String)}
+   */
+  @Deprecated
   @NonBlocking
   void send(String text);
 
+  /**
+   * @deprecated please use {@link #sendText(ByteBuf)} or {@link #sendBinary(ByteBuf)}
+   */
+  @Deprecated
   @NonBlocking
   void send(ByteBuf text);
+
+  @NonBlocking
+  void sendText(String text);
+
+  @NonBlocking
+  void sendText(ByteBuf text);
+
+  @NonBlocking
+  void sendBinary(ByteBuf text);
 
 }

--- a/ratpack-core/src/main/java/ratpack/websocket/WebSocketMessage.java
+++ b/ratpack-core/src/main/java/ratpack/websocket/WebSocketMessage.java
@@ -16,9 +16,15 @@
 
 package ratpack.websocket;
 
+import io.netty.buffer.ByteBuf;
+
 public interface WebSocketMessage<T> {
 
   WebSocket getConnection();
+
+  boolean isBinary();
+
+  ByteBuf getContent();
 
   String getText();
 

--- a/ratpack-core/src/main/java/ratpack/websocket/internal/DefaultWebSocket.java
+++ b/ratpack-core/src/main/java/ratpack/websocket/internal/DefaultWebSocket.java
@@ -18,6 +18,7 @@ package ratpack.websocket.internal;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
+import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
 import ratpack.websocket.WebSocket;
@@ -55,12 +56,27 @@ public class DefaultWebSocket implements WebSocket {
 
   @Override
   public void send(String text) {
-    channel.writeAndFlush(new TextWebSocketFrame(text));
+    sendText(text);
   }
 
   @Override
   public void send(ByteBuf text) {
+    sendText(text);
+  }
+
+  @Override
+  public void sendText(String text) {
     channel.writeAndFlush(new TextWebSocketFrame(text));
+  }
+
+  @Override
+  public void sendText(ByteBuf text) {
+    channel.writeAndFlush(new TextWebSocketFrame(text));
+  }
+
+  @Override
+  public void sendBinary(ByteBuf text) {
+    channel.writeAndFlush(new BinaryWebSocketFrame(text));
   }
 
 }

--- a/ratpack-core/src/main/java/ratpack/websocket/internal/DefaultWebSocketMessage.java
+++ b/ratpack-core/src/main/java/ratpack/websocket/internal/DefaultWebSocketMessage.java
@@ -16,18 +16,22 @@
 
 package ratpack.websocket.internal;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.util.CharsetUtil;
 import ratpack.websocket.WebSocket;
 import ratpack.websocket.WebSocketMessage;
 
 public class DefaultWebSocketMessage<T> implements WebSocketMessage<T> {
 
   private final WebSocket webSocket;
-  private final String text;
+  private final boolean binary;
+  private final ByteBuf content;
   private final T openResult;
 
-  public DefaultWebSocketMessage(WebSocket webSocket, String text, T openResult) {
+  public DefaultWebSocketMessage(WebSocket webSocket, boolean binary, ByteBuf content, T openResult) {
     this.webSocket = webSocket;
-    this.text = text;
+    this.binary = binary;
+    this.content = content;
     this.openResult = openResult;
   }
 
@@ -37,8 +41,18 @@ public class DefaultWebSocketMessage<T> implements WebSocketMessage<T> {
   }
 
   @Override
+  public boolean isBinary() {
+    return binary;
+  }
+
+  @Override
+  public ByteBuf getContent() {
+    return content;
+  }
+
+  @Override
   public String getText() {
-    return text;
+    return content.toString(CharsetUtil.UTF_8);
   }
 
   @Override

--- a/ratpack-core/src/main/java/ratpack/websocket/internal/WebSocketEngine.java
+++ b/ratpack-core/src/main/java/ratpack/websocket/internal/WebSocketEngine.java
@@ -127,9 +127,9 @@ public class WebSocketEngine {
                 channel.writeAndFlush(new PongWebSocketFrame(frame.content()));
                 return;
               }
-              if (frame instanceof TextWebSocketFrame) {
-                TextWebSocketFrame textWebSocketFrame = (TextWebSocketFrame) frame;
-                handler.onMessage(new DefaultWebSocketMessage<>(webSocket, textWebSocketFrame.text(), openResult));
+              if (frame instanceof TextWebSocketFrame || frame instanceof BinaryWebSocketFrame) {
+                boolean binary = frame instanceof BinaryWebSocketFrame;
+                handler.onMessage(new DefaultWebSocketMessage<>(webSocket, binary, frame.content(), openResult));
                 frame.release();
               }
             }

--- a/ratpack-test-internal/src/main/groovy/ratpack/websocket/RecordingWebSocketClient.groovy
+++ b/ratpack-test-internal/src/main/groovy/ratpack/websocket/RecordingWebSocketClient.groovy
@@ -17,10 +17,13 @@
 package ratpack.websocket
 
 import groovy.transform.CompileStatic
+import io.netty.buffer.ByteBuf
+import io.netty.buffer.Unpooled
 import org.java_websocket.client.WebSocketClient
 import org.java_websocket.framing.Framedata
 import org.java_websocket.handshake.ServerHandshake
 
+import java.nio.ByteBuffer
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
@@ -29,6 +32,7 @@ import java.util.concurrent.TimeUnit
 class RecordingWebSocketClient extends WebSocketClient {
 
   final LinkedBlockingQueue<String> receivedText = new LinkedBlockingQueue<String>()
+  final LinkedBlockingQueue<ByteBuf> receivedBytes = new LinkedBlockingQueue<ByteBuf>()
   final LinkedBlockingQueue<Framedata> receivedFragments = new LinkedBlockingQueue<Framedata>()
 
   Exception exception
@@ -62,6 +66,11 @@ class RecordingWebSocketClient extends WebSocketClient {
   @Override
   void onMessage(String message) {
     receivedText.put message
+  }
+
+  @Override
+  void onMessage(ByteBuffer byteBuffer) {
+    receivedBytes.put Unpooled.wrappedBuffer(byteBuffer)
   }
 
   @Override


### PR DESCRIPTION
The `WebSocket` now has `sendText(String/ByteBuf)` and
`sendBinary(ByteBuf)` methods. The old `send(String/ByteBuf)` methods
are deprecated to make it clear that `sendText()` or `sendBinary()`
should be used instead.

The `WebSocketMessage` now has new `isBinary()` and `getContent()`
methods. The `getText()` method is still supported and decodes the
content into a utf8 `String`. The only drawback of this approach is
that existing implementations of `WebSocketHandler` will start
receiving binary frames in their `onMessage(WebSocketMessage)` methods.
An alternative would be to introduce a new `onBinaryMessage` method
with an empty default implementation, deprecate `onMessage`, and
delegate to `onMessage` from the default implementation of
`onTextMessage` for backwards compatibility.

Resolves #746.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1501)
<!-- Reviewable:end -->
