### PR TITLE
Migrated to using accessKey authentication for remote cache

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -71,17 +71,14 @@ def setBuildFile(project) {
 
 setBuildFile(rootProject)
 
+
+
 buildCache {
-  remote(HttpBuildCache) {
-    url = 'https://ge.ratpack.io/cache/'
-    def cacheUsername = System.getenv('GRADLE_ENTERPRISE_CACHE_USERNAME')
-    def cachePassword = System.getenv('GRADLE_ENTERPRISE_CACHE_PASSWORD')
-    if (cacheUsername && cachePassword) {
-      push = true
-      credentials {
-        username = cacheUsername
-        password = cachePassword
-      }
-    }
+  remote(gradleEnterprise.buildCache) {
+    enabled = true
+    def ci = System.getenv("CI")
+    // Also check access key to avoid warning logs
+    def accessKey = System.getenv("GRADLE_ENTERPRISE_ACCESS_KEY")
+    push = ci && accessKey != null && !accessKey.isEmpty()
   }
 }


### PR DESCRIPTION
Migrated gradle remote cache to the gradleEnterprise connector and with that to access key authentication.

In the near future OSS project will be switched to new high-availability remote cache nodes, which will need accessKey-based authentication. Your setup is already connected to the server via accessKey for scan publishing, however it was still using username and password authentication. Given that you're already publishing scans via accessKey auth, the only thing left (other than merging this PR) would be to verify that the user that the accessKey belongs to has the `ci-agent` role (or any other role) that has the read and write to remote build cache permission.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ratpack/ratpack/1705)
<!-- Reviewable:end -->
