### PR TITLE
Fix race condition in exec streaming

### DIFF
--- a/ratpack-exec/src/main/java/ratpack/exec/internal/ContinuationStream.java
+++ b/ratpack-exec/src/main/java/ratpack/exec/internal/ContinuationStream.java
@@ -20,8 +20,8 @@ import ratpack.func.Block;
 
 public interface ContinuationStream {
 
-  boolean complete(Block rest);
+  void complete(Block rest);
 
-  boolean event(Block event);
+  void event(Block event);
 
 }

--- a/ratpack-exec/src/main/java/ratpack/exec/internal/DefaultExecution.java
+++ b/ratpack-exec/src/main/java/ratpack/exec/internal/DefaultExecution.java
@@ -38,9 +38,10 @@ import ratpack.registry.internal.DefaultMutableRegistry;
 import ratpack.stream.TransformablePublisher;
 
 import java.util.*;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 
+@SuppressWarnings("UnstableApiUsage")
 public class DefaultExecution implements Execution {
 
   public final static Logger LOGGER = LoggerFactory.getLogger(Execution.class);
@@ -370,6 +371,46 @@ public class DefaultExecution implements Execution {
 
   }
 
+  private class NonUserCodeExecStream extends ExecStream {
+
+    protected final ExecStream parent;
+
+    NonUserCodeExecStream(ExecStream parent) {
+      this.parent = parent;
+    }
+
+    @Override
+    boolean exec() throws Exception {
+      execStream = parent;
+      return true;
+    }
+
+    @Override
+    void delimit(Action<? super Throwable> onError, Action<? super Continuation> segment) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    void delimitStream(Action<? super Throwable> onError, Action<? super ContinuationStream> segment) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    void enqueue(Block segment) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    void error(Throwable throwable) {
+      parent.error(throwable);
+    }
+
+    @Override
+    ExecStream asParent() {
+      return this;
+    }
+  }
+
   private static class TerminalExecStream extends ExecStream {
 
     private static final ExecStream INSTANCE = new TerminalExecStream();
@@ -595,75 +636,51 @@ public class DefaultExecution implements Execution {
     }
   }
 
-  private class MultiEventExecStream extends BaseExecStream implements ContinuationStream {
-    final ExecStream parent;
-    private final Action<? super Throwable> onError;
-    final Queue<Queue<Block>> events = PlatformDependent.newMpscQueue();
-    private final AtomicReference<Block> complete = new AtomicReference<>();
+  private class MultiEventExecStream extends NonUserCodeExecStream {
+    final Queue<ExecStream> events = PlatformDependent.newMpscQueue();
+    final AtomicBoolean complete = new AtomicBoolean();
+
+    final ExecStream nextEvent = new NonUserCodeExecStream(this);
+    final ExecStream completeEvent = new NonUserCodeExecStream(parent);
 
     MultiEventExecStream(ExecStream parent, Action<? super Throwable> onError, Action<? super ContinuationStream> initial) {
-      this.parent = parent;
-      this.onError = onError;
-      event(() -> initial.execute(this));
-    }
+      super(parent);
+      events.add(new SingleEventExecStream(nextEvent, onError, continuation -> continuation.resume(() ->
+        initial.execute(new ContinuationStream() {
+          public boolean event(Block action) {
+            if (complete.get()) {
+              return false;
+            } else {
+              events.add(new SingleEventExecStream(nextEvent, onError, continuation -> continuation.resume(action)));
+              drain();
+              return true;
+            }
+          }
 
-    public boolean event(Block action) {
-      if (complete.get() == null) {
-        Queue<Block> event = new ArrayDeque<>();
-        event.add(action);
-        events.add(event);
-        drain();
-        return true;
-      } else {
-        return false;
-      }
-    }
-
-    public boolean complete(Block action) {
-      if (complete.compareAndSet(null, action)) {
-        drain();
-        return true;
-      } else {
-        return false;
-      }
+          public boolean complete(Block action) {
+            if (complete.compareAndSet(false, true)) {
+              events.add(new SingleEventExecStream(completeEvent, onError, continuation -> continuation.resume(action)));
+              drain();
+              return true;
+            } else {
+              return false;
+            }
+          }
+        })
+      )));
     }
 
     @Override
     boolean exec() throws Exception {
-      Block nextSegment = events.peek().poll();
-      if (nextSegment == null) {
-        if (events.size() == 1) {
-          if (complete.get() == null) {
-            return false;
-          } else {
-            execStream = parent;
-            complete.get().execute();
-            return true;
-          }
-        } else {
-          events.poll();
-          return true;
-        }
+      ExecStream next = events.poll();
+      if (next == null) {
+        return false;
       } else {
-        nextSegment.execute();
+        execStream = next;
         return true;
       }
     }
 
-    @Override
-    void enqueue(Block segment) {
-      events.peek().add(segment);
-    }
-
-    @Override
-    void error(Throwable throwable) {
-      execStream = parent;
-      try {
-        onError.execute(throwable);
-      } catch (Exception e) {
-        execStream.error(e);
-      }
-    }
   }
 
   private static final class Ref implements ExecutionRef {

--- a/ratpack-exec/src/test/groovy/ratpack/exec/StreamExecutionSpec.groovy
+++ b/ratpack-exec/src/test/groovy/ratpack/exec/StreamExecutionSpec.groovy
@@ -336,26 +336,25 @@ class StreamExecutionSpec extends RatpackGroovyDslSpec {
   }
 
   def "stream reliably completes when producer and consumer race"() {
-    when:
-    def n = 3
-    def l = harness.yield {
-      Streams.bindExec { subscriber ->
-        harness.fork().start {
-          periodically(
-            harness.controller.eventLoopGroup.next(),
-            Duration.ofNanos(2),
-            { i -> i < n ? i : null }
-          )
-            .subscribe(subscriber)
-        }
-      }.toList()
-    }.valueOrThrow
+    expect:
+    def t = 5000
+    def n = 10
 
-    then:
-    l == (0..<n).toList()
-
-    where:
-    i << (1..100)
+    t.times {
+      def l = harness.yield {
+        Streams.bindExec { subscriber ->
+          harness.fork().start {
+            periodically(
+              harness.controller.eventLoopGroup.next(),
+              Duration.ofNanos(2),
+              { i -> i < n ? i : null }
+            )
+              .subscribe(subscriber)
+          }
+        }.toList()
+      }.valueOrThrow
+      assert l == (0..<n).toList()
+    }
   }
 
 }

--- a/ratpack-exec/src/test/groovy/ratpack/exec/StreamExecutionSpec.groovy
+++ b/ratpack-exec/src/test/groovy/ratpack/exec/StreamExecutionSpec.groovy
@@ -27,7 +27,6 @@ import ratpack.stream.internal.CollectingSubscriber
 import ratpack.test.exec.ExecHarness
 import ratpack.test.internal.RatpackGroovyDslSpec
 import spock.lang.AutoCleanup
-import spock.lang.Ignore
 
 import java.time.Duration
 import java.util.concurrent.TimeUnit
@@ -316,7 +315,6 @@ class StreamExecutionSpec extends RatpackGroovyDslSpec {
     max == 1
   }
 
-  @Ignore("LD")
   def "items are serialized even when dispatched on event loop"() {
     when:
     def max = 0

--- a/ratpack-exec/src/test/groovy/ratpack/exec/StreamExecutionSpec.groovy
+++ b/ratpack-exec/src/test/groovy/ratpack/exec/StreamExecutionSpec.groovy
@@ -27,6 +27,7 @@ import ratpack.stream.internal.CollectingSubscriber
 import ratpack.test.exec.ExecHarness
 import ratpack.test.internal.RatpackGroovyDslSpec
 import spock.lang.AutoCleanup
+import spock.lang.Shared
 
 import java.time.Duration
 import java.util.concurrent.TimeUnit
@@ -36,6 +37,7 @@ import static ratpack.stream.Streams.periodically
 class StreamExecutionSpec extends RatpackGroovyDslSpec {
 
   @AutoCleanup
+  @Shared
   def harness = ExecHarness.harness()
 
   def "stream can use promises"() {
@@ -45,13 +47,13 @@ class StreamExecutionSpec extends RatpackGroovyDslSpec {
       get { ctx ->
         def s = Streams.bindExec(periodically(ctx, Duration.ofMillis(100)) { it < 10 ? it : null })
           .flatMap { n ->
-          Promise.async { f ->
-            ctx.get(ExecController).executor.schedule({ f.success(n) } as Runnable, 10, TimeUnit.MILLISECONDS)
+            Promise.async { f ->
+              ctx.get(ExecController).executor.schedule({ f.success(n) } as Runnable, 10, TimeUnit.MILLISECONDS)
+            }
           }
-        }
-        .map {
-          it.toString()
-        }
+          .map {
+            it.toString()
+          }
 
         render(ResponseChunks.stringChunks(s))
       }
@@ -68,16 +70,16 @@ class StreamExecutionSpec extends RatpackGroovyDslSpec {
       get { ctx ->
         def s = Streams.bindExec(periodically(ctx, Duration.ofMillis(100)) { it < 10 ? it : null })
           .flatMap { n ->
-          Promise.async { f ->
-            def c = new CollectingSubscriber({
-              f.success(it.value.get(0))
-            }, { it.request(10) })
+            Promise.async { f ->
+              def c = new CollectingSubscriber({
+                f.success(it.value.get(0))
+              }, { it.request(10) })
 
-            Streams.bindExec(periodically(ctx, Duration.ofMillis(100)) {
-              it < 1 ? n : null
-            }).subscribe(c)
-          }
-        }.map { it.toString() }
+              Streams.bindExec(periodically(ctx, Duration.ofMillis(100)) {
+                it < 1 ? n : null
+              }).subscribe(c)
+            }
+          }.map { it.toString() }
 
         render(ResponseChunks.stringChunks(s))
       }
@@ -332,4 +334,28 @@ class StreamExecutionSpec extends RatpackGroovyDslSpec {
     l == (1..100).toList()
     max == 1
   }
+
+  def "stream reliably completes when producer and consumer race"() {
+    when:
+    def n = 3
+    def l = harness.yield {
+      Streams.bindExec { subscriber ->
+        harness.fork().start {
+          periodically(
+            harness.controller.eventLoopGroup.next(),
+            Duration.ofNanos(2),
+            { i -> i < n ? i : null }
+          )
+            .subscribe(subscriber)
+        }
+      }.toList()
+    }.valueOrThrow
+
+    then:
+    l == (0..<n).toList()
+
+    where:
+    i << (1..100)
+  }
+
 }


### PR DESCRIPTION
If between the execution noticing the exec stream event queue being empty, and another event occurring and the stream completing, the completion signal would be processed before the extra event that had arrived.
    
This change fixes the situation by effectively putting the completion signal on the event queue, ensuring that it is only processed after all events.

This bug was identified by @sorin-florea.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1648)
<!-- Reviewable:end -->
