### PR TITLE
Migrated from gradleEnterprise to Develocity

### DIFF
--- a/gradle/buildScan.gradle
+++ b/gradle/buildScan.gradle
@@ -17,12 +17,11 @@ def env = System.getenv()
 def publishToSlack = gradle.startParameter.projectProperties.publishToSlack != null
 def ci = System.getenv("CI")
 
-gradleEnterprise.buildScan {
-    server = "https://ge.ratpack.io"
-    captureTaskInputFiles = true
+develocity {
+  server = "https://ge.ratpack.io"
+  buildScan {
     uploadInBackground = !ci
-    publishAlways()
-    publishIfAuthenticated()
+    publishing.onlyIf { it.authenticated }
 
     if (env.CIRCLE_BUILD_URL) {
       def buildLink = env.CIRCLE_BUILD_URL
@@ -33,7 +32,7 @@ gradleEnterprise.buildScan {
         buildFinished { buildResult ->
 
           buildScanPublished {
-            def json="{'attachments': [{'fallback': '${buildTitle}', 'color': '${buildResult.failure != null ? 'danger' : 'good'}', 'title': '${buildTitle}', 'title_link': '${buildLink}', 'text': 'Build scan: ${it.buildScanUri}'}]}"
+            def json = "{'attachments': [{'fallback': '${buildTitle}', 'color': '${buildResult.failure != null ? 'danger' : 'good'}', 'title': '${buildTitle}', 'title_link': '${buildLink}', 'text': 'Build scan: ${it.buildScanUri}'}]}"
             ['curl', '-s', '-d', "payload=$json", "https://hooks.slack.com/services/${env.SLACK_TOKEN}"].execute()
           }
 
@@ -67,3 +66,5 @@ gradleEnterprise.buildScan {
       }
     }
   }
+}
+

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 plugins {
-  id "com.gradle.enterprise" version "3.16.2"
-  id "com.gradle.common-custom-user-data-gradle-plugin" version "1.12.1"
+  id 'com.gradle.develocity' version '3.17'
+  id 'com.gradle.common-custom-user-data-gradle-plugin' version '2.0'
 }
 
 enableFeaturePreview("GROOVY_COMPILATION_AVOIDANCE")
@@ -74,7 +74,7 @@ setBuildFile(rootProject)
 
 
 buildCache {
-  remote(gradleEnterprise.buildCache) {
+  remote(develocity.buildCache) {
     enabled = true
     def ci = System.getenv("CI")
     // Also check access key to avoid warning logs

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 plugins {
-  id 'com.gradle.develocity' version '3.17'
-  id 'com.gradle.common-custom-user-data-gradle-plugin' version '2.0'
+  id 'com.gradle.develocity' version '3.17.5'
+  id 'com.gradle.common-custom-user-data-gradle-plugin' version '2.0.1'
 }
 
 enableFeaturePreview("GROOVY_COMPILATION_AVOIDANCE")


### PR DESCRIPTION
Migrated from gradleEnterprise 3.16.2 to Develocity plugin 3.17 and updated Common Custom User Data Gradle plugin to 2.0. Starting with version 3.17, the plugin is available under the “Develocity” brand. Some configuration APIs have been renamed or depracated, functionally, there should be no changes.