### PR TITLE
Replace Request.getClientCertificate() with Request.getSslSession().

### DIFF
--- a/ratpack-core/src/main/java/ratpack/core/http/Request.java
+++ b/ratpack-core/src/main/java/ratpack/core/http/Request.java
@@ -33,6 +33,7 @@ import ratpack.exec.stream.TransformablePublisher;
 import ratpack.func.MultiValueMap;
 import ratpack.func.Types;
 
+import javax.net.ssl.SSLSession;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Optional;
@@ -445,14 +446,15 @@ public interface Request extends MutableRegistry {
   long getMaxContentLength();
 
   /**
-   * The client's verified certificate if the connection was made with HTTPS
-   * and client authentication is enabled.
+   * The client SSL session if the connection was made with HTTPS.
+   * <p>
+   * If client authentication is enabled, the client's certificate can
+   * be obtained via {@link SSLSession#getPeerCertificates()}
    *
-   * @return the client's certificate
-   * @since 1.5
+   * @return the client's SSL session
+   * @since 2.0
    */
-  @SuppressWarnings("deprecation")
-  Optional<javax.security.cert.X509Certificate> getClientCertificate();
+  Optional<SSLSession> getSslSession();
 
   /**
    * {@inheritDoc}

--- a/ratpack-core/src/main/java/ratpack/core/http/internal/DefaultRequest.java
+++ b/ratpack-core/src/main/java/ratpack/core/http/internal/DefaultRequest.java
@@ -42,6 +42,7 @@ import ratpack.exec.stream.TransformablePublisher;
 import ratpack.func.MultiValueMap;
 import ratpack.func.internal.ImmutableDelegatingMultiValueMap;
 
+import javax.net.ssl.SSLSession;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.time.Duration;
@@ -70,8 +71,7 @@ public class DefaultRequest implements Request {
 
   private long maxContentLength;
   private final RequestIdleTimeout idleTimeout;
-  @SuppressWarnings("deprecation")
-  private final javax.security.cert.X509Certificate clientCertificate;
+  private final SSLSession sslSession;
 
   public DefaultRequest(
     Instant timestamp,
@@ -84,7 +84,7 @@ public class DefaultRequest implements Request {
     ServerConfig serverConfig,
     @Nullable RequestBodyReader bodyReader,
     RequestIdleTimeout idleTimeout,
-    @SuppressWarnings("deprecation") @Nullable javax.security.cert.X509Certificate clientCertificate
+    @Nullable SSLSession sslSession
   ) {
     this.headers = headers;
     this.bodyReader = bodyReader;
@@ -96,7 +96,7 @@ public class DefaultRequest implements Request {
     this.timestamp = timestamp;
     this.maxContentLength = serverConfig.getMaxContentLength();
     this.idleTimeout = idleTimeout;
-    this.clientCertificate = clientCertificate;
+    this.sslSession = sslSession;
     if (bodyReader != null) {
       bodyReader.setMaxContentLength(serverConfig.getMaxContentLength());
     }
@@ -141,9 +141,8 @@ public class DefaultRequest implements Request {
   }
 
   @Override
-  @SuppressWarnings("deprecation")
-  public Optional<javax.security.cert.X509Certificate> getClientCertificate() {
-    return Optional.ofNullable(clientCertificate);
+  public Optional<SSLSession> getSslSession() {
+    return Optional.ofNullable(sslSession);
   }
 
   public String getRawUri() {

--- a/ratpack-core/src/test/groovy/ratpack/core/ssl/HttpsSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/core/ssl/HttpsSpec.groovy
@@ -32,6 +32,7 @@ import sun.security.provider.certpath.SunCertPathBuilderException
 
 import javax.net.ssl.SNIHostName
 import java.security.cert.CertificateException
+import java.security.cert.X509Certificate
 
 class HttpsSpec extends RatpackGroovyDslSpec {
 
@@ -135,7 +136,8 @@ class HttpsSpec extends RatpackGroovyDslSpec {
     when:
     handlers {
       get {
-        render request.clientCertificate.get().subjectDN.name
+        X509Certificate cert = request.sslSession.get().peerCertificates[0]
+        render cert.subjectDN.name
       }
     }
 
@@ -188,7 +190,7 @@ class HttpsSpec extends RatpackGroovyDslSpec {
     logs.removeAppender(testAppender)
     logs.setAdditive(false)
   }
-  
+
   def "can serve multiple certificates using sni"() {
     given:
     def ratpackCert = new SelfSignedCertificate("*.ratpack.io")


### PR DESCRIPTION
This allows us to drop the use of the deprecated javax.security.cert
package and provides the server with access to all available SSL session
information.

Breaking Change for 2.0

Closes #1599

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1635)
<!-- Reviewable:end -->
