### PR TITLE
Improve `@NonBlocking` usage

### DIFF
--- a/ratpack-exec/src/main/java/ratpack/exec/Operation.java
+++ b/ratpack-exec/src/main/java/ratpack/exec/Operation.java
@@ -67,6 +67,7 @@ import java.util.Optional;
  * }
  * }</pre>
  */
+@NonBlocking
 public interface Operation {
 
   static Operation of(Block block) {
@@ -173,10 +174,8 @@ public interface Operation {
     ).operation();
   }
 
-  @NonBlocking
   void then(Block block);
 
-  @NonBlocking
   default void then() {
     then(Block.noop());
   }

--- a/ratpack-exec/src/main/java/ratpack/exec/Promise.java
+++ b/ratpack-exec/src/main/java/ratpack/exec/Promise.java
@@ -55,6 +55,7 @@ import static ratpack.func.Action.ignoreArg;
  * @param <T> the type of promised value
  */
 @SuppressWarnings("JavadocReference")
+@NonBlocking
 public interface Promise<T> {
 
   /**

--- a/ratpack-exec/src/main/java/ratpack/exec/api/NonBlocking.java
+++ b/ratpack-exec/src/main/java/ratpack/exec/api/NonBlocking.java
@@ -35,6 +35,6 @@ import java.lang.annotation.*;
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD, ElementType.PARAMETER})
+@Target({ElementType.METHOD, ElementType.PARAMETER, ElementType.TYPE})
 public @interface NonBlocking {
 }


### PR DESCRIPTION
Add `TYPE` as target to bring it in line with
`org.jetbrains.annotations.NonBlocking`.
Annotate `Promise` and `Operation` as `@NonBlocking` to facilitate static checking of calling blocking code in a non-blocking context.

https://www.jetbrains.com/help/inspectopedia/BlockingMethodInNonBlockingContext.html