### PR TITLE
Create a new and improved SSE client

### DIFF
--- a/ratpack-core/src/main/java/ratpack/server/internal/ServerRegistry.java
+++ b/ratpack-core/src/main/java/ratpack/server/internal/ServerRegistry.java
@@ -48,13 +48,14 @@ import ratpack.registry.Registry;
 import ratpack.registry.RegistryBuilder;
 import ratpack.render.internal.*;
 import ratpack.server.*;
-import ratpack.sse.ServerSentEventStreamClient;
+import ratpack.sse.client.ServerSentEventClient;
 
 import java.time.Clock;
 import java.util.Optional;
 
 import static ratpack.util.Exceptions.uncheck;
 
+@SuppressWarnings("deprecation")
 public abstract class ServerRegistry {
 
   public static Registry serverRegistry(RatpackServer ratpackServer, Impositions impositions, ExecControllerInternal execController, ServerConfig serverConfig, Function<? super Registry, ? extends Registry> userRegistryFactory) {
@@ -122,7 +123,8 @@ public abstract class ServerRegistry {
           return null;
         }))
         .add(HttpClient.class, httpClient)
-        .add(ServerSentEventStreamClient.class, ServerSentEventStreamClient.of(httpClient))
+        .add(ServerSentEventClient.class, ServerSentEventClient.of(httpClient))
+        .add(ratpack.sse.ServerSentEventStreamClient.class, ratpack.sse.ServerSentEventStreamClient.of(httpClient))
         .add(HealthCheckResultsRenderer.TYPE, new HealthCheckResultsRenderer(ByteBufAllocator.DEFAULT))
         .add(RequestId.Generator.class, UuidBasedRequestIdGenerator.INSTANCE);
 

--- a/ratpack-core/src/main/java/ratpack/sse/ServerSentEventStreamClient.java
+++ b/ratpack-core/src/main/java/ratpack/sse/ServerSentEventStreamClient.java
@@ -21,22 +21,28 @@ import ratpack.exec.Promise;
 import ratpack.func.Action;
 import ratpack.http.client.HttpClient;
 import ratpack.http.client.RequestSpec;
-import ratpack.sse.internal.DefaultEvent;
+import ratpack.sse.client.ServerSentEventClient;
 import ratpack.sse.internal.DefaultServerSentEventStreamClient;
 import ratpack.stream.TransformablePublisher;
 import ratpack.util.Exceptions;
 
 import java.net.URI;
 
