### PR TITLE
Set checkstyle plugin config dir via configDirectory option

### DIFF
--- a/gradle/checkstyle.gradle
+++ b/gradle/checkstyle.gradle
@@ -24,7 +24,7 @@ def checkstyleConfigDir = new File(buildscript.sourceFile.parentFile, 'checkstyl
 
 checkstyle {
   configFile = new File(checkstyleConfigDir, "checkstyle.xml")
-  configProperties.checkstyleConfigDir = checkstyleConfigDir
+  configDirectory = checkstyleConfigDir
 }
 
 plugins.withType(GroovyBasePlugin).configureEach {
@@ -33,7 +33,7 @@ plugins.withType(GroovyBasePlugin).configureEach {
       configFile = new File(checkstyleConfigDir, "checkstyle-groovy.xml")
       source sourceSet.allGroovy
       classpath = sourceSet.compileClasspath
-      reports.xml.destination new File(checkstyle.reportsDir, "${sourceSet.name}-groovy.xml")
+      reports.xml.destination = new File(checkstyle.reportsDir, "${sourceSet.name}-groovy.xml")
     }
   }
 }

--- a/gradle/checkstyle/checkstyle-api.xml
+++ b/gradle/checkstyle/checkstyle-api.xml
@@ -18,7 +18,7 @@
         "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
 <module name="Checker">
     <module name="SuppressionFilter">
-        <property name="file" value="${checkstyleConfigDir}/suppressions.xml"/>
+        <property name="file" value="${config_loc}/suppressions.xml"/>
     </module>
     <module name="JavadocPackage"/>
 

--- a/gradle/checkstyle/checkstyle-groovy.xml
+++ b/gradle/checkstyle/checkstyle-groovy.xml
@@ -18,10 +18,10 @@
     "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
 <module name="Checker">
   <module name="SuppressionFilter">
-    <property name="file" value="${checkstyleConfigDir}/suppressions.xml"/>
+    <property name="file" value="${config_loc}/suppressions.xml"/>
   </module>
   <module name="RegexpHeader">
-    <property name="headerFile" value="${checkstyleConfigDir}/required-header.txt"/>
+    <property name="headerFile" value="${config_loc}/required-header.txt"/>
   </module>
   <module name="RegexpSingleline">
     <property name="format" value="File \| Settings \| File Templates"/>

--- a/gradle/checkstyle/checkstyle.xml
+++ b/gradle/checkstyle/checkstyle.xml
@@ -18,7 +18,7 @@
         "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
 <module name="Checker">
     <module name="SuppressionFilter">
-        <property name="file" value="${checkstyleConfigDir}/suppressions.xml"/>
+        <property name="file" value="${config_loc}/suppressions.xml"/>
     </module>
     <module name="TreeWalker">
       <!--<module name="Indentation">-->
@@ -108,7 +108,7 @@
         <module name="FileContentsHolder"/>
     </module>
     <module name="RegexpHeader">
-        <property name="headerFile" value="${checkstyleConfigDir}/required-header.txt"/>
+        <property name="headerFile" value="${config_loc}/required-header.txt"/>
     </module>
     <module name="FileTabCharacter"/>
     <module name="RegexpSingleline">


### PR DESCRIPTION
Update references to the config directory in the Checkstyle configuration files to use [the provided](https://docs.gradle.org/current/dsl/org.gradle.api.plugins.quality.Checkstyle.html) 'config_loc' variable accordingly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1579)
<!-- Reviewable:end -->
