### PR TITLE
Adding support for underscores in large numbers for YAML files

### DIFF
--- a/ratpack-config/ratpack-config.gradle
+++ b/ratpack-config/ratpack-config.gradle
@@ -32,7 +32,7 @@ dependencies {
   compile project(":ratpack-func")
 
   compile commonDependencies.jackson
-  compile("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${commonVersions.jackson}") {
+  compile("com.fasterxml.jackson.dataformat:jackson-dataformats-text:${commonVersions.jackson}") {
     exclude group: "org.yaml", module: "snakeyaml"
   }
   compile("com.fasterxml.jackson.datatype:jackson-datatype-guava:${commonVersions.jackson}") {

--- a/ratpack-config/ratpack-config.gradle
+++ b/ratpack-config/ratpack-config.gradle
@@ -32,7 +32,7 @@ dependencies {
   compile project(":ratpack-func")
 
   compile commonDependencies.jackson
-  compile("com.fasterxml.jackson.dataformat:jackson-dataformats-text:${commonVersions.jackson}") {
+  compile("com.fasterxml.jackson.dataformat:jackson-dataformats-text:2.12.1") {
     exclude group: "org.yaml", module: "snakeyaml"
   }
   compile("com.fasterxml.jackson.datatype:jackson-datatype-guava:${commonVersions.jackson}") {

--- a/ratpack-config/src/main/java/ratpack/config/internal/source/YamlConfigSource.java
+++ b/ratpack-config/src/main/java/ratpack/config/internal/source/YamlConfigSource.java
@@ -18,7 +18,7 @@ package ratpack.config.internal.source;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformats.text.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.google.common.io.ByteSource;
 
 import java.net.URL;

--- a/ratpack-config/src/main/java/ratpack/config/internal/source/YamlConfigSource.java
+++ b/ratpack-config/src/main/java/ratpack/config/internal/source/YamlConfigSource.java
@@ -18,7 +18,7 @@ package ratpack.config.internal.source;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformats.text.YAMLFactory;
 import com.google.common.io.ByteSource;
 
 import java.net.URL;

--- a/ratpack-core/ratpack-core.gradle
+++ b/ratpack-core/ratpack-core.gradle
@@ -47,7 +47,7 @@ dependencies {
   compile 'org.javassist:javassist:3.22.0-GA'
 
   compile commonDependencies.jackson
-  compile("com.fasterxml.jackson.dataformat:jackson-dataformats-text:${commonVersions.jackson}") {
+  compile("com.fasterxml.jackson-dataformats-text:2.12.1") {
     exclude group: "org.yaml", module: "snakeyaml"
   }
   compile("com.fasterxml.jackson.datatype:jackson-datatype-guava:${commonVersions.jackson}") {

--- a/ratpack-core/ratpack-core.gradle
+++ b/ratpack-core/ratpack-core.gradle
@@ -47,7 +47,7 @@ dependencies {
   compile 'org.javassist:javassist:3.22.0-GA'
 
   compile commonDependencies.jackson
-  compile("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${commonVersions.jackson}") {
+  compile("com.fasterxml.jackson.dataformat:jackson-dataformats-text:${commonVersions.jackson}") {
     exclude group: "org.yaml", module: "snakeyaml"
   }
   compile("com.fasterxml.jackson.datatype:jackson-datatype-guava:${commonVersions.jackson}") {


### PR DESCRIPTION
My team is looking into adding underscores to our config files to improve the readability of large numerical values.

i.e. 
`1000 --> 1_000`
`10000 --> 10_000`
`100000 --> 100_000`
etc.

The `jackson-dataformat-yaml` package does not support underscores in numerical values. The yaml package was added into `jackson-dataformats-text` and updated to include this support.

The purpose of this PR is to update the `jackson-dataformat-yaml` instances to `jackson-dataformats-text`. The only difference this should make is the `YAMLFactory` object in the `YAMLConfigSource` class now uses the newer version that supports underscores in numerical values (This appears to be the only place that is using that package).

Cheers!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1588)
<!-- Reviewable:end -->
