### PR TITLE
Change redirect encoding mechanism to not decode parameters

### DIFF
--- a/ratpack-core/src/main/java/ratpack/core/http/client/internal/RequestActionSupport.java
+++ b/ratpack-core/src/main/java/ratpack/core/http/client/internal/RequestActionSupport.java
@@ -618,7 +618,7 @@ abstract class RequestActionSupport<T> implements Upstream<T> {
         String rawQuery = redirectLocationUri.getRawQuery() != null
           ? "?" + redirectLocationUri.getRawQuery() : "";
         return new URI(new URI(requestUri.getScheme(),
-          requestUri.getRawUserInfo(),
+          requestUri.getUserInfo(),
           requestUri.getHost(),
           requestUri.getPort(),
           null,

--- a/ratpack-core/src/main/java/ratpack/core/http/client/internal/RequestActionSupport.java
+++ b/ratpack-core/src/main/java/ratpack/core/http/client/internal/RequestActionSupport.java
@@ -608,17 +608,17 @@ abstract class RequestActionSupport<T> implements Upstream<T> {
         return URI.create(requestUri.getScheme() + ":" + redirectLocation);
       } else {
 
-        String path = redirectLocationUri.getPath();
+        String path = redirectLocationUri.getRawPath();
         if (!path.startsWith("/")) { // absolute path
-          path = getParentPath(requestUri.getPath()) + path;
+          path = getParentPath(requestUri.getRawPath()) + path;
         }
         return new URI(
           requestUri.getScheme(),
-          requestUri.getUserInfo(),
+          requestUri.getRawUserInfo(),
           requestUri.getHost(),
           requestUri.getPort(),
           path,
-          redirectLocationUri.getQuery(),
+          redirectLocationUri.getRawQuery(),
           null
         );
       }

--- a/ratpack-core/src/main/java/ratpack/core/http/client/internal/RequestActionSupport.java
+++ b/ratpack-core/src/main/java/ratpack/core/http/client/internal/RequestActionSupport.java
@@ -612,15 +612,18 @@ abstract class RequestActionSupport<T> implements Upstream<T> {
         if (!path.startsWith("/")) { // absolute path
           path = getParentPath(requestUri.getRawPath()) + path;
         }
-        return new URI(
-          requestUri.getScheme(),
+
+        // By default, the URI encodes the path given to it. We don't want that here. But, we can let the URI
+        // do most of the work and then just append the raw path and query afterwords
+        String rawQuery = redirectLocationUri.getRawQuery() != null
+          ? "?" + redirectLocationUri.getRawQuery() : "";
+        return new URI(new URI(requestUri.getScheme(),
           requestUri.getRawUserInfo(),
           requestUri.getHost(),
           requestUri.getPort(),
-          path,
-          redirectLocationUri.getRawQuery(),
-          null
-        );
+          null,
+          null,
+          null) + path + rawQuery);
       }
     }
   }

--- a/ratpack-core/src/test/groovy/ratpack/core/http/client/HttpClientRedirectionSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/core/http/client/HttpClientRedirectionSpec.groovy
@@ -182,11 +182,13 @@ class HttpClientRedirectionSpec extends BaseHttpClientSpec {
     }
 
     then:
-    text == "http://ratpack.io=10"
+    text == "${URLEncoder.encode("http://ratpack.io=10", "UTF-8")}"
 
     where:
     pooled << [true, false]
   }
+
+
 
   def "can follow a relative redirect get request"() {
     given:

--- a/ratpack-core/src/test/groovy/ratpack/core/http/client/HttpClientRedirectionSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/core/http/client/HttpClientRedirectionSpec.groovy
@@ -153,6 +153,10 @@ class HttpClientRedirectionSpec extends BaseHttpClientSpec {
     pooled << [true, false]
   }
 
+  // NOTE: The redirect specification doesn't get into to detail surrounding URL encoding for the
+  // location header. Therefore, this test is not designed to be a definition of this behavior, since
+  // the specification is ambiguous. However, this will act as a regression test should further changes
+  // be done in this area.
   def "can follow a relative redirect get request with non-encoded query parameters"() {
     given:
     bindings {

--- a/ratpack-core/src/test/groovy/ratpack/core/http/client/HttpClientRedirectionSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/core/http/client/HttpClientRedirectionSpec.groovy
@@ -229,6 +229,7 @@ class HttpClientRedirectionSpec extends BaseHttpClientSpec {
 
   def "can follow a relative redirect get request with encoded path parameters"() {
     given:
+    def valToken = ''
     bindings {
       bindInstance(HttpClient, HttpClient.of { it.poolSize(pooled ? 8 : 0) })
     }
@@ -242,6 +243,7 @@ class HttpClientRedirectionSpec extends BaseHttpClientSpec {
       }
       get("scan-data/bazel/nslowehwwgbgm/target/:val") {
         render request.path
+        valToken = pathTokens.get("val")
       }
     }
 
@@ -257,6 +259,7 @@ class HttpClientRedirectionSpec extends BaseHttpClientSpec {
 
     then:
     text == "scan-data/bazel/nslowehwwgbgm/target/%2F%2F%3AHelloWorldTest"
+    valToken == '//:HelloWorldTest'
 
     where:
     pooled << [true, false]
@@ -265,6 +268,7 @@ class HttpClientRedirectionSpec extends BaseHttpClientSpec {
 
   def "can follow a relative redirect get request without encoded path parameters"() {
     given:
+    def valToken = ''
     bindings {
       bindInstance(HttpClient, HttpClient.of { it.poolSize(pooled ? 8 : 0) })
     }
@@ -278,6 +282,7 @@ class HttpClientRedirectionSpec extends BaseHttpClientSpec {
       }
       get("scan-data/bazel/nslowehwwgbgm/target///:val") {
         render request.path
+        valToken = pathTokens.get("val")
       }
     }
 
@@ -293,6 +298,7 @@ class HttpClientRedirectionSpec extends BaseHttpClientSpec {
 
     then:
     text == "scan-data/bazel/nslowehwwgbgm/target///:HelloWorldTest"
+    valToken == ':HelloWorldTest'
 
     where:
     pooled << [true, false]


### PR DESCRIPTION
This stemmed from an internal issue where the redirect url was getting decoded, and thus changing from the original. 

It looked like there were test around the query parameters, but not so much for path parameters.  The change make it such that the path parameters do not get decoded if they are encoded.  Thus, something like this: `some-data/endpoint/nslowehwwgbgm/target/%2F%2F%3AHelloWorldTest` would end up getting mapped to an endpoint that matches `../target/`.

FWIW, this is our internal issue that was a motivator for this: https://github.com/gradle/dv/issues/40337