### PR TITLE
Update manual for Gradle configuration names that cause errors in Gradle 7 (runtime, etc.)

### DIFF
--- a/ratpack-manual/src/content/chapters/02-quick-start.md
+++ b/ratpack-manual/src/content/chapters/02-quick-start.md
@@ -81,7 +81,7 @@ repositories {
 }
 
 dependencies {
-  runtime "org.slf4j:slf4j-simple:@slf4j-version@"
+  runtimeOnly "org.slf4j:slf4j-simple:@slf4j-version@"
 }
 
 mainClassName = "my.app.Main"

--- a/ratpack-manual/src/content/chapters/02-quick-start.md
+++ b/ratpack-manual/src/content/chapters/02-quick-start.md
@@ -81,7 +81,7 @@ repositories {
 }
 
 dependencies {
-  runtimeOnly "org.slf4j:slf4j-simple:@slf4j-version@"
+  runtimeOnly "org.slf4j:slf4j-simple:@slf4j-version@" // Configuration name was runtime prior to Gradle 5
 }
 
 mainClassName = "my.app.Main"
@@ -141,7 +141,7 @@ repositories {
 }
 
 dependencies {
-  runtime "org.slf4j:slf4j-simple:@slf4j-version@"
+  runtimeOnly "org.slf4j:slf4j-simple:@slf4j-version@" // Configuration name was runtime prior to Gradle 5
 }
 ```
 

--- a/ratpack-manual/src/content/chapters/13-http.md
+++ b/ratpack-manual/src/content/chapters/13-http.md
@@ -591,10 +591,10 @@ repositories {
 }
 
 dependencies {
-  runtime 'org.slf4j:slf4j-simple:@slf4j-version@'
+  runtimeOnly 'org.slf4j:slf4j-simple:@slf4j-version@' // Configuration name was runtime prior to Gradle 5
   compile group: 'io.ratpack', name: 'ratpack-session', version: '@ratpack-version@'
 
-  testCompile "org.spockframework:spock-core:@spock-version@"
+  testImplementation "org.spockframework:spock-core:@spock-version@" // Configuration name was testCompile prior to Gradle 5
 }
 ```
 

--- a/ratpack-manual/src/content/chapters/60-gradle.md
+++ b/ratpack-manual/src/content/chapters/60-gradle.md
@@ -72,7 +72,7 @@ repositories {
 }
 
 dependencies {
-  compile ratpack.dependency("dropwizard-metrics")
+  implementation ratpack.dependency("dropwizard-metrics") // Configuration name was compile prior to Gradle 5
 }
 ```
 


### PR DESCRIPTION
`runtime` produces an error `Could not find method runtime() for arguments [org.slf4j:slf4j-simple:1.7.30] on object of type org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyHandler.` in Gradle 7.1.1.

`runtimeOnly` has been present since Gradle 5.0 in November 2018.
If we want to support pre-Gradle 5.0, we could add a comment to note the alternative (as I have done in this PR).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1611)
<!-- Reviewable:end -->
