### PR TITLE
Use custom zstd options...

### DIFF
--- a/ratpack-core/src/main/java/ratpack/server/internal/IgnorableHttpContentCompressor.java
+++ b/ratpack-core/src/main/java/ratpack/server/internal/IgnorableHttpContentCompressor.java
@@ -16,24 +16,34 @@
 
 package ratpack.server.internal;
 
+import io.netty.handler.codec.compression.Brotli;
+import io.netty.handler.codec.compression.CompressionOptions;
 import io.netty.handler.codec.compression.StandardCompressionOptions;
+import io.netty.handler.codec.compression.Zstd;
 import io.netty.handler.codec.http.HttpContentCompressor;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpResponse;
 import ratpack.http.internal.HttpHeaderConstants;
 
+import java.util.Objects;
+import java.util.stream.Stream;
+
 public class IgnorableHttpContentCompressor extends HttpContentCompressor {
 
+  // Define compression options for the supported encodings to fix https://github.com/netty/netty/issues/14972
   public IgnorableHttpContentCompressor() {
     super(
-      StandardCompressionOptions.brotli(),
-      StandardCompressionOptions.deflate(),
-      StandardCompressionOptions.gzip(),
-      StandardCompressionOptions.zstd(
-        /* DEFAULT_COMPRESSION_LEVEL = */ 3,
-        /* DEFAULT_BLOCK_SIZE = */ 1 << 16,
-        Integer.MAX_VALUE // default maxEncodeSize is 32MiB which is too small, as this is a hard limit let's set it to Integer.MAX_VALUE
-      )
+      Stream.of(
+        Brotli.isAvailable() ? StandardCompressionOptions.brotli() : null,
+        StandardCompressionOptions.deflate(),
+        StandardCompressionOptions.gzip(),
+        Zstd.isAvailable()
+          ? StandardCompressionOptions.zstd(
+          /* DEFAULT_COMPRESSION_LEVEL = */ 3,
+          /* DEFAULT_BLOCK_SIZE = */ 1 << 16,
+          Integer.MAX_VALUE) // default maxEncodeSize is 32MiB which is too small, as this is a hard limit let's set it to Integer.MAX_VALUE
+          : null
+      ).filter(Objects::nonNull).toArray(CompressionOptions[]::new)
     );
   }
 

--- a/ratpack-core/src/main/java/ratpack/server/internal/IgnorableHttpContentCompressor.java
+++ b/ratpack-core/src/main/java/ratpack/server/internal/IgnorableHttpContentCompressor.java
@@ -16,12 +16,26 @@
 
 package ratpack.server.internal;
 
+import io.netty.handler.codec.compression.StandardCompressionOptions;
 import io.netty.handler.codec.http.HttpContentCompressor;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpResponse;
 import ratpack.http.internal.HttpHeaderConstants;
 
 public class IgnorableHttpContentCompressor extends HttpContentCompressor {
+
+  public IgnorableHttpContentCompressor() {
+    super(
+      StandardCompressionOptions.brotli(),
+      StandardCompressionOptions.deflate(),
+      StandardCompressionOptions.gzip(),
+      StandardCompressionOptions.zstd(
+        /* DEFAULT_COMPRESSION_LEVEL = */ 3,
+        /* DEFAULT_BLOCK_SIZE = */ 1 << 16,
+        Integer.MAX_VALUE // default maxEncodeSize is 32MiB which is too small, as this is a hard limit let's set it to Integer.MAX_VALUE
+      )
+    );
+  }
 
   @SuppressWarnings("deprecation")
   @Override

--- a/ratpack-manual/src/content/chapters/99-about-the-project.md
+++ b/ratpack-manual/src/content/chapters/99-about-the-project.md
@@ -118,10 +118,10 @@ The following people have contributed their time to Ratpack in the past, but are
 
 #### Fonts
 
-Web fonts are served by [Google Web Fonts](http://www.google.com/fonts/).
+Web fonts are served by [Google Web Fonts](https://fonts.google.com/).
 
-* [Merriweather](http://www.google.com/fonts/specimen/Merriweather) and [Merriweather Sans](http://www.google.com/fonts/specimen/Merriweather+Sans) by [Eben Sorkin](http://ebensorkin.wordpress.com/about-eben-sorkin/)
-* [Engagement](http://www.google.com/fonts/specimen/Engagement) by [Astigmatic One Eye Typographic Institute](http://www.astigmatic.com/)
+* [Merriweather](https://fonts.google.com/specimen/Merriweather) and [Merriweather Sans](https://fonts.google.com/specimen/Merriweather+Sans) by [Eben Sorkin](http://ebensorkin.wordpress.com/about-eben-sorkin/)
+* [Engagement](https://fonts.google.com/specimen/Engagement) by [Astigmatic One Eye Typographic Institute](http://www.astigmatic.com/)
 
 #### Images
 


### PR DESCRIPTION
as the default options will fail if it has to encode anything over 32MB. Now that Chrome supports zstd by default, this is a serious issue.

https://github.com/netty/netty/issues/14972