### PR TITLE
Add Predicate and Class onError handlers to Operation

### DIFF
--- a/ratpack-exec/src/main/java/ratpack/exec/internal/DefaultOperation.java
+++ b/ratpack-exec/src/main/java/ratpack/exec/internal/DefaultOperation.java
@@ -16,11 +16,11 @@
 
 package ratpack.exec.internal;
 
-import ratpack.exec.Downstream;
 import ratpack.exec.Operation;
 import ratpack.exec.Promise;
 import ratpack.func.Action;
 import ratpack.func.Block;
+import ratpack.func.Predicate;
 
 public class DefaultOperation implements Operation {
 
@@ -36,42 +36,8 @@ public class DefaultOperation implements Operation {
   }
 
   @Override
-  public Operation onError(Action<? super Throwable> onError) {
-    return new DefaultOperation(
-      promise.transform(up -> down ->
-        up.connect(new Downstream<Void>() {
-          @Override
-          public void success(Void value) {
-            down.success(value);
-          }
-
-          @Override
-          public void error(Throwable throwable) {
-            Operation.of(() -> onError.execute(throwable)).promise().connect(new Downstream<Void>() {
-              @Override
-              public void success(Void value) {
-                down.complete();
-              }
-
-              @Override
-              public void error(Throwable throwable) {
-                down.error(throwable);
-              }
-
-              @Override
-              public void complete() {
-                down.complete();
-              }
-            });
-          }
-
-          @Override
-          public void complete() {
-            down.complete();
-          }
-        })
-      )
-    );
+  public Operation onError(Predicate<? super Throwable> predicate, Action<? super Throwable> errorHandler) {
+    return new DefaultOperation(promise.onError(predicate, errorHandler));
   }
 
   @Override

--- a/ratpack-exec/src/test/groovy/ratpack/exec/OperationErrorSpec.groovy
+++ b/ratpack-exec/src/test/groovy/ratpack/exec/OperationErrorSpec.groovy
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.exec
+
+import ratpack.func.Action
+import ratpack.test.exec.ExecHarness
+import ratpack.test.internal.BaseRatpackSpec
+import spock.lang.AutoCleanup
+
+import java.util.concurrent.CountDownLatch
+
+class OperationErrorSpec extends BaseRatpackSpec {
+
+  @AutoCleanup
+  ExecHarness execHarness = ExecHarness.harness()
+  List events = []
+  def latch = new CountDownLatch(1)
+
+
+  def exec(Action<? super Execution> action, Action<? super Throwable> onError = Action.noop()) {
+    execHarness.controller.fork()
+      .onError(onError)
+      .onComplete {
+      events << "complete"
+      latch.countDown()
+    } start {
+      action.execute(it)
+    }
+
+    latch.await()
+  }
+
+  def "on error can throw different error"() {
+    when:
+    exec {
+      Operation.of { throw new IllegalArgumentException("!") }
+        .onError {
+        throw new NullPointerException("!")
+      }
+      .then {
+        events << "then"
+      }
+    } {
+      events << it
+    }
+
+    then:
+    events.size() == 2
+    events[0] instanceof NullPointerException
+    (events[0] as Exception).suppressed[0] instanceof IllegalArgumentException
+  }
+
+  def "on error can throw same error"() {
+    when:
+    exec {
+      Operation.of { throw new IllegalArgumentException("!") }
+        .onError { throw it }
+        .then {
+        events << "then"
+      }
+    } {
+      events << it
+    }
+
+    then:
+    events.size() == 2
+    events[0] instanceof IllegalArgumentException
+    (events[0] as Exception).suppressed.length == 0
+  }
+
+  def "on error called when predicate passes"() {
+    when:
+    exec {
+      Operation.of { throw new IllegalArgumentException("!") }
+        .onError { it.message == "!" } { events << "error" }
+        .then {
+        events << "then"
+      }
+    } {
+      events << it
+    }
+
+    then:
+    events == ["error", "complete"]
+  }
+
+  def "on error not called when predicate fails"() {
+    when:
+    exec {
+      Operation.of { throw new IllegalArgumentException("!") }
+        .onError { it.message != "!" } { events << "error" }
+        .then {
+        events << "then"
+      }
+    } {
+      events << it
+    }
+
+    then:
+    events.size() == 2
+    events[0] instanceof IllegalArgumentException
+  }
+
+  def "on error called for match on exception"() {
+    when:
+    exec {
+      Operation.of { throw new IllegalArgumentException("!") }
+        .onError(IllegalArgumentException) { events << "error" }
+        .then {
+        events << "then"
+      }
+    } {
+      events << it
+    }
+
+    then:
+    events == ["error", "complete"]
+  }
+
+  def "on error not called when exception doesn't match"() {
+    when:
+    exec {
+      Operation.of { throw new IllegalArgumentException("!") }
+        .onError(NullPointerException) { events << "error" }
+        .then {
+        events << "then"
+      }
+    } {
+      events << it
+    }
+
+    then:
+    events.size() == 2
+    events[0] instanceof IllegalArgumentException
+  }
+
+  def "multiple on error handlers"() {
+    when:
+    exec {
+      Operation.of { throw new IllegalArgumentException("!") }
+        .onError { t -> t.message == "foo" } { events << "error1" }
+        .onError(IllegalArgumentException) { events << "error2" }
+        .then {
+        events << "then"
+      }
+    } {
+      events << it
+    }
+
+    then:
+    events == ["error2", "complete"]
+  }
+
+}


### PR DESCRIPTION
`Promise` has `onError(Class<Throwable>, ...)` and `onError(Predicate<Throwable>, ...)` methods

These were missing from Operation, so this PR adds them in

I realise you can simply do

`o.promise().onError(E.class, ...).operation()`, but this hides it away

I basically used the promise methods in the operation classes...  I hope this is ok 🤔

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1584)
<!-- Reviewable:end -->
