### PR TITLE
Use the correct cleanup method for ServerSentEvent

### DIFF
--- a/ratpack-core/src/main/java/ratpack/sse/internal/ServerSentEventDecodingPublisher.java
+++ b/ratpack-core/src/main/java/ratpack/sse/internal/ServerSentEventDecodingPublisher.java
@@ -18,7 +18,6 @@ package ratpack.sse.internal;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.util.ReferenceCountUtil;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
@@ -28,7 +27,7 @@ import ratpack.stream.internal.BufferingPublisher;
 public class ServerSentEventDecodingPublisher extends BufferingPublisher<ServerSentEvent> {
 
   public ServerSentEventDecodingPublisher(Publisher<? extends ByteBuf> publisher, ByteBufAllocator allocator) {
-    super(ReferenceCountUtil::safeRelease, write -> {
+    super(ServerSentEvent::close, write -> {
       return new Subscription() {
 
         Subscription upstream;


### PR DESCRIPTION
`ServerSentEvent` was changed to implement `AutoClosable` instead of `ReferenceCounted`.  However, we still tried to use `ReferenceCountUtil::safeRelease` with it.  This compiled successfully, but always did nothing, resulting in buffered events leaking.

Not 100% sure on the correct base branch.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1692)
<!-- Reviewable:end -->
