### PR TITLE
Add Gradle Enterprise Integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ ratpack-lazybones/templates/**/VERSION
 ratpack-version.txt
 deploy
 .jruby-container
+.idea

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://circleci.com/gh/ratpack/ratpack/tree/master.svg?style=svg)](https://circleci.com/gh/ratpack/ratpack)
 [![codecov.io](http://codecov.io/github/ratpack/ratpack/coverage.svg?branch=master)](http://codecov.io/github/ratpack/ratpack?branch=master)
+[![Revved up by Gradle Enterprise](https://img.shields.io/badge/Revved%20up%20by-Gradle%20Enterprise-06A0CE?logo=Gradle&labelColor=02303A)](https://ge.ratpack.io/scans)
 
 [![Ratpack.io](/ratpack-site/src/assets/images/ratpack-logo.png?raw=true)](https://ratpack.io)
 

--- a/gradle/buildScan.gradle
+++ b/gradle/buildScan.gradle
@@ -15,29 +15,14 @@
  */
 def env = System.getenv()
 def publishToSlack = gradle.startParameter.projectProperties.publishToSlack != null
+def ci = System.getenv("CI")
 
 gradleEnterprise.buildScan {
-  background {
-    def commitId = env.REVISION
-    try {
-      commitId = 'git rev-parse --verify HEAD'.execute().text.trim()
-    } catch (ignore) {
-      // ignore
-    }
-
-    if (commitId) {
-      link "Source", "https://github.com/ratpack/ratpack/tree/" + commitId
-    }
-  }
-}
-
-if (System.getenv("CI")) {
-  gradleEnterprise.buildScan {
-    termsOfServiceUrl = 'https://gradle.com/terms-of-service'
-    termsOfServiceAgree = 'yes'
-
+    server = "https://ge.ratpack.io"
+    captureTaskInputFiles = true
+    uploadInBackground = !ci
     publishAlways()
-    tag "CI"
+    publishIfAuthenticated()
 
     if (env.CIRCLE_BUILD_URL) {
       def buildLink = env.CIRCLE_BUILD_URL
@@ -82,4 +67,3 @@ if (System.getenv("CI")) {
       }
     }
   }
-}

--- a/settings.gradle
+++ b/settings.gradle
@@ -67,3 +67,18 @@ def setBuildFile(project) {
 }
 
 setBuildFile(rootProject)
+
+buildCache {
+  remote(HttpBuildCache) {
+    url = 'https://ge.ratpack.io/cache/'
+    def cacheUsername = System.getenv('GRADLE_ENTERPRISE_CACHE_USERNAME')
+    def cachePassword = System.getenv('GRADLE_ENTERPRISE_CACHE_PASSWORD')
+    if (cacheUsername && cachePassword) {
+      push = true
+      credentials {
+        username = cacheUsername
+        password = cachePassword
+      }
+    }
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 plugins {
-  id "com.gradle.enterprise" version "3.5"
+  id "com.gradle.enterprise" version "3.5.2"
+  id "com.gradle.common-custom-user-data-gradle-plugin" version "1.1.1"
 }
 
 enableFeaturePreview("GROOVY_COMPILATION_AVOIDANCE")


### PR DESCRIPTION
This publishes scans to Gradle Enterprise when authenticated for local and CI builds.
This also add the Gradle Enterprise Common Custom User Data Gradle Plugin.

In order to publish scans on CI, [first create the key](https://docs.gradle.com/enterprise/gradle-plugin/#creating_access_keys) and then set the [environment variable in CI](https://docs.gradle.com/enterprise/gradle-plugin/#via_environment_variable).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1582)
<!-- Reviewable:end -->
