### PR TITLE
Don't send CONTENT_LENGTH if TRANSFER_ENCODING is CHUNKED

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -18,8 +18,8 @@ ext {
   commonVersions = [
     remote           : "0.7",
     slf4j            : "1.7.25",
-    netty            : "4.1.37.Final",
-    nettyTCNative    : "2.0.25.Final",
+    netty            : "4.1.45.Final",
+    nettyTCNative    : "2.0.28.Final",
     guava            : "21.0",
     groovy           : "2.5.4",
     pac4j            : "1.8.8",


### PR DESCRIPTION
According to https://tools.ietf.org/html/rfc7230#section-3.3.3:

> <img width="535" alt="Screen Shot 2020-02-14 at 12 49 00 PM" src="https://user-images.githubusercontent.com/1841944/74528360-66311400-4f28-11ea-8bc4-386dff615540.png">

This was needed to be able to upgrade Netty to > [4-1-44](https://netty.io/news/2019/12/18/4-1-44-Final.html)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1509)
<!-- Reviewable:end -->
