### PR TITLE
Allow stream executions to throw in non-contiguous onComplete

### DIFF
--- a/ratpack-exec/src/main/java/ratpack/exec/internal/DefaultExecution.java
+++ b/ratpack-exec/src/main/java/ratpack/exec/internal/DefaultExecution.java
@@ -391,17 +391,17 @@ public class DefaultExecution implements Execution {
 
     @Override
     void delimit(Action<? super Throwable> onError, Action<? super Continuation> segment) {
-      throw new UnsupportedOperationException();
+      parent.delimit(onError, segment);
     }
 
     @Override
     void delimitStream(Action<? super Throwable> onError, Action<? super ContinuationStream> segment) {
-      throw new UnsupportedOperationException();
+      parent.delimitStream(onError, segment);
     }
 
     @Override
     void enqueue(Block segment) {
-      throw new UnsupportedOperationException();
+      parent.enqueue(segment);
     }
 
     @Override

--- a/ratpack-exec/src/test/groovy/ratpack/exec/StreamExecutionSpec.groovy
+++ b/ratpack-exec/src/test/groovy/ratpack/exec/StreamExecutionSpec.groovy
@@ -36,325 +36,378 @@ import static ratpack.stream.Streams.periodically
 
 class StreamExecutionSpec extends RatpackGroovyDslSpec {
 
-  @AutoCleanup
-  @Shared
-  def harness = ExecHarness.harness()
+    @AutoCleanup
+    @Shared
+    def harness = ExecHarness.harness()
 
-  def "stream can use promises"() {
-    when:
-    serverConfig { development(true) }
-    handlers {
-      get { ctx ->
-        def s = Streams.bindExec(periodically(ctx, Duration.ofMillis(100)) { it < 10 ? it : null })
-          .flatMap { n ->
-            Promise.async { f ->
-              ctx.get(ExecController).executor.schedule({ f.success(n) } as Runnable, 10, TimeUnit.MILLISECONDS)
+    def "stream can use promises"() {
+        when:
+        serverConfig { development(true) }
+        handlers {
+            get { ctx ->
+                def s = Streams.bindExec(periodically(ctx, Duration.ofMillis(100)) { it < 10 ? it : null })
+                        .flatMap { n ->
+                            Promise.async { f ->
+                                ctx.get(ExecController).executor.schedule({ f.success(n) } as Runnable, 10, TimeUnit.MILLISECONDS)
+                            }
+                        }
+                        .map {
+                            it.toString()
+                        }
+
+                render(ResponseChunks.stringChunks(s))
             }
-          }
-          .map {
-            it.toString()
-          }
+        }
 
-        render(ResponseChunks.stringChunks(s))
-      }
+        then:
+        text == "0123456789"
     }
 
-    then:
-    text == "0123456789"
-  }
+    def "stream can consume stream during event promises"() {
+        when:
+        serverConfig { development(true) }
+        handlers {
+            get { ctx ->
+                def s = Streams.bindExec(periodically(ctx, Duration.ofMillis(100)) { it < 10 ? it : null })
+                        .flatMap { n ->
+                            Promise.async { f ->
+                                def c = new CollectingSubscriber({
+                                    f.success(it.value.get(0))
+                                }, { it.request(10) })
 
-  def "stream can consume stream during event promises"() {
-    when:
-    serverConfig { development(true) }
-    handlers {
-      get { ctx ->
-        def s = Streams.bindExec(periodically(ctx, Duration.ofMillis(100)) { it < 10 ? it : null })
-          .flatMap { n ->
-            Promise.async { f ->
-              def c = new CollectingSubscriber({
-                f.success(it.value.get(0))
-              }, { it.request(10) })
+                                Streams.bindExec(periodically(ctx, Duration.ofMillis(100)) {
+                                    it < 1 ? n : null
+                                }).subscribe(c)
+                            }
+                        }.map { it.toString() }
 
-              Streams.bindExec(periodically(ctx, Duration.ofMillis(100)) {
-                it < 1 ? n : null
-              }).subscribe(c)
+                render(ResponseChunks.stringChunks(s))
             }
-          }.map { it.toString() }
+        }
 
-        render(ResponseChunks.stringChunks(s))
-      }
+        then:
+        text == "0123456789"
     }
 
-    then:
-    text == "0123456789"
-  }
+    def "requests for more items can be issued off execution"() {
+        when:
+        def p = Streams.flatYield { r -> r.requestNum < 3 ? Promise.value(1) : Promise.value(null) }.bindExec()
+        def e = []
 
-  def "requests for more items can be issued off execution"() {
-    when:
-    def p = Streams.flatYield { r -> r.requestNum < 3 ? Promise.value(1) : Promise.value(null) }.bindExec()
-    def e = []
+        harness.yield {
+            Promise.async { down ->
+                p.subscribe(new Subscriber() {
+                    Subscription subscription
 
-    harness.yield {
-      Promise.async { down ->
-        p.subscribe(new Subscriber() {
-          Subscription subscription
+                    private void request() {
+                        Thread.start {
+                            sleep 100
+                            subscription.request(1)
+                        }
+                    }
 
-          private void request() {
+                    @Override
+                    void onSubscribe(Subscription s) {
+                        subscription = s
+                        request()
+                    }
+
+                    @Override
+                    void onNext(Object o) {
+                        e << o
+                        request()
+                    }
+
+                    @Override
+                    void onError(Throwable t) {
+                        down.error(t)
+                    }
+
+                    @Override
+                    void onComplete() {
+                        down.success(e)
+                    }
+                })
+            }
+        }
+
+        then:
+        e == [1, 1, 1]
+    }
+
+    def "cancel can be issued off thread"() {
+        when:
+        def p = Streams.flatYield { r -> r.requestNum < 3 ? Promise.value(1) : Promise.value(null) }.bindExec()
+        def e = []
+
+        harness.yield {
+            Promise.async { down ->
+                p.subscribe(new Subscriber() {
+                    Subscription subscription
+
+                    private void request() {
+                        Thread.start {
+                            sleep 100
+                            subscription.request(1)
+                        }
+                    }
+
+                    private void cancel() {
+                        Thread.start {
+                            sleep 100
+                            subscription.cancel()
+                            down.complete()
+                        }
+                    }
+
+                    @Override
+                    void onSubscribe(Subscription s) {
+                        subscription = s
+                        request()
+                    }
+
+                    @Override
+                    void onNext(Object o) {
+                        e << o
+                        cancel()
+                    }
+
+                    @Override
+                    void onError(Throwable t) {
+                        down.error(t)
+                    }
+
+                    @Override
+                    void onComplete() {
+                        down.success(e)
+                    }
+                })
+            }
+        }
+
+        then:
+        e == [1]
+    }
+
+    def "exec bound publisher will stop publishing on sync cancel"() {
+        when:
+        def p = Streams.constant(1).bindExec()
+
+        then:
+        def v = harness.yield {
+            Promise.async { down ->
+                p.subscribe(new Subscriber<Integer>() {
+                    Subscription subscription
+
+                    @Override
+                    void onSubscribe(Subscription s) {
+                        subscription = s
+                        s.request(Long.MAX_VALUE)
+                    }
+
+                    def i = 0
+
+                    @Override
+                    void onNext(Integer integer) {
+                        if (++i == 100) {
+                            subscription.cancel()
+                            down.success(true)
+                        }
+                    }
+
+                    @Override
+                    void onError(Throwable t) {
+                        down.error(t)
+                    }
+
+                    @Override
+                    void onComplete() {
+                        down.complete()
+                    }
+                })
+            }
+        }.valueOrThrow
+
+        then:
+        v == true
+    }
+
+    def "exec bound publisher will stop publishing on async cancel"() {
+        when:
+        def p = Streams.constant(1).bindExec()
+
+        then:
+        def v = harness.yield {
+            Promise.async { down ->
+                p.subscribe(new Subscriber<Integer>() {
+                    Subscription subscription
+
+                    @Override
+                    void onSubscribe(Subscription s) {
+                        subscription = s
+                        s.request(Long.MAX_VALUE)
+                    }
+
+                    def i = 0
+
+                    @Override
+                    void onNext(Integer integer) {
+                        if (++i == 100) {
+                            Thread.start {
+                                subscription.cancel()
+                                down.success(true)
+                            }
+                        }
+                    }
+
+                    @Override
+                    void onError(Throwable t) {
+                        down.error(t)
+                    }
+
+                    @Override
+                    void onComplete() {
+                        down.complete()
+                    }
+                })
+            }
+        }.valueOrThrow
+
+        then:
+        v == true
+    }
+
+    def "items are serialized"() {
+        when:
+        def p = new BufferingPublisher(Action.noop(), { write ->
             Thread.start {
-              sleep 100
-              subscription.request(1)
+                100.times {
+                    sleep(3)
+                    write.item(it)
+                }
+                write.complete()
             }
-          }
 
-          @Override
-          void onSubscribe(Subscription s) {
-            subscription = s
-            request()
-          }
+            new Subscription() {
+                @Override
+                void request(long n) {
 
-          @Override
-          void onNext(Object o) {
-            e << o
-            request()
-          }
+                }
 
-          @Override
-          void onError(Throwable t) {
-            down.error(t)
-          }
+                @Override
+                void cancel() {
 
-          @Override
-          void onComplete() {
-            down.success(e)
-          }
-        })
-      }
+                }
+            }
+        } as Function)
+
+        def max = 0
+        def i = 0
+        def l = harness.yield {
+            p.bindExec().flatMap {
+                max = Math.max(max, ++i)
+                Promise.value(it).wiretap {
+                    --i
+                }.defer(Duration.ofMillis(5))
+            }.toList()
+        }.valueOrThrow
+
+        then:
+        l == (0..99).toList()
+        max == 1
     }
 
-    then:
-    e == [1, 1, 1]
-  }
+    def "items are serialized even when dispatched on event loop"() {
+        when:
+        def max = 0
+        def i = 0
+        def l = harness.yield {
+            Streams.publish(1..100).bindExec().flatMap {
+                max = Math.max(max, ++i)
+                Promise.value(it).wiretap {
+                    --i
+                }
+            }.toList()
+        }.valueOrThrow
 
-  def "cancel can be issued off thread"() {
-    when:
-    def p = Streams.flatYield { r -> r.requestNum < 3 ? Promise.value(1) : Promise.value(null) }.bindExec()
-    def e = []
-
-    harness.yield {
-      Promise.async { down ->
-        p.subscribe(new Subscriber() {
-          Subscription subscription
-
-          private void request() {
-            Thread.start {
-              sleep 100
-              subscription.request(1)
-            }
-          }
-
-          private void cancel() {
-            Thread.start {
-              sleep 100
-              subscription.cancel()
-              down.complete()
-            }
-          }
-
-          @Override
-          void onSubscribe(Subscription s) {
-            subscription = s
-            request()
-          }
-
-          @Override
-          void onNext(Object o) {
-            e << o
-            cancel()
-          }
-
-          @Override
-          void onError(Throwable t) {
-            down.error(t)
-          }
-
-          @Override
-          void onComplete() {
-            down.success(e)
-          }
-        })
-      }
+        then:
+        l == (1..100).toList()
+        max == 1
     }
 
-    then:
-    e == [1]
-  }
+    def "stream reliably completes when producer and consumer race"() {
+        expect:
+        def t = 5000
+        def n = 10
 
-  def "exec bound publisher will stop publishing on sync cancel"() {
-    when:
-    def p = Streams.constant(1).bindExec()
-
-    then:
-    def v = harness.yield {
-      Promise.async { down ->
-        p.subscribe(new Subscriber<Integer>() {
-          Subscription subscription
-
-          @Override
-          void onSubscribe(Subscription s) {
-            subscription = s
-            s.request(Long.MAX_VALUE)
-          }
-
-          def i = 0
-
-          @Override
-          void onNext(Integer integer) {
-            if (++i == 100) {
-              subscription.cancel()
-              down.success(true)
-            }
-          }
-
-          @Override
-          void onError(Throwable t) {
-            down.error(t)
-          }
-
-          @Override
-          void onComplete() {
-            down.complete()
-          }
-        })
-      }
-    }.valueOrThrow
-
-    then:
-    v == true
-  }
-
-  def "exec bound publisher will stop publishing on async cancel"() {
-    when:
-    def p = Streams.constant(1).bindExec()
-
-    then:
-    def v = harness.yield {
-      Promise.async { down ->
-        p.subscribe(new Subscriber<Integer>() {
-          Subscription subscription
-
-          @Override
-          void onSubscribe(Subscription s) {
-            subscription = s
-            s.request(Long.MAX_VALUE)
-          }
-
-          def i = 0
-
-          @Override
-          void onNext(Integer integer) {
-            if (++i == 100) {
-              Thread.start {
-                subscription.cancel()
-                down.success(true)
-              }
-            }
-          }
-
-          @Override
-          void onError(Throwable t) {
-            down.error(t)
-          }
-
-          @Override
-          void onComplete() {
-            down.complete()
-          }
-        })
-      }
-    }.valueOrThrow
-
-    then:
-    v == true
-  }
-
-  def "items are serialized"() {
-    when:
-    def p = new BufferingPublisher(Action.noop(), { write ->
-      Thread.start {
-        100.times {
-          sleep(3)
-          write.item(it)
+        t.times {
+            def l = harness.yield {
+                Streams.bindExec { subscriber ->
+                    harness.fork().start {
+                        periodically(
+                                harness.controller.eventLoopGroup.next(),
+                                Duration.ofNanos(2),
+                                { i -> i < n ? i : null }
+                        )
+                                .subscribe(subscriber)
+                    }
+                }.toList()
+            }.valueOrThrow
+            assert l == (0..<n).toList()
         }
-        write.complete()
-      }
-
-      new Subscription() {
-        @Override
-        void request(long n) {
-
-        }
-
-        @Override
-        void cancel() {
-
-        }
-      }
-    } as Function)
-
-    def max = 0
-    def i = 0
-    def l = harness.yield {
-      p.bindExec().flatMap {
-        max = Math.max(max, ++i)
-        Promise.value(it).wiretap {
-          --i
-        }.defer(Duration.ofMillis(5))
-      }.toList()
-    }.valueOrThrow
-
-    then:
-    l == (0..99).toList()
-    max == 1
-  }
-
-  def "items are serialized even when dispatched on event loop"() {
-    when:
-    def max = 0
-    def i = 0
-    def l = harness.yield {
-      Streams.publish(1..100).bindExec().flatMap {
-        max = Math.max(max, ++i)
-        Promise.value(it).wiretap {
-          --i
-        }
-      }.toList()
-    }.valueOrThrow
-
-    then:
-    l == (1..100).toList()
-    max == 1
-  }
-
-  def "stream reliably completes when producer and consumer race"() {
-    expect:
-    def t = 5000
-    def n = 10
-
-    t.times {
-      def l = harness.yield {
-        Streams.bindExec { subscriber ->
-          harness.fork().start {
-            periodically(
-              harness.controller.eventLoopGroup.next(),
-              Duration.ofNanos(2),
-              { i -> i < n ? i : null }
-            )
-              .subscribe(subscriber)
-          }
-        }.toList()
-      }.valueOrThrow
-      assert l == (0..<n).toList()
     }
-  }
+
+    def "stream can throw on on complete after non-contiguous segment"() {
+        given:
+        def n = 10
+        def l = [].asSynchronized()
+
+        when:
+        harness.execute(Operation.of {
+            Streams.bindExec { subscriber ->
+                harness.fork().start {
+                    periodically(
+                            harness.controller.eventLoopGroup.next(),
+                            Duration.ofNanos(2),
+                            { i -> i < n ? i : null }
+                    )
+                            .subscribe(subscriber)
+                }
+            }.subscribe(new Subscriber<Integer>() {
+                @Override
+                void onSubscribe(Subscription s) {
+                    s.request(Long.MAX_VALUE)
+                }
+
+                @Override
+                void onNext(Integer o) {
+                    l << o
+                }
+
+                @Override
+                void onError(Throwable error) {
+                    throw error
+                }
+
+                @Override
+                void onComplete() {
+                    Promise.async { down ->
+                        Thread.start {
+                            sleep 300
+                            down.success(true)
+                        }
+                    }.next {
+                        throw new IllegalStateException("in on complete")
+                    }.then {}
+                }
+            })
+        })
+
+        then:
+        l == (0..<n).toList()
+
+        and:
+        thrown IllegalStateException
+    }
 
 }


### PR DESCRIPTION
Hat tip to @faqa for reporting the problem privately.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1681)
<!-- Reviewable:end -->
