### PR TITLE
Add SOCKS proxy support

### DIFF
--- a/ratpack-core/src/main/java/ratpack/core/http/client/Proxy.java
+++ b/ratpack-core/src/main/java/ratpack/core/http/client/Proxy.java
@@ -26,6 +26,24 @@ import java.util.Collection;
 public interface Proxy {
 
   /**
+   * List of valid proxy types.
+   */
+  enum Type {
+    /**
+     * HTTP proxy
+     */
+    HTTP,
+    /**
+     * SOCKS4 proxy
+     */
+    SOCKS4,
+    /**
+     * SOCKS5 proxy
+     */
+    SOCKS5
+  }
+
+  /**
    * The host that proxied requests will be sent.
    *
    * @return The host that proxied requests will be sent.
@@ -48,4 +66,10 @@ public interface Proxy {
    * @return A collection of patterns which if any or matched, the outgoing request will bypass the HTTP proxy.
    */
   Collection<String> getNonProxyHosts();
+
+  /**
+   * The type of the proxy where proxied requests will be sent.
+   * @return The type of the proxy where proxied requests will be sent.
+   */
+  Type getType();
 }

--- a/ratpack-core/src/main/java/ratpack/core/http/client/ProxySpec.java
+++ b/ratpack-core/src/main/java/ratpack/core/http/client/ProxySpec.java
@@ -33,7 +33,7 @@ public interface ProxySpec {
   ProxySpec host(String host);
 
   /**
-   * Configure the port on the proxy to will outbound HTTP requests will be sent.
+   * Configure the port on the proxy to which outbound HTTP requests will be sent.
    * @param port the port for the HTTP proxy
    * @return {@code this}
    */
@@ -49,4 +49,12 @@ public interface ProxySpec {
    * @return {@code this}
    */
   ProxySpec nonProxyHosts(Collection<String> nonProxyHosts);
+
+  /**
+   * Configure the type of the proxy that will proxy outbound HTTP requests.
+   *
+   * @param type the type of the proxy
+   * @return {@code this}
+   */
+  ProxySpec type(Proxy.Type type);
 }

--- a/ratpack-core/src/main/java/ratpack/core/http/client/internal/DefaultProxy.java
+++ b/ratpack-core/src/main/java/ratpack/core/http/client/internal/DefaultProxy.java
@@ -27,10 +27,13 @@ public class DefaultProxy implements ProxyInternal {
   private final int port;
   private final Collection<String> nonProxyHosts;
 
-  public DefaultProxy(String host, int port, Collection<String> nonProxyHosts) {
+  private final Type type;
+
+  public DefaultProxy(String host, int port, Collection<String> nonProxyHosts, Type type) {
     this.host = host;
     this.port = port;
     this.nonProxyHosts = nonProxyHosts;
+    this.type = type;
   }
 
   @Override
@@ -46,6 +49,11 @@ public class DefaultProxy implements ProxyInternal {
   @Override
   public Collection<String> getNonProxyHosts() {
     return nonProxyHosts;
+  }
+
+  @Override
+  public Type getType() {
+    return type;
   }
 
   @Override
@@ -101,6 +109,7 @@ public class DefaultProxy implements ProxyInternal {
     private String host;
     private int port;
     private Collection<String> nonProxyHosts = Collections.emptyList();
+    private Type type = Type.HTTP;
 
     @Override
     public ProxySpec host(String host) {
@@ -120,8 +129,14 @@ public class DefaultProxy implements ProxyInternal {
       return this;
     }
 
+    @Override
+    public ProxySpec type(Type type) {
+      this.type = type;
+      return this;
+    }
+
     ProxyInternal build() {
-      return new DefaultProxy(host, port, nonProxyHosts);
+      return new DefaultProxy(host, port, nonProxyHosts, type);
     }
   }
 }

--- a/ratpack-core/src/main/java/ratpack/core/http/client/internal/NoopFixedChannelPoolHandler.java
+++ b/ratpack-core/src/main/java/ratpack/core/http/client/internal/NoopFixedChannelPoolHandler.java
@@ -17,8 +17,11 @@
 package ratpack.core.http.client.internal;
 
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelPipeline;
 import io.netty.channel.pool.AbstractChannelPoolHandler;
 import io.netty.handler.proxy.HttpProxyHandler;
+import io.netty.handler.proxy.Socks4ProxyHandler;
+import io.netty.handler.proxy.Socks5ProxyHandler;
 import io.netty.handler.timeout.IdleStateHandler;
 
 import java.net.InetSocketAddress;
@@ -42,9 +45,21 @@ public class NoopFixedChannelPoolHandler extends AbstractChannelPoolHandler impl
 
   @Override
   public void channelCreated(Channel ch) throws Exception {
-    if  (proxy != null && proxy.shouldProxy(host)) {
-      SocketAddress proxyAddress = new InetSocketAddress(proxy.getHost(), proxy.getPort());
-      ch.pipeline().addLast(new HttpProxyHandler(proxyAddress));
+    if (proxy != null && proxy.shouldProxy(host)) {
+      ChannelPipeline pipeline = ch.pipeline();
+      switch (proxy.getType()) {
+        case SOCKS4:
+          SocketAddress socks4ProxyAddress = InetSocketAddress.createUnresolved(proxy.getHost(), proxy.getPort());
+          pipeline.addLast(new Socks4ProxyHandler(socks4ProxyAddress));
+          break;
+        case SOCKS5:
+          SocketAddress socks5ProxyAddress = InetSocketAddress.createUnresolved(proxy.getHost(), proxy.getPort());
+          pipeline.addLast(new Socks5ProxyHandler(socks5ProxyAddress));
+          break;
+        default:
+          SocketAddress httpProxyAddress = new InetSocketAddress(proxy.getHost(), proxy.getPort());
+          pipeline.addLast(new HttpProxyHandler(httpProxyAddress));
+      }
     }
   }
 


### PR DESCRIPTION
This change adds support for SOCKS4 and SOCKS5 proxies. The use case I have is to test Ratpack services as if they are part of a test environment network. SOCKS proxies offer remote DNS resolution capabilities that allow the service to resolve internal hostnames for the target network/environment. I saw that Netty already has support for SOCKS proxies, but Ratpack was not exposing it.

Example usage:
```
HttpClient.of(spec ->
    spec.proxy(proxySpec ->
        proxySpec.host("localhost").port(7777).type(Proxy.Type.SOCKS5)
    )
);
```

I explored a few other options here as well. Instead of a SOCKS proxy you can just use local port forwarding, but if there are a lot of different upstreams then it can be quite tedious to forward all the ports and reconfigure the app to use the proper ports for each upstream. The JVM also has `socksProxyHost` and `socksProxyPort` flags, but unfortunately there is a [bug in the JVM](https://bugs.openjdk.org/browse/JDK-8028776) that prevents remote DNS from working properly when using those, so this was the next best approach.