### PR TITLE
Reliably respond to too-large-request-body server handling

### DIFF
--- a/ratpack-core/src/main/java/ratpack/file/internal/ResponseTransmitter.java
+++ b/ratpack-core/src/main/java/ratpack/file/internal/ResponseTransmitter.java
@@ -18,7 +18,7 @@ package ratpack.file.internal;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http.HttpResponseStatus;
-import org.reactivestreams.Subscriber;
+import org.reactivestreams.Publisher;
 import ratpack.func.Action;
 import ratpack.handling.RequestOutcome;
 
@@ -30,7 +30,7 @@ public interface ResponseTransmitter {
 
   void transmit(HttpResponseStatus status, Path file);
 
-  Subscriber<ByteBuf> transmitter(HttpResponseStatus status);
+  void transmit(HttpResponseStatus status, Publisher<? extends ByteBuf> publisher);
 
   void addOutcomeListener(Action<? super RequestOutcome> action);
 

--- a/ratpack-core/src/main/java/ratpack/http/Request.java
+++ b/ratpack-core/src/main/java/ratpack/http/Request.java
@@ -161,9 +161,13 @@ public interface Request extends MutableRegistry {
    * <p>
    * If this request does not have a body, a non null object is still returned but it effectively has no data.
    * <p>
-   * If the transmitted content is larger than provided {@code maxContentLength}, the given block will be invoked.
+   * If the body content is larger than provided {@code maxContentLength}, the given block will be invoked.
    * If the block completes successfully, the promise will be terminated.
    * If the block errors, the promise will carry the failure.
+   * <p>
+   * If the body content is larger than the provided {@code maxContentLength},
+   * a {@code 413} status will be issued and the connection will be closed,
+   * regardless of any other attempts to render a response.
    *
    * @param onTooLarge the action to take if the request body exceeds the given maxContentLength
    * @return the body of the request
@@ -176,7 +180,9 @@ public interface Request extends MutableRegistry {
    * <p>
    * If this request does not have a body, a non null object is still returned but it effectively has no data.
    * <p>
-   * If the transmitted content is larger than the provided {@code maxContentLength}, an {@code 413} client error will be issued.
+   * If the body content is larger than the provided {@code maxContentLength},
+   * a {@code 413} status will be issued and the connection will be closed,
+   * regardless of any other attempts to render a response.
    *
    * @param maxContentLength the maximum number of bytes allowed for the request.
    * @return the body of the request.
@@ -189,9 +195,13 @@ public interface Request extends MutableRegistry {
    * <p>
    * If this request does not have a body, a non null object is still returned but it effectively has no data.
    * <p>
-   * If the transmitted content is larger than the provided {@code maxContentLength}, the given block will be invoked.
+   * If the body content is larger than the provided {@code maxContentLength}, the given block will be invoked.
    * If the block completes successfully, the promise will be terminated.
    * If the block errors, the promise will carry the failure.
+   * <p>
+   * If the body content is larger than the provided {@code maxContentLength},
+   * a {@code 413} status will be issued and the connection will be closed,
+   * regardless of any other attempts to render a response.
    *
    * @param maxContentLength the maximum number of bytes allowed for the request.
    * @param onTooLarge the action to take if the request body exceeds the given maxContentLength
@@ -220,6 +230,10 @@ public interface Request extends MutableRegistry {
    * <p>
    * If the request body is larger than the given {@code maxContentLength}, a {@link RequestBodyTooLargeException} will be emitted.
    * If the request body has already been read, a {@link RequestBodyAlreadyReadException} will be emitted.
+   * <p>
+   * If the body content is larger than the provided {@code maxContentLength},
+   * a {@code 413} status will be issued and the connection will be closed,
+   * regardless of any other attempts to render a response.
    * <p>
    * The returned publisher is bound to the calling execution via {@link Streams#bindExec(Publisher)}.
    * If your subscriber's onNext(), onComplete() or onError() methods are asynchronous they <b>MUST</b> use {@link Promise},

--- a/ratpack-core/src/main/java/ratpack/http/internal/DefaultResponse.java
+++ b/ratpack-core/src/main/java/ratpack/http/internal/DefaultResponse.java
@@ -286,7 +286,7 @@ public class DefaultResponse implements Response {
   public void sendStream(Publisher<? extends ByteBuf> stream) {
     finalizeResponse(() -> {
       setCookieHeader();
-      stream.subscribe(responseTransmitter.transmitter(status.getNettyStatus()));
+      responseTransmitter.transmit(status.getNettyStatus(), stream);
     }, t -> {
       throw t;
     });

--- a/ratpack-core/src/main/java/ratpack/server/internal/NettyHandlerAdapter.java
+++ b/ratpack-core/src/main/java/ratpack/server/internal/NettyHandlerAdapter.java
@@ -216,7 +216,9 @@ public class NettyHandlerAdapter extends ChannelInboundHandlerAdapter {
         }
 
         response.getHeaders().set(HttpHeaderConstants.CONTENT_LENGTH, body.readableBytes());
-        responseTransmitter.transmit(HttpResponseStatus.INTERNAL_SERVER_ERROR, body);
+        execution.getController().fork()
+          .eventLoop(execution.getEventLoop())
+          .start(e -> responseTransmitter.transmit(HttpResponseStatus.INTERNAL_SERVER_ERROR, body));
       }
     });
   }

--- a/ratpack-core/src/main/java/ratpack/server/internal/RequestBody.java
+++ b/ratpack-core/src/main/java/ratpack/server/internal/RequestBody.java
@@ -43,7 +43,7 @@ public class RequestBody implements RequestBodyReader, RequestBodyAccumulator {
   private static final HttpResponse CONTINUE_RESPONSE = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.CONTINUE, Unpooled.EMPTY_BUFFER);
 
   enum State {
-    UNREAD, READING, READ
+    UNREAD, READING, READ, TOO_LARGE
   }
 
   private final List<ByteBuf> received = new ArrayList<>();
@@ -140,6 +140,7 @@ public class RequestBody implements RequestBodyReader, RequestBodyAccumulator {
 
   private void tooLarge(Block onTooLarge, long length, Downstream<? super ByteBuf> downstream) {
     discard();
+    state = State.TOO_LARGE;
     if (onTooLarge == RequestBodyReader.DEFAULT_TOO_LARGE_SENTINEL) {
       downstream.error(tooLargeException(length));
     } else {
@@ -182,6 +183,7 @@ public class RequestBody implements RequestBodyReader, RequestBodyAccumulator {
 
       if (isExceedsMaxContentLength(advertisedLength) || isExceedsMaxContentLength(receivedLength)) {
         discard();
+        state = State.TOO_LARGE;
         throw tooLargeException(Math.max(advertisedLength, receivedLength));
       }
 
@@ -207,13 +209,14 @@ public class RequestBody implements RequestBodyReader, RequestBodyAccumulator {
                   if (readableBytes > 0) {
                     receivedLength += readableBytes;
                     if (isExceedsMaxContentLength(receivedLength)) {
+                      state = State.TOO_LARGE;
                       byteBuf.release();
                       discard();
                       listener = null;
                       write.error(tooLargeException(RequestBody.this.receivedLength));
                       return;
                     } else {
-                      write.item(byteBuf);
+                      write.item(byteBuf.touch());
                     }
                   } else {
                     byteBuf.release();
@@ -268,7 +271,7 @@ public class RequestBody implements RequestBodyReader, RequestBodyAccumulator {
 
   @Override
   public void add(HttpContent httpContent) {
-    if (state == State.READ) {
+    if (state == State.READ || state == State.TOO_LARGE) {
       httpContent.release();
     } else {
       if (httpContent instanceof LastHttpContent) {
@@ -293,10 +296,6 @@ public class RequestBody implements RequestBodyReader, RequestBodyAccumulator {
     } else {
       byteBuf.release();
     }
-  }
-
-  public boolean isUnread() {
-    return state == State.UNREAD;
   }
 
   private void release() {
@@ -331,53 +330,68 @@ public class RequestBody implements RequestBodyReader, RequestBodyAccumulator {
     }
   }
 
-  public void drain(Consumer<? super Throwable> resume) {
-    release();
+  enum DrainOutcome {
+    DRAINED,
+    TOO_LARGE,
+    EARLY_CLOSE;
 
-    if (!isUnread()) {
-      throw new RequestBodyAlreadyReadException();
-    }
-
-    state = State.READING;
-    if (earlyClose) {
-      discard();
-      resume.accept(null);
-    } else if (advertisedLength > maxContentLength || receivedLength > maxContentLength) {
-      discard();
-      resume.accept(tooLargeException(advertisedLength));
-    } else if (receivedLast || isContinueExpected()) {
-      release(); // don't close connection, we can reuse
-      state = State.READ;
-      resume.accept(null);
-    } else {
-      listener = new Listener() {
-        @Override
-        public void onContent(HttpContent httpContent) {
-          httpContent.release();
-          if ((receivedLength += httpContent.content().readableBytes()) > maxContentLength) {
-            state = State.READ;
-            listener = null;
-            resume.accept(tooLargeException(RequestBody.this.receivedLength));
-          } else if (httpContent instanceof LastHttpContent) {
-            state = State.READ;
-            listener = null;
-            resume.accept(null);
-          } else {
-            ctx.read();
-          }
-        }
-
-        @Override
-        public void onEarlyClose() {
-          resume.accept(null);
-        }
-      };
-
-      // Don't use startBodyRead as we don't want to issue continue
-      ctx.read();
-    }
-
+    final Promise<DrainOutcome> promise = Promise.value(this);
   }
+
+  public Promise<DrainOutcome> drain() {
+    return Promise.flatten(() -> {
+      release();
+      if (state == State.READ) {
+        return DrainOutcome.DRAINED.promise;
+      }
+      if (state == State.TOO_LARGE) {
+        return DrainOutcome.TOO_LARGE.promise;
+      }
+
+      state = State.READING;
+      if (earlyClose) {
+        discard();
+        return DrainOutcome.EARLY_CLOSE.promise;
+      } else if (receivedLast || isContinueExpected()) {
+        release(); // don't close connection, we can reuse
+        state = State.READ;
+        return DrainOutcome.DRAINED.promise;
+      } else if (advertisedLength > maxContentLength || receivedLength > maxContentLength) {
+        discard();
+        state = State.TOO_LARGE;
+        return DrainOutcome.TOO_LARGE.promise;
+      } else {
+        return Promise.async(down -> {
+          listener = new Listener() {
+            @Override
+            public void onContent(HttpContent httpContent) {
+              httpContent.release();
+              if ((receivedLength += httpContent.content().readableBytes()) > maxContentLength) {
+                state = State.TOO_LARGE;
+                listener = null;
+                down.success(DrainOutcome.TOO_LARGE);
+              } else if (httpContent instanceof LastHttpContent) {
+                state = State.READ;
+                listener = null;
+                down.success(DrainOutcome.DRAINED);
+              } else {
+                ctx.read();
+              }
+            }
+
+            @Override
+            public void onEarlyClose() {
+              down.success(DrainOutcome.EARLY_CLOSE);
+            }
+          };
+
+          // Don't use startBodyRead as we don't want to issue continue
+          ctx.read();
+        });
+      }
+    });
+  }
+
 
   @Override
   public long getContentLength() {

--- a/ratpack-core/src/test/groovy/ratpack/file/FileIoSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/file/FileIoSpec.groovy
@@ -18,6 +18,7 @@ package ratpack.file
 
 import io.netty.buffer.ByteBufAllocator
 import io.netty.buffer.Unpooled
+import ratpack.http.Status
 import ratpack.stream.Streams
 import ratpack.test.internal.RatpackGroovyDslSpec
 
@@ -76,7 +77,7 @@ class FileIoSpec extends RatpackGroovyDslSpec {
     when:
     handlers {
       post {
-        request.maxContentLength = n / 2
+        request.maxContentLength = (long) (n / 2)
         FileIo.write(request.bodyStream, FileIo.open(file, CREATE_NEW, WRITE))
           .onError { render it.toString() }
           .then { render "bad" }
@@ -84,8 +85,8 @@ class FileIoSpec extends RatpackGroovyDslSpec {
     }
 
     then:
-    def text = request { it.post().body.text(content) }.body.text
-    text == "ratpack.http.RequestBodyTooLargeException: the request content length of 10000 exceeded the allowed maximum of 5000"
+    def response = request { it.post().body.text(content) }
+    response.status == Status.PAYLOAD_TOO_LARGE
 
     and:
     // We opened the file, but didn't write anything.

--- a/ratpack-core/src/test/groovy/ratpack/handling/NoResponseSentDetectionSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/handling/NoResponseSentDetectionSpec.groovy
@@ -17,6 +17,7 @@
 package ratpack.handling
 
 import ratpack.exec.Promise
+import ratpack.http.Status
 import ratpack.test.internal.RatpackGroovyDslSpec
 
 class NoResponseSentDetectionSpec extends RatpackGroovyDslSpec {
@@ -36,7 +37,7 @@ class NoResponseSentDetectionSpec extends RatpackGroovyDslSpec {
     }
 
     then:
-    getText() == "No response sent for GET request to / (last handler: closure at line 33 of NoResponseSentDetectionSpec.groovy)"
+    getText() == "No response sent for GET request to / (last handler: closure at line 34 of NoResponseSentDetectionSpec.groovy)"
     response.statusCode == 500
   }
 
@@ -50,7 +51,7 @@ class NoResponseSentDetectionSpec extends RatpackGroovyDslSpec {
     }
 
     then:
-    getText() == "No response sent for GET request to / (last handler: closure at line 48 of NoResponseSentDetectionSpec.groovy)"
+    getText() == "No response sent for GET request to / (last handler: closure at line 49 of NoResponseSentDetectionSpec.groovy)"
     response.statusCode == 500
   }
 
@@ -84,7 +85,7 @@ class NoResponseSentDetectionSpec extends RatpackGroovyDslSpec {
     }
 
     then:
-    getText() == "No response sent for GET request to / (last handler: anonymous class ratpack.handling.NoResponseSentDetectionSpec\$1 at approximately line 81 of NoResponseSentDetectionSpec.groovy)"
+    getText() == "No response sent for GET request to / (last handler: anonymous class ratpack.handling.NoResponseSentDetectionSpec\$1 at approximately line 82 of NoResponseSentDetectionSpec.groovy)"
     response.statusCode == 500
   }
 
@@ -101,7 +102,7 @@ class NoResponseSentDetectionSpec extends RatpackGroovyDslSpec {
       it.post().body.text("1" * 10000)
     }
 
-    r.body.text == "No response sent for POST request to / (last handler: closure at line 94 of NoResponseSentDetectionSpec.groovy)"
+    r.body.text == "No response sent for POST request to / (last handler: closure at line 95 of NoResponseSentDetectionSpec.groovy)"
     response.statusCode == 500
   }
 
@@ -114,12 +115,10 @@ class NoResponseSentDetectionSpec extends RatpackGroovyDslSpec {
       }
     }
 
-    then:
-    def r = request {
-      it.post().body.text("1" * 10000)
-    }
+    and:
+    request { it.post().body.text("1" * 10000) }
 
-    r.body.text == "No response sent for POST request to / (last handler: closure at line 112 of NoResponseSentDetectionSpec.groovy)"
-    response.statusCode == 500
+    then:
+    response.status == Status.PAYLOAD_TOO_LARGE
   }
 }

--- a/ratpack-core/src/test/groovy/ratpack/http/FormHandlingSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/http/FormHandlingSpec.groovy
@@ -62,7 +62,7 @@ class FormHandlingSpec extends RatpackGroovyDslSpec {
     resetRequest()
     requestSpec { RequestSpec requestSpec ->
       requestSpec.headers.add("Content-Type", APPLICATION_FORM)
-      requestSpec.body.stream({ it << [a: "b"].collect({ it }).join('&') })
+      requestSpec.body.text([a: "b"].collect({ it }).join('&'))
     }
     then:
     postText() == "[a:[b]]"
@@ -345,8 +345,8 @@ class FormHandlingSpec extends RatpackGroovyDslSpec {
     handlers {
       post {
         parse(form())
-          .onError {render it.toString() }
-          .then {render "ok" }
+          .onError { render it.toString() }
+          .then { render "ok" }
       }
     }
 

--- a/ratpack-core/src/test/groovy/ratpack/http/ResponseBodyReleaseSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/http/ResponseBodyReleaseSpec.groovy
@@ -17,7 +17,6 @@
 package ratpack.http
 
 import io.netty.buffer.Unpooled
-import io.netty.handler.codec.PrematureChannelClosureException
 import io.netty.handler.codec.http.HttpResponseStatus
 import ratpack.exec.Blocking
 import ratpack.exec.Execution
@@ -62,9 +61,9 @@ class ResponseBodyReleaseSpec extends RatpackGroovyDslSpec {
     executionCompletionReportingHandler {
       Blocking.op(Block.noop()) //jump off thread for the chanel close event to be processed
         .then {
-        connectionTerminated.await()
-        response.send(buffer)
-      }
+          connectionTerminated.await()
+          response.send(buffer)
+        }
     }
 
     when:
@@ -99,19 +98,16 @@ class ResponseBodyReleaseSpec extends RatpackGroovyDslSpec {
   }
 
   def "body is released if there is an error while sending headers"() {
-    given:
+    when:
     executionCompletionReportingHandler {
       response.status(new TransmissionErrorCausingStatus())
       response.send(buffer)
     }
 
-    when:
-    get()
-
     then:
-    thrown(PrematureChannelClosureException)
+    get().status == Status.INTERNAL_SERVER_ERROR
 
-    and:
+    when:
     requestExecutionCompleted.await()
 
     then:

--- a/ratpack-core/src/test/groovy/ratpack/http/ResponseStreamingSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/http/ResponseStreamingSpec.groovy
@@ -51,8 +51,7 @@ class ResponseStreamingSpec extends RatpackGroovyDslSpec {
 
     then:
     def r = request { it.post().body.text("a" * 100_000) }
-    r.status.code == 200
-    r.body.text == "abc" * 3
+    r.status == Status.PAYLOAD_TOO_LARGE
   }
 
   def "unread request body is silently discarded when streaming a response"() {
@@ -190,7 +189,7 @@ class ResponseStreamingSpec extends RatpackGroovyDslSpec {
             it.headers.add("bar", "1")
           }
         }
-        request.maxContentLength = 12
+        request.maxContentLength = 100_000
         render stringChunks(
           publish(["abc"] * 3)
         )

--- a/ratpack-core/src/test/groovy/ratpack/http/client/HttpReverseProxySpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/http/client/HttpReverseProxySpec.groovy
@@ -552,11 +552,10 @@ connection: close
 
     then:
     response == """HTTP/1.1 413 Request Entity Too Large
-content-type: text/plain;charset=UTF-8
-content-length: 16
+content-length: 0
 connection: close
 
-Client error 413"""
+"""
     !replied
 
     cleanup:

--- a/ratpack-test/src/main/java/ratpack/test/handling/internal/DefaultHandlingResult.java
+++ b/ratpack-test/src/main/java/ratpack/test/handling/internal/DefaultHandlingResult.java
@@ -22,7 +22,7 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.cookie.Cookie;
 import io.netty.util.CharsetUtil;
-import org.reactivestreams.Subscriber;
+import org.reactivestreams.Publisher;
 import org.slf4j.LoggerFactory;
 import ratpack.api.Nullable;
 import ratpack.exec.ExecController;
@@ -116,7 +116,7 @@ public class DefaultHandlingResult implements HandlingResult {
       }
 
       @Override
-      public Subscriber<ByteBuf> transmitter(HttpResponseStatus status) {
+      public void transmit(HttpResponseStatus status, Publisher<? extends ByteBuf> publisher) {
         throw new UnsupportedOperationException("streaming not supported while unit testing");
       }
 


### PR DESCRIPTION
Previously, a number of things could happen if a request came in with a body size larger than the server was willing to read. Now, we reliably respond with a deterministic 417 response and close the connection.

This makes it possibly to reliably test the too-large-request-body scenario with our client.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1606)
<!-- Reviewable:end -->
