### PR TITLE
A more consistent `DefaultRequest.getUri()`

### DIFF
--- a/ratpack-core/src/main/java/ratpack/http/internal/DefaultRequest.java
+++ b/ratpack-core/src/main/java/ratpack/http/internal/DefaultRequest.java
@@ -16,7 +16,6 @@
 
 package ratpack.http.internal;
 
-import com.google.common.base.Strings;
 import com.google.common.collect.Iterables;
 import com.google.common.net.HostAndPort;
 import com.google.common.reflect.TypeToken;

--- a/ratpack-core/src/test/groovy/ratpack/http/internal/DefaultRequestSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/http/internal/DefaultRequestSpec.groovy
@@ -62,14 +62,26 @@ class DefaultRequestSpec extends RatpackGroovyDslSpec {
 
     where:
     inputUri                                       | expectedUri                                    | expectedQuery                  | expectedPath
+    "relative_path"                                | "/relative_path"                               | ""                             | "relative_path"
+    "relative_path?name={malformed"                | "/relative_path?name={malformed"               | "name={malformed"              | "relative_path"
     "/user/12345"                                  | "/user/12345"                                  | ""                             | "user/12345"
     "/user?name=fred"                              | "/user?name=fred"                              | "name=fred"                    | "user"
+    "/user?name={malformed}"                       | "/user?name={malformed}"                       | "name={malformed}"             | "user"
+    "/user?name=%7bok%7d"                          | "/user?name=%7bok%7d"                          | "name=%7bok%7d"                | "user"
+    "/user?name=%7bok%7d&a=b"                      | "/user?name=%7bok%7d&a=b"                      | "name=%7bok%7d&a=b"            | "user"
     "/article/search?text=gradle&max=25&offset=50" | "/article/search?text=gradle&max=25&offset=50" | "text=gradle&max=25&offset=50" | "article/search"
     "http://example.com"                           | "/"                                            | ""                             | ""
     "http://example.com?message=hello"             | "/?message=hello"                              | "message=hello"                | ""
     "http://example.com:8080/?message=hello"       | "/?message=hello"                              | "message=hello"                | ""
     "http://example.com:8080/user/12345"           | "/user/12345"                                  | ""                             | "user/12345"
+    "http://example.com/user?name={malformed}"     | "/user?name={malformed}"                       | "name={malformed}"             | "user"
+    "http://example.com/user?name=%7bok%7d"        | "/user?name=%7bok%7d"                          | "name=%7bok%7d"                | "user"
+    "http://example.com/user?name=%7bok%7d&a=b"    | "/user?name=%7bok%7d&a=b"                      | "name=%7bok%7d&a=b"            | "user"
     "https://example.com:8443/user?name=fred"      | "/user?name=fred"                              | "name=fred"                    | "user"
+    "file:/path/to/foo"                            | "/path/to/foo"                                 | ""                             | "path/to/foo"
+    "uri:opaque-component-here"                    | "/"                                            | ""                             | ""
+    "*"                                            | "*"                                            | ""                             | "*"
+    ""                                             | "/"                                            | ""                             | ""
   }
 
   def "It should detect an AJAX request"() {


### PR DESCRIPTION
It helps to see Request-URI per the HTTP spec to understand this
change:

Request-URI    = "*" | absoluteURI | abs_path | authority

Previously abs_paths would be passed through unmodified while
absoluteURIs were parsed and either rejected because of malformed
URIs (triggering HTTP 500s) or accepted but with subtle encoding
issues.

"*" was also not properly handled by getPath(). There were also
other implementation-specific quirks like "uri:foo" yielding a
path consisting of the "null" string literal.

The "authority-only" case doesn't need to be handled because
Ratpack does not support the CONNECT method.

This change leaves abs_paths alone but tries to make all the
other cases more consistent with one another. When in doubt
we try to do something predictable. This does, however,
change the semantics of a few edge cases. I have kept the
commit implementing tests independent of the key change
here so the previous semantics and the new semantics can
be compared.

This is the proposed fix/work-around for #1517.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1518)
<!-- Reviewable:end -->
