### PR TITLE
Fix race condition causing onClose handlers to never fire on connection close

### DIFF
--- a/ratpack-core/src/main/java/ratpack/server/internal/StreamingResponseBodyWriter.java
+++ b/ratpack-core/src/main/java/ratpack/server/internal/StreamingResponseBodyWriter.java
@@ -139,6 +139,10 @@ class StreamingResponseBodyWriter implements ResponseBodyWriter, ResponseWriting
     }
 
     private void requestOrDelimit() {
+      if (done) {
+        return;
+      }
+
       if (channel.isWritable()) {
         subscription.request(1);
       } else {

--- a/ratpack-core/src/test/groovy/ratpack/http/RequesterDisconnectSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/http/RequesterDisconnectSpec.groovy
@@ -18,8 +18,12 @@ package ratpack.http
 
 import io.netty.buffer.Unpooled
 import ratpack.exec.Promise
+import ratpack.sse.ServerSentEvents
+import ratpack.stream.Streams
 import ratpack.test.internal.RatpackGroovyDslSpec
 import spock.util.concurrent.BlockingVariable
+
+import java.util.concurrent.CountDownLatch
 
 class RequesterDisconnectSpec extends RatpackGroovyDslSpec {
 
@@ -112,6 +116,157 @@ class RequesterDisconnectSpec extends RatpackGroovyDslSpec {
     "HTTP/1.1 200 OK".size().times {
       socket.inputStream.read() as char
     }
+    socket.close()
+
+    then:
+    executionClosed.get()
+
+    cleanup:
+    responseBodyChunk.release()
+  }
+
+  def "gracefully handles disconnect while streaming large SSE response"() {
+    given:
+    def executionClosed = new BlockingVariable(10)
+    def firstEventSent = new CountDownLatch(1)
+
+    handlers {
+      get {
+        context.onClose { executionClosed.set(true) }
+
+        // Create a large SSE stream with big events to fill the buffer quickly
+        def stream = Streams.publish(1..1000).map { i ->
+          if (i == 1) {
+            firstEventSent.countDown()
+          }
+          // Each event is ~1KB to quickly fill the network buffer
+          ratpack.sse.ServerSentEvent.builder()
+            .id(i.toString())
+            .event("data")
+            .data(("x" * 1024).toString())
+            .build()
+        }
+
+        render ServerSentEvents.builder().build(stream)
+      }
+    }
+
+    when:
+    def socket = socket()
+    withSocket(socket) {
+      write("GET / HTTP/1.1\r\n")
+      write("\r\n")
+      flush()
+    }
+
+    // Wait for first event to be sent (means streaming has started)
+    firstEventSent.await()
+
+    // Read a bit of the response to ensure we're mid-stream
+    20.times {
+      socket.inputStream.read()
+    }
+
+    // Close connection while streaming
+    socket.close()
+
+    then:
+    executionClosed.get()
+  }
+
+  def "gracefully handles disconnect while streaming with small buffer"() {
+    given:
+    def executionClosed = new BlockingVariable(10)
+    def firstChunkSent = new CountDownLatch(1)
+
+    handlers {
+      get {
+        context.onClose {
+          executionClosed.set(true)
+        }
+
+        // Stream with many small chunks to increase chance of hitting the race condition
+        def stream = Streams.publish(1..500).map { i ->
+          if (i == 1) {
+            firstChunkSent.countDown()
+          }
+          Unpooled.wrappedBuffer(("chunk-$i-" + ("y" * 100)).bytes)
+        }
+
+        response.sendStream(stream)
+      }
+    }
+
+    when:
+    def socket = socket()
+    withSocket(socket) {
+      write("GET / HTTP/1.1\r\n")
+      write("\r\n")
+      flush()
+    }
+
+    // Wait for first chunk
+    firstChunkSent.await()
+
+    // Read some bytes to ensure we're streaming
+    10.times {
+      socket.inputStream.read()
+    }
+
+    // Close connection abruptly
+    socket.close()
+
+    then:
+    executionClosed.get()
+  }
+
+  def "gracefully handles disconnect with very large streaming response"() {
+    given:
+    def executionClosed = new BlockingVariable(10)
+    def streamStarted = new CountDownLatch(1)
+
+    // Create a massive response to ensure buffer fills up
+    def responseBodyChunk = Unpooled.wrappedBuffer(("a" * 1024).bytes)
+    def responseBody = Unpooled.compositeBuffer(2048) // 2MB
+    2048.times {
+      responseBody.addComponent(true, responseBodyChunk.retainedSlice())
+    }
+
+    handlers {
+      post {
+        context.onClose { executionClosed.set(true) }
+        request.body.then {
+          streamStarted.countDown()
+          response.send(responseBody)
+        }
+      }
+    }
+
+    when:
+    def socket = socket()
+    withSocket(socket) {
+      write("POST / HTTP/1.1\r\n")
+      write("content-length: 5\r\n")
+      write("\r\n")
+      write("hello")
+      flush()
+    }
+
+    streamStarted.await()
+
+    // Read just the headers, then close
+    def line = new StringBuilder()
+    while (true) {
+      int b = socket.inputStream.read()
+      if (b == -1) {
+        break
+      }
+      line.append((char) b)
+      if (line.toString().endsWith("\r\n\r\n")) {
+        break
+      }
+    }
+
     socket.close()
 
     then:


### PR DESCRIPTION
When a connection closes during streaming response body write, there's a race condition that can cause execution to get stuck in a delimited state, preventing context.onClose handlers from ever being called. 

The issue occurs when:
1. Channel buffer fills up and requestOrDelimit() pauses execution
2. Connection closes, triggering onClosed() which sets done=true and completes the channel promise
3. The promise completion triggers requestOrDelimit() again
4. Without checking done=true, a new continuation is created that never resumes, leaving the execution stuck 

The fix adds an early return in requestOrDelimit() when done=true to prevent the creation of unnecessary continuations after the stream is closed. This was particularly noticeable with SSE streams or large response bodies, where the network buffer would fill up before the connection closed.

Added three new tests that reliably reproduce the issue:
- Large SSE response with 1KB events
- Many small chunks to stress the buffer
- Very large 2MB streaming response 
- These tests timeout without the fix and pass with it.