### PR TITLE
Avoid to serve internal .ratpack file

### DIFF
--- a/ratpack-core/src/main/java/ratpack/file/internal/FileHandler.java
+++ b/ratpack-core/src/main/java/ratpack/file/internal/FileHandler.java
@@ -44,7 +44,10 @@ public class FileHandler implements Handler {
   public void handle(Context context) throws Exception {
     String path = context.getExecution().get(PathBindingStorage.TYPE).peek().getPastBinding();
     String decodedPath = decodeComponent(path, CharsetUtil.UTF_8);
-    Path asset = context.file(decodedPath);
+    Path asset = null;
+    if (!decodedPath.endsWith(".ratpack")) {
+      asset = context.file(decodedPath);
+    }
 
     if (asset == null) {
       context.clientError(404);

--- a/ratpack-core/src/test/groovy/ratpack/file/StaticFileSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/file/StaticFileSpec.groovy
@@ -406,6 +406,20 @@ class StaticFileSpec extends RatpackGroovyDslSpec {
     getText("other") == "after"
   }
 
+  def "avoid to serve hidden .ratpack file"() {
+    given:
+    def file = write ".ratpack", "private content"
+
+    when:
+    handlers {
+      files()
+    }
+
+    then:
+    getText(".ratpack") == ""
+    response.statusCode == 404
+  }
+
   def "only serve files from within the binding root"() {
     setup:
     write("public/foo.txt", "bar")


### PR DESCRIPTION
This PR avoid to serve `.ratpack` marker file, solves #1450
It filters the paths that ends with `.ratpack` returning a 404. I probably could extend to make "what exlude from current FS binding" configurable in the files DSL part.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1520)
<!-- Reviewable:end -->