+/**
+ * Deprecated.
+ *
+ * @deprecated since 1.10, use {@link ServerSentEventClient}.
+ */
+@Deprecated
+@SuppressWarnings("DeprecatedIsStillUsed")
 public interface ServerSentEventStreamClient {
 
   /**
-   * Creates an SSE client.
+   * Deprecated.
    *
-   * @param httpClient the underlying HTTP client to use
-   * @return an SSE client
-   * @since 1.4
+   * @deprecated since 1.10, use {@link ServerSentEventClient}.
    */
+  @Deprecated
   static ServerSentEventStreamClient of(HttpClient httpClient) {
     return new DefaultServerSentEventStreamClient(httpClient);
   }
@@ -57,35 +63,19 @@ public interface ServerSentEventStreamClient {
   /**
    * Deprecated.
    *
-   * @deprecated since 1.10 - use {@link #open(URI, Action)}
+   * @deprecated since 1.10, use {@link ServerSentEventClient}.
    */
   @Deprecated
-  default Promise<TransformablePublisher<Event<?>>> request(URI uri, Action<? super RequestSpec> action) {
-    return open(uri, action).map(stream ->
-      stream.map(e ->
-        new DefaultEvent<>(null)
-          .id(e.getId())
-          .event(e.getEvent())
-          .data(e.getData())
-          .comment(e.getComment())
-      )
-    );
-  }
+  Promise<TransformablePublisher<Event<?>>> request(URI uri, Action<? super RequestSpec> action);
 
   /**
    * Deprecated.
    *
-   * @deprecated since 1.10 - use {@link #open(URI)}
+   * @deprecated since 1.10, use {@link ServerSentEventClient}.
    */
   @Deprecated
   default Promise<TransformablePublisher<Event<?>>> request(URI uri) {
     return request(uri, Action.noop());
-  }
-
-  Promise<TransformablePublisher<? extends ServerSentEvent>> open(URI uri, Action<? super RequestSpec> action);
-
-  default Promise<TransformablePublisher<? extends ServerSentEvent>> open(URI uri) {
-    return open(uri, Action.noop());
   }
 
 }

--- a/ratpack-core/src/main/java/ratpack/sse/client/ServerSentEventClient.java
+++ b/ratpack-core/src/main/java/ratpack/sse/client/ServerSentEventClient.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.sse.client;
+
+import ratpack.exec.Promise;
+import ratpack.func.Action;
+import ratpack.http.client.HttpClient;
+import ratpack.http.client.RequestSpec;
+import ratpack.sse.client.internal.DefaultServerSentEventClient;
+
+import java.net.URI;
+
+/**
+ * A client for request Server Sent Event streams.
+ *
+ * @since 1.10
+ */
+public interface ServerSentEventClient {
+
+  /**
+   * Creates a client that uses the given HTTP client.
+   *
+   * @param httpClient the HTTP client to use
+   * @return a server sent event client
+   */
+  static ServerSentEventClient of(HttpClient httpClient) {
+    return new DefaultServerSentEventClient(httpClient);
+  }
+
+  /**
+   * Makes a request for an event stream to the given location.
+   *
+   * @param uri the location of the event stream
+   * @param action the request configurer
+   * @return the response
+   */
+  Promise<ServerSentEventResponse> request(URI uri, Action<? super RequestSpec> action);
+
+  /**
+   * Makes a request for an event stream to the given location.
+   *
+   * @param uri the location of the event stream
+   * @return the response
+   */
+  default Promise<ServerSentEventResponse> request(URI uri) {
+    return request(uri, Action.noop());
+  }
+
+}

--- a/ratpack-core/src/main/java/ratpack/sse/client/ServerSentEventResponse.java
+++ b/ratpack-core/src/main/java/ratpack/sse/client/ServerSentEventResponse.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.sse.client;
+
+import ratpack.http.client.StreamedResponse;
+import ratpack.sse.ServerSentEvent;
+import ratpack.stream.TransformablePublisher;
+
+/**
+ * A response for a server sent event stream.
+ *
+ * @since 1.10
+ */
+public interface ServerSentEventResponse extends StreamedResponse {
+
+  /**
+   * Whether the response is actually an event stream.
+   * <p>
+   * The server may have responded with some other type of content, or an error status code.
+   * <p>
+   * If this method returns false, {@link #getEvents()} will throw an exception when called.
+   * The non event-stream response body can be read via {@link #getBody()}.
+   *
+   * @return whether the response is actually an event stream
+   */
+  boolean isEventStream();
+
+  /**
+   * The response body parsed as events.
+   *
+   * If {@link #isEventStream()} returns false, this method will throw an exception when called.
+   * The non event-stream response body can be read via {@link #getBody()}.
+   *
+   * @return the event stream
+   */
+  TransformablePublisher<ServerSentEvent> getEvents();
+
+}

--- a/ratpack-core/src/main/java/ratpack/sse/client/internal/DefaultServerSentEventResponse.java
+++ b/ratpack-core/src/main/java/ratpack/sse/client/internal/DefaultServerSentEventResponse.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.sse.client.internal;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import ratpack.func.Action;
+import ratpack.http.Headers;
+import ratpack.http.MutableHeaders;
+import ratpack.http.Response;
+import ratpack.http.Status;
+import ratpack.http.client.StreamedResponse;
+import ratpack.sse.ServerSentEvent;
+import ratpack.sse.client.ServerSentEventResponse;
+import ratpack.sse.internal.ServerSentEventDecodingPublisher;
+import ratpack.stream.Streams;
+import ratpack.stream.TransformablePublisher;
+
+public class DefaultServerSentEventResponse implements ServerSentEventResponse {
+
+  private final StreamedResponse delegate;
+  private final ByteBufAllocator allocator;
+
+  public DefaultServerSentEventResponse(StreamedResponse delegate, ByteBufAllocator allocator) {
+    this.delegate = delegate;
+    this.allocator = allocator;
+  }
+
+  @Override
+  public boolean isEventStream() {
+    if (getStatus().equals(Status.NO_CONTENT)) {
+      return true;
+    } else {
+      String contentType = getHeaders().get(HttpHeaderNames.CONTENT_TYPE);
+      return contentType != null && contentType.startsWith(HttpHeaderValues.TEXT_EVENT_STREAM.toString());
+    }
+  }
+
+  @Override
+  public TransformablePublisher<ServerSentEvent> getEvents() {
+    if (!isEventStream()) {
+      throw new IllegalStateException("Response is not an event stream; has content type '" + getHeaders().get(HttpHeaderNames.CONTENT_TYPE) + "' and status " + getStatus());
+    }
+
+    if (getStatus().equals(Status.NO_CONTENT)) {
+      return Streams.empty();
+    } else {
+      return new ServerSentEventDecodingPublisher(getBody(), allocator);
+    }
+  }
+
+  @Override
+  public Status getStatus() {
+    return delegate.getStatus();
+  }
+
+  @Override
+  public int getStatusCode() {
+    return delegate.getStatusCode();
+  }
+
+  @Override
+  public Headers getHeaders() {
+    return delegate.getHeaders();
+  }
+
+  @Override
+  public TransformablePublisher<ByteBuf> getBody() {
+    return delegate.getBody();
+  }
+
+  @Override
+  public void forwardTo(Response response) {
+    delegate.forwardTo(response);
+  }
+
+  @Override
+  public void forwardTo(Response response, Action<? super MutableHeaders> headerMutator) {
+    delegate.forwardTo(response, headerMutator);
+  }
+}

--- a/ratpack-core/src/main/java/ratpack/sse/internal/ServerSentEventDecodingPublisher.java
+++ b/ratpack-core/src/main/java/ratpack/sse/internal/ServerSentEventDecodingPublisher.java
@@ -32,7 +32,7 @@ public class ServerSentEventDecodingPublisher extends BufferingPublisher<ServerS
       return new Subscription() {
 
         Subscription upstream;
-        ServerSentEventDecoder decoder = new ServerSentEventDecoder(allocator, write::item);
+        final ServerSentEventDecoder decoder = new ServerSentEventDecoder(allocator, write::item);
 
         volatile boolean emitting;
 

--- a/ratpack-core/src/test/groovy/ratpack/sse/ServerSentEventsSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/sse/ServerSentEventsSpec.groovy
@@ -28,7 +28,6 @@ import java.util.concurrent.TimeUnit
 import java.util.zip.GZIPInputStream
 
 import static io.netty.handler.codec.http.HttpResponseStatus.OK
-import static ratpack.http.ResponseChunks.stringChunks
 import static ratpack.stream.Streams.*
 
 class ServerSentEventsSpec extends BaseHttpClientSpec {
@@ -177,33 +176,6 @@ data: Event 3
 
     new GZIPInputStream(response.body.inputStream).text ==
       "id: 1\nevent: add\ndata: Event 1\n\nid: 2\nevent: add\ndata: Event 2\n\n: last\n\n"
-  }
-
-  def "can consume server sent event stream"() {
-    given:
-    otherApp {
-      get("foo") {
-        def stream = periodically(context.execution.controller.executor, Duration.ofMillis(100)) { it < 10 ? it : null }
-
-        render ServerSentEvents.builder().build(stream.map {
-          ServerSentEvent.builder().id(it.toString()).data("Event ${it}".toString()).build()
-        })
-      }
-    }
-
-    and:
-    handlers {
-      get { ServerSentEventStreamClient sseStreamClient ->
-        sseStreamClient.open(otherAppUrl("foo")).then { eventStream ->
-          render stringChunks(
-            eventStream.map { it.data }
-          )
-        }
-      }
-    }
-
-    expect:
-    getText() == "Event 0Event 1Event 2Event 3Event 4Event 5Event 6Event 7Event 8Event 9"
   }
 
   def "can send empty stream"() {
@@ -364,7 +336,7 @@ data: Event 1
     }
 
     expect:
-    def response = request { it.headers.add("Accept-Encoding", "gzip")}
+    def response = request { it.headers.add("Accept-Encoding", "gzip") }
     def text = response.body.text
 
     text.contains("""
@@ -386,7 +358,7 @@ data: Event 1
 """)
   }
 
-  def "can buffer with hearbeats"() {
+  def "can buffer with heart beats"() {
     given:
     handlers {
       all {

--- a/ratpack-core/src/test/groovy/ratpack/sse/client/ServerSentEventClientSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/sse/client/ServerSentEventClientSpec.groovy
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.sse.client
+
+import ratpack.exec.Promise
+import ratpack.http.client.BaseHttpClientSpec
+import ratpack.sse.ServerSentEvent
+import ratpack.sse.ServerSentEvents
+import ratpack.stream.Streams
+
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+
+import static ratpack.http.ResponseChunks.stringChunks
+import static ratpack.stream.Streams.flatYield
+import static ratpack.stream.Streams.periodically
+
+class ServerSentEventClientSpec extends BaseHttpClientSpec {
+
+  def "can consume server sent event stream"() {
+    given:
+    otherApp {
+      get("foo") {
+        def stream = periodically(context.execution.controller.executor, Duration.ofMillis(100)) { it < 10 ? it : null }
+
+        render ServerSentEvents.builder().build(stream.map {
+          ServerSentEvent.builder().id(it.toString()).data("Event ${it}".toString()).build()
+        })
+      }
+    }
+
+    and:
+    handlers {
+      get { ServerSentEventClient sseClient ->
+        sseClient.request(otherAppUrl("foo")).then { eventStream ->
+          render stringChunks(
+            eventStream.events.map { it.data }
+          )
+        }
+      }
+    }
+
+    expect:
+    getText() == "Event 0Event 1Event 2Event 3Event 4Event 5Event 6Event 7Event 8Event 9"
+  }
+
+  def "can consume empty stream"() {
+    given:
+    otherApp {
+      get {
+        render ServerSentEvents.builder().build(Streams.empty())
+      }
+    }
+
+    and:
+    handlers {
+      get { ServerSentEventClient sseClient ->
+        sseClient.request(otherAppUrl()).then { eventStream ->
+          render stringChunks(
+            eventStream.events.map { it.data }
+          )
+        }
+      }
+    }
+
+    expect:
+    getText() == ""
+  }
+
+  def "can receive no content stream"() {
+    given:
+    otherApp {
+      get {
+        render ServerSentEvents.builder().noContentOnEmpty().build(Streams.empty())
+      }
+    }
+
+    and:
+    handlers {
+      get { ServerSentEventClient sseClient ->
+        sseClient.request(otherAppUrl()).then { eventStream ->
+          render stringChunks(
+            eventStream.events.map { it.data }
+          )
+        }
+      }
+    }
+
+    expect:
+    getText() == ""
+  }
+
+  def "can consume heartbeats to keep stream alive"() {
+    given:
+    otherApp {
+      all {
+        def stream = flatYield { req ->
+          Promise.async { down ->
+            execution.eventLoop.schedule({ down.success(req.requestNum > 1 ? null : req.requestNum) }, 1, TimeUnit.SECONDS)
+          }
+        }
+        render ServerSentEvents.builder()
+          .keepAlive(Duration.ofMillis(10))
+          .build(stream.map {
+            ServerSentEvent.builder().id(it.toString()).data("Event ${it}".toString()).build()
+          })
+      }
+    }
+
+    and:
+    handlers {
+      get { ServerSentEventClient sseClient ->
+        sseClient.request(otherAppUrl(), { it.readTimeout(Duration.ofMillis(500)) }).then { eventStream ->
+          render stringChunks(
+            eventStream.events.map { it.data }
+          )
+        }
+      }
+    }
+
+    expect:
+    text == "Event 0Event 1"
+  }
+
+}

--- a/ratpack-guice/src/main/java/ratpack/guice/internal/RatpackBaseRegistryModule.java
+++ b/ratpack-guice/src/main/java/ratpack/guice/internal/RatpackBaseRegistryModule.java
@@ -48,7 +48,7 @@ import ratpack.render.internal.RenderableRenderer;
 import ratpack.server.PublicAddress;
 import ratpack.server.RatpackServer;
 import ratpack.server.ServerConfig;
-import ratpack.sse.ServerSentEventStreamClient;
+import ratpack.sse.client.ServerSentEventClient;
 
 import java.lang.reflect.Method;
 import java.util.List;
@@ -58,15 +58,15 @@ import java.util.Optional;
  * Expose bindings for objects in the base registry.
  * This should be kept in sync with the base registry assembled in {@link ratpack.server.internal.ServerRegistry}.
  */
+@SuppressWarnings("deprecation")
 public class RatpackBaseRegistryModule extends AbstractModule {
 
   private static final List<Class<?>> SIMPLE_TYPES = ImmutableList.of(
     ServerConfig.class, ByteBufAllocator.class, ExecController.class, MimeTypes.class, PublicAddress.class,
     Redirector.class, ClientErrorHandler.class, ServerErrorHandler.class, RatpackServer.class,
-    HttpClient.class, ServerSentEventStreamClient.class
+    HttpClient.class, ratpack.sse.ServerSentEventStreamClient.class, ServerSentEventClient.class
   );
 
-  @SuppressWarnings({"rawtypes"})
   private static final ImmutableList<TypeToken<?>> PARAMETERISED_TYPES = ImmutableList.of(
     FileRenderer.TYPE,
     PromiseRenderer.TYPE,
@@ -107,7 +107,6 @@ public class RatpackBaseRegistryModule extends AbstractModule {
     bind(type).toProvider(() -> baseRegistry.get(type));
   }
 
-  @SuppressWarnings("unchecked")
   private <T> void parameterisedBind(TypeToken<T> typeToken) {
     bind(GuiceUtil.toTypeLiteral(typeToken)).toProvider(() -> baseRegistry.get(typeToken));
   }


### PR DESCRIPTION
The new client allows full access to the response, which is necessary when something goes wrong and it's not the expected event stream.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1610)
<!-- Reviewable:end -->
