### PR TITLE
Only inline exec stream signals if no other events are enqueued

### DIFF
--- a/ratpack-exec/src/main/java/ratpack/exec/internal/ContinuationStream.java
+++ b/ratpack-exec/src/main/java/ratpack/exec/internal/ContinuationStream.java
@@ -24,4 +24,5 @@ public interface ContinuationStream {
 
   void event(Block event);
 
+  boolean isEmpty();
 }

--- a/ratpack-exec/src/main/java/ratpack/exec/internal/DefaultExecution.java
+++ b/ratpack-exec/src/main/java/ratpack/exec/internal/DefaultExecution.java
@@ -657,13 +657,18 @@ public class DefaultExecution implements Execution {
             addEvent(nextEvent, action);
           }
 
+          @Override
+          public boolean isEmpty() {
+            return events.isEmpty();
+          }
+
           public void complete(Block action) {
             addEvent(new NonUserCodeExecStream(parent), action);
           }
 
           private void addEvent(ExecStream parent, Block action) {
             events.add(new SingleEventExecStream(parent, Action.throwException(), continuation -> continuation.resume(action)));
-             drain();
+            drain();
           }
         })
       )));

--- a/ratpack-exec/src/main/java/ratpack/exec/internal/ExecutionBoundPublisher.java
+++ b/ratpack-exec/src/main/java/ratpack/exec/internal/ExecutionBoundPublisher.java
@@ -48,7 +48,7 @@ public class ExecutionBoundPublisher<T> implements TransformablePublisher<T> {
         private final AtomicBoolean pendingCancelSignal = new AtomicBoolean(true);
 
         private void dispatch(Block block) {
-          if (execution.isBound()) {
+          if (execution.isBound() && continuation.isEmpty()) {
             try {
               block.execute();
             } catch (Exception e) {


### PR DESCRIPTION
Previously, out of order signalling could occur if multiple signals were received in an exec segment where older signals were already enqueued.