### PR TITLE
Replace deprecated API usages

### DIFF
--- a/ratpack-gradle/src/main/groovy/ratpack/gradle/RatpackPlugin.groovy
+++ b/ratpack-gradle/src/main/groovy/ratpack/gradle/RatpackPlugin.groovy
@@ -75,7 +75,7 @@ class RatpackPlugin implements Plugin<Project> {
         into "app"
       }
       eachFile {
-        if (it.name == jarTask.archiveName) {
+        if (it.name == jarTask.archiveFileName.get()) {
           it.exclude()
         }
       }
@@ -84,7 +84,7 @@ class RatpackPlugin implements Plugin<Project> {
     CreateStartScripts startScripts = project.startScripts
     startScripts.with {
       doLast {
-        def jarName = jarTask.archiveName
+        def jarName = jarTask.archiveFileName.get()
 
         unixScript.text = unixScript.text
           .replaceAll('CLASSPATH=(")?(.+)(")?\n', 'CLASSPATH=$1\\$APP_HOME/app:$2$3\ncd "\\$APP_HOME/app"\n')


### PR DESCRIPTION
The ratpack-gradle plugin currently uses a deprecated API from `AbstractArchiveTask` to retrieve the jar file name. In Gradle 7.0 we're planning to remove those APIs.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1571)
<!-- Reviewable:end -->
