### PR TITLE
Fix deprecations reported on Gradle 8.5

### DIFF
--- a/ratpack-gradle/src/main/java/ratpack/gradle/RatpackGroovyPlugin.java
+++ b/ratpack-gradle/src/main/java/ratpack/gradle/RatpackGroovyPlugin.java
@@ -39,7 +39,7 @@ public class RatpackGroovyPlugin implements Plugin<Project> {
     if (gradleVersion.compareTo(V6_0) < 0) {
       project.setProperty("mainClassName", MAIN_CLASS_NAME);
     } else {
-      project.getExtensions().getByType(JavaApplication.class).setMainClassName(MAIN_CLASS_NAME);
+      project.getExtensions().getByType(JavaApplication.class).getMainClass().set(MAIN_CLASS_NAME);
     }
 
     RatpackExtension ratpackExtension = project.getExtensions().getByType(RatpackExtension.class);

--- a/ratpack-gradle/src/main/java/ratpack/gradle/RatpackGroovyPlugin.java
+++ b/ratpack-gradle/src/main/java/ratpack/gradle/RatpackGroovyPlugin.java
@@ -28,6 +28,7 @@ import java.util.Optional;
 public class RatpackGroovyPlugin implements Plugin<Project> {
 
   private static final GradleVersion V6_0 = GradleVersion.version("6.0");
+  private static final GradleVersion V8_0 = GradleVersion.version("8.0");
   private static final String MAIN_CLASS_NAME = "ratpack.groovy.GroovyRatpackMain";
 
   @Override
@@ -38,6 +39,8 @@ public class RatpackGroovyPlugin implements Plugin<Project> {
     GradleVersion gradleVersion = GradleVersion.version(project.getGradle().getGradleVersion());
     if (gradleVersion.compareTo(V6_0) < 0) {
       project.setProperty("mainClassName", MAIN_CLASS_NAME);
+    } else if (gradleVersion.compareTo(V8_0) < 0) {
+      project.getExtensions().getByType(JavaApplication.class).setMainClassName(MAIN_CLASS_NAME);
     } else {
       project.getExtensions().getByType(JavaApplication.class).getMainClass().set(MAIN_CLASS_NAME);
     }

--- a/ratpack-gradle/src/main/java/ratpack/gradle/internal/RatpackContinuousRunAction.java
+++ b/ratpack-gradle/src/main/java/ratpack/gradle/internal/RatpackContinuousRunAction.java
@@ -222,7 +222,7 @@ public class RatpackContinuousRunAction implements Action<Task> {
     List<String> args = task.getArgs();
     return new RatpackSpec(nonChanging.toArray(new URL[0]),
       changing.toArray(new URL[0]),
-      task.getMain(),
+      task.getMainClass().get(),
       args.toArray(new String[0])
     );
   }

--- a/ratpack-gradle/src/main/java/ratpack/gradle/internal/RatpackContinuousRunAction.java
+++ b/ratpack-gradle/src/main/java/ratpack/gradle/internal/RatpackContinuousRunAction.java
@@ -23,7 +23,7 @@ import org.gradle.deployment.internal.DeploymentRegistry;
 import org.gradle.internal.Factory;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.process.internal.JavaExecHandleBuilder;
-import org.gradle.util.VersionNumber;
+import ratpack.gradle.GradleVersion;
 import ratpack.gradle.continuous.RatpackDeploymentHandle;
 import ratpack.gradle.continuous.run.*;
 
@@ -37,12 +37,12 @@ import java.util.Set;
 import java.util.function.Supplier;
 
 public class RatpackContinuousRunAction implements Action<Task> {
-  private static final VersionNumber V2_13 = VersionNumber.parse("2.13");
-  private static final VersionNumber V2_14 = VersionNumber.parse("2.14");
-  private static final VersionNumber V4_2 = VersionNumber.parse("4.2");
+  private static final GradleVersion V2_13 = GradleVersion.version("2.13");
+  private static final GradleVersion V2_14 = GradleVersion.version("2.14");
+  private static final GradleVersion V4_2 = GradleVersion.version("4.2");
   private static final String FLATTEN_CLASSLOADERS = "ratpack.flattenClassloaders";
 
-  private final VersionNumber gradleVersion;
+  private final GradleVersion gradleVersion;
   private final String absoluteRootDirPath;
   private final Supplier<ServiceRegistry> serviceRegistrySupplier;
 
@@ -52,8 +52,7 @@ public class RatpackContinuousRunAction implements Action<Task> {
     Supplier<ServiceRegistry> serviceRegistrySupplier
   ) {
     this.serviceRegistrySupplier = serviceRegistrySupplier;
-    VersionNumber realVersionNumber = VersionNumber.parse(gradleVersion);
-    this.gradleVersion = new VersionNumber(realVersionNumber.getMajor(), realVersionNumber.getMinor(), realVersionNumber.getMicro(), null);
+    this.gradleVersion = GradleVersion.version(gradleVersion);
     this.absoluteRootDirPath = absoluteRootDirPath;
   }
 

--- a/ratpack-gradle/src/main/java/ratpack/gradle/internal/RatpackContinuousRunAction.java
+++ b/ratpack-gradle/src/main/java/ratpack/gradle/internal/RatpackContinuousRunAction.java
@@ -40,6 +40,7 @@ public class RatpackContinuousRunAction implements Action<Task> {
   private static final GradleVersion V2_13 = GradleVersion.version("2.13");
   private static final GradleVersion V2_14 = GradleVersion.version("2.14");
   private static final GradleVersion V4_2 = GradleVersion.version("4.2");
+  private static final GradleVersion V8_0 = GradleVersion.version("8.0");
   private static final String FLATTEN_CLASSLOADERS = "ratpack.flattenClassloaders";
 
   private final GradleVersion gradleVersion;
@@ -222,7 +223,7 @@ public class RatpackContinuousRunAction implements Action<Task> {
     List<String> args = task.getArgs();
     return new RatpackSpec(nonChanging.toArray(new URL[0]),
       changing.toArray(new URL[0]),
-      task.getMainClass().get(),
+      getMainClass(task),
       args.toArray(new String[0])
     );
   }
@@ -235,6 +236,13 @@ public class RatpackContinuousRunAction implements Action<Task> {
     }
   }
 
+  private String getMainClass(JavaExec task) {
+    if (gradleVersion.compareTo(V8_0) < 0) {
+      return task.getMain();
+    } else {
+      return task.getMainClass().get();
+    }
+  }
 
   final private static class ProxyBacking implements InvocationHandler {
     public ProxyBacking(RatpackAdapter delegate) {

--- a/ratpack-gradle/src/test/groovy/ratpack/gradle/functional/DeprecationsSpec.groovy
+++ b/ratpack-gradle/src/test/groovy/ratpack/gradle/functional/DeprecationsSpec.groovy
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ratpack.gradle.functional
+
+class DeprecationsSpec extends FunctionalSpec {
+
+  def "plugin does not produce deprecations"() {
+    given:
+    buildFile.delete()
+    buildFile.text == """
+      apply plugin: 'io.ratpack.ratpack-groovy'
+    """
+
+    expect:
+    runner("help", "--warning-mode", "fail")
+      .withGradleVersion("8.5")
+      .build()
+  }
+}


### PR DESCRIPTION
Summary of the changes:

- Use GradleVersion instead of VersionNumber (same as on master branch)
- Use `getMainClass()` on `JavaApplication` extension
- Call `getSourceSets()` via reflection on `JavaPluginExtension` when running on a Gradle version that supports it.
- Add a test verifying configuring the plugin on Gradle 8.5 does not yield deprecation warning.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1704)
<!-- Reviewable:end -->
