### PR TITLE
executingSingle with registry

### DIFF
--- a/ratpack-test/src/main/java/ratpack/test/exec/ExecHarness.java
+++ b/ratpack-test/src/main/java/ratpack/test/exec/ExecHarness.java
@@ -229,6 +229,10 @@ public interface ExecHarness extends AutoCloseable {
     yield(e -> function.apply(e).promise()).getValueOrThrow();
   }
 
+  default void execute(Action<? super RegistrySpec> registry, Function<? super Execution, ? extends Operation> function) throws Exception {
+    yield(registry, e -> function.apply(e).promise()).getValueOrThrow();
+  }
+
   default void execute(Operation operation) throws Exception {
     execute(e -> operation);
   }
@@ -236,6 +240,12 @@ public interface ExecHarness extends AutoCloseable {
   static void executeSingle(Function<? super Execution, ? extends Operation> function) throws Exception {
     try (ExecHarness harness = harness()) {
       harness.execute(function);
+    }
+  }
+
+  static void executeSingle(Action<? super RegistrySpec> registry, Function<? super Execution, ? extends Operation> function) throws Exception {
+    try (ExecHarness harness = harness()) {
+      harness.execute(registry, function);
     }
   }
 


### PR DESCRIPTION
@johnrengelman We have a use case where a function that produces operation uses execution context of the request. This PR adds overloaded executeSingle function to accept registry which can inject the context before testing the function that produces operation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1515)
<!-- Reviewable:end -->
