### PR TITLE
Upgrade dropwizard metrics to 4.2.21

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -20,7 +20,7 @@ ext {
     commonsCodec     : "1.14",
     commonsLang3     : "3.12.0",
     commonsLogging   : "1.2",
-    dropwizardMetrics: "4.2.9",
+    dropwizardMetrics: "4.2.21",
     groovy           : "3.0.9", // Gradle 7.4 uses Groovy 3.0.9
     guava            : "31.1-jre",
     guice            : "5.1.0",


### PR DESCRIPTION
... to eventually bring `com.rabbitmq:amqp-client:5.19.0` that contains CVE-2023-46120 fix.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1699)
<!-- Reviewable:end -->
